### PR TITLE
Move access policy registration code to config/initializers

### DIFF
--- a/app/access_policies/contact_info_access_policy.rb
+++ b/app/access_policies/contact_info_access_policy.rb
@@ -12,6 +12,3 @@ class ContactInfoAccessPolicy
   end
 
 end
-
-AccessPolicy.register(ContactInfo, ContactInfoAccessPolicy)
-AccessPolicy.register(EmailAddress, ContactInfoAccessPolicy)

--- a/app/access_policies/user_access_policy.rb
+++ b/app/access_policies/user_access_policy.rb
@@ -12,5 +12,3 @@ class UserAccessPolicy
   end
 
 end
-
-AccessPolicy.register(User, UserAccessPolicy)

--- a/config/initializers/03_access_policies.rb
+++ b/config/initializers/03_access_policies.rb
@@ -1,0 +1,3 @@
+AccessPolicy.register(User, UserAccessPolicy)
+AccessPolicy.register(ContactInfo, ContactInfoAccessPolicy)
+AccessPolicy.register(EmailAddress, ContactInfoAccessPolicy)


### PR DESCRIPTION
Access policies were not getting registered when the server is running
in development mode.
