### PR TITLE
Add a UUID field to the users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,10 @@ class User < ActiveRecord::Base
 
   attr_accessible :username
 
+  attr_readonly :uuid
+
+  before_create :generate_uuid
+
   def is_anonymous?
     false
   end
@@ -94,6 +98,10 @@ protected
 
   def normalize_username
     self.username = username.gsub(USERNAME_DISCARDED_CHAR_REGEX, '').downcase
+  end
+
+  def generate_uuid
+    self.uuid ||= SecureRandom.uuid
   end
 
 end

--- a/db/migrate/20140317153739_add_uuid_to_users.rb
+++ b/db/migrate/20140317153739_add_uuid_to_users.rb
@@ -1,0 +1,6 @@
+class AddUuidToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :uuid, :string
+    add_index :users, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140307234043) do
+ActiveRecord::Schema.define(:version => 20140317153739) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
@@ -147,8 +147,10 @@ ActiveRecord::Schema.define(:version => 20140307234043) do
     t.string   "last_name"
     t.string   "full_name"
     t.string   "title"
+    t.string   "uuid"
   end
 
   add_index "users", ["username"], :name => "index_users_on_username", :unique => true
+  add_index "users", ["uuid"], :name => "index_users_on_uuid", :unique => true
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe User do
+
+  context 'uuid' do
+    it 'is generated when created' do
+      user = FactoryGirl.create :user
+      expect(user.uuid.length).to eq(36)
+    end
+
+    it 'cannot be updated' do
+      user = FactoryGirl.create :user
+      old_uuid = user.uuid
+      user.update_attributes(username: 'newuser')
+      user.reload
+      expect(user.username).to eq('newuser')
+      expect(user.uuid).to eq(old_uuid)
+
+      new_uuid = SecureRandom.uuid
+      user.uuid = new_uuid
+      user.save
+      user.reload
+      expect(user.uuid).to eq(old_uuid)
+    end
+  end
+
+end


### PR DESCRIPTION
We need a static field that identifies a user.  Username is unique but
it may change so adding the UUID field.

UUID is a read only field and is generated upon user creation.
