### PR TITLE
ses email sending for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :production do
   gem 'pg'
   gem 'unicorn'
   gem 'lograge'
+  gem 'aws-ses', '~> 0.6.0', :require => 'aws/ses'
 end
 
 gem "codeclimate-test-reporter", group: :test, require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,11 @@ GEM
     attribeautiful (0.0.7)
       activesupport (~> 3.0)
       eager_beaver (~> 0.0.4)
+    aws-ses (0.6.0)
+      builder
+      mail (> 2.2.5)
+      mime-types
+      xml-simple
     bcrypt-ruby (3.0.1)
     bootstrap-sass (3.1.1.0)
       sass (~> 3.2)
@@ -312,6 +317,7 @@ GEM
       raindrops (~> 0.7)
     valuable (0.9.9)
     websocket-driver (0.3.2)
+    xml-simple (1.1.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -321,6 +327,7 @@ PLATFORMS
 DEPENDENCIES
   action_interceptor (~> 0.5.1)
   apipie-rails (~> 0.1.2)
+  aws-ses (~> 0.6.0)
   bcrypt-ruby (~> 3.0.0)
   bootstrap-sass (~> 3.1.1)
   capybara

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,7 @@ Accounts::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :ses
   config.action_mailer.default_url_options = { :protocol => 'https', :host => 'accounts.openstax.org' }
 
   # Enable threaded mode

--- a/config/initializers/amazon_ses.rb
+++ b/config/initializers/amazon_ses.rb
@@ -1,0 +1,4 @@
+ActionMailer::Base.add_delivery_method :ses, AWS::SES::Base,
+  :access_key_id     => SECRET_SETTINGS[:aws_ses_access_key_id],
+  :secret_access_key => SECRET_SETTINGS[:aws_ses_secret_access_key],
+  :server => 'email.us-east-1.amazonaws.com'


### PR DESCRIPTION
Adds code to enable production servers to send emails via AWS SES.
