### PR TITLE
Change SendMessage routine to use Action Mailer

### DIFF
--- a/app/mailers/api_mailer.rb
+++ b/app/mailers/api_mailer.rb
@@ -1,0 +1,11 @@
+# Copyright 2015 Rice University. Licensed under the Affero General Public 
+# License version 3 or later.  See the COPYRIGHT file for details.
+
+class ApiMailer < ActionMailer::Base
+  def mail(html_body, text_body, headers={})
+    super(headers) do |format|
+      format.html { render text: html_body }
+      format.text { render text: text_body }
+    end
+  end
+end

--- a/app/routines/send_message.rb
+++ b/app/routines/send_message.rb
@@ -7,23 +7,16 @@ class SendMessage
   protected
 
   def exec(msg)
-    fatal_error(code: :not_sent, message: 'Message could not be sent') \
-      unless Mail.deliver do
-      from msg.from_address
-      to msg.to_addresses
-      cc msg.cc_addresses
-      bcc msg.bcc_addresses
-      subject msg.subject_string
-
-      html_part do
-        content_type 'text/html; charset=UTF-8'
-        body msg.body.html
-      end
-
-      text_part do
-        body msg.body.text
-      end
-    end
+    mail = ApiMailer.mail(
+      msg.body.html,
+      msg.body.text,
+      from: msg.from_address,
+      to: msg.to_addresses,
+      cc: msg.cc_addresses,
+      bcc: msg.bcc_addresses,
+      subject: msg.subject_string,
+    )
+    fatal_error(code: :not_sent, message: 'Message could not be sent') unless mail.deliver
   end
 
 end


### PR DESCRIPTION
The aws-ses gem doesn't support using Mail directly, there also seems to
be no way of initializing a class for Mail.delivery_method.

Add a new mailer called "ApiMailer" for sending messages on behalf of
registered apps using the messages API.

Fix #127 

This works locally with smtp.