### PR TITLE
Finish fixing double authentication bug; Fixes admin user search bug

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -20,7 +20,7 @@ class TermsController < ApplicationController
 
   def show
     # Hide old agreements (should never get them)
-    raise ActiveRecord::RecordNotFound if !@contract.is_latest? && !current_user.is_admin?
+    raise ActiveRecord::RecordNotFound if !@contract.is_latest? && !current_user.is_administrator?
   end
 
   def pose

--- a/app/handlers/admin/users_search.rb
+++ b/app/handlers/admin/users_search.rb
@@ -15,7 +15,7 @@ module Admin
     protected
 
     def authorized?
-      !Rails.env.production? || caller.is_admin?
+      !Rails.env.production? || caller.is_administrator?
     end
 
     def handle

--- a/app/routines/transfer_omniauth_data.rb
+++ b/app/routines/transfer_omniauth_data.rb
@@ -11,7 +11,8 @@ class TransferOmniauthData
     raise Unexpected if data.provider == 'identity'
 
     run(AddEmailToUser, data.email, user, {already_verified: true}) \
-      unless data.email.blank?
+      unless data.email.blank? || \
+             user.email_addresses.where(value: data.email).exists?
   end
 
 end


### PR DESCRIPTION
Turns out my first fix was incomplete. The routine still tries to add a duplicate email for Ross and errors out.

Also fixed undefined method call when trying to do admin user search.

Improved the test that was supposed to cover Ross's case (apparently it didn't actually work)

@edwoodward @reedstrm Maybe Karen could review this since JP is gone? Should be quick, it's pretty small. If not, we could ask LN.

Btw the reason only Ross found this bug is that he's the only one that has the same email on FB and google (and attempted to login with both)