### PR TITLE
Add group, user and authentication for app admin.

### DIFF
--- a/lib/tasks/add_ost_apps.rake
+++ b/lib/tasks/add_ost_apps.rake
@@ -8,23 +8,42 @@ namespace :accounts do
                 {:name => "Openstax Exchange", :prefix => "exchange"},
                 {:name => "Openstax Biglearn", :prefix => "biglearn"}]
     desc "Manage applications for exercises, exchange, tutor and biglearn"
-    ost_apps = [{:name => 'Openstax Exercises', :redirect_uri => ''}]
-    task :create_apps, [:app_domain_suffix] => :environment do |t, args|
-      # Create application owner if needed
-      app_owner = User.find_or_create_by_username('ost_app_admin')
-      # Get the application url suffix if provided
-      suffix = args[:app_domain_suffix] || ''
-      # For each app above, create and assign defaults if it doesn't exist
-      app_data.each do |app|
-        url = "https://#{app[:prefix]}#{suffix}.openstax.org/auth/openstax/callback"
-        Doorkeeper::Application.find_or_create_by_name(app[:name]) do |application|
-          application.redirect_uri = url
-          application.owner = app_owner
-          application.trusted = true
-          application.email_from_address = 'noreply@#{app[:prefix].openstax.org'
-          application.email_subject_prefix = '[#{app[:name]}]'
-          application.save
-          puts "Created #{app[:name]} with return url @ #{url}"
+    task :create_apps, [:app_domain_suffix, :admin_password] => :environment do |t, args|
+      ActiveRecord::Base.transaction do
+        begin
+          # Create application owner if needed
+          app_owner_group = Group.find_or_create_by_name('ost_app_admin_group')
+          user = User.find_or_create_by_username('ost_app_admin')
+          app_owner_group.add_owner(user)
+          password = args[:admin_password]
+          user.identity = Identity.create do |identity|
+            identity.password = password
+            identity.password_confirmation = password
+            identity.user_id = user.id
+          end
+          user.identity.save!
+          auth = Authentication.create(uid: user.identity.id.to_s,
+                                       provider: 'identity',
+                                       user_id: user.id)
+          auth.save!
+          # Get the application url suffix if provided
+          suffix = args[:app_domain_suffix] || ''
+          # For each app above, create and assign defaults if it doesn't exist
+          app_data.each do |app|
+            url = "https://#{app[:prefix]}#{suffix}.openstax.org/auth/openstax/callback"
+            Doorkeeper::Application.find_or_create_by_name(app[:name]) do |application|
+              application.redirect_uri = url
+              application.owner = app_owner_group
+              application.trusted = true
+              application.email_from_address = 'noreply@#{app[:prefix]}.openstax.org'
+              application.email_subject_prefix = '[#{app[:name]}]'
+              application.save!
+              puts "Created #{app[:name]} with return url @ #{url}"
+            end
+          end
+        rescue Exception => e
+          puts e
+          raise ActiveRecord::Rollback
         end
       end
     end


### PR DESCRIPTION
- Create a group for the ost app admin
- Create an ost app admin user and make them a part of that group
- Ensure that the ost app admin user can log in with a predefined password
- Wrap everything in a transaction