### PR TITLE
Add /application_users/find/username/:username endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - tar xf phantomjs-1.9.7-linux-x86_64.tar.bz2
   - export PATH=$PATH:phantomjs-1.9.7-linux-x86_64/bin/
 install:
-  - bundle install --without production
+  - bundle install --without production --retry=6
   - bundle exec rake db:setup
 script:
   - bundle exec rake

--- a/app/access_policies/application_user_access_policy.rb
+++ b/app/access_policies/application_user_access_policy.rb
@@ -5,8 +5,8 @@ class ApplicationUserAccessPolicy
     # Human users are not allowed
     return false if requestor.is_human?
 
-    # Apps can only call search, updates and updated
-    return [:search, :updates, :updated].include?(action)
+    # Apps can only call read, search, updates and updated
+    return [:read, :search, :updates, :updated].include?(action)
   end
 
 end

--- a/app/access_policies/application_user_access_policy.rb
+++ b/app/access_policies/application_user_access_policy.rb
@@ -4,9 +4,15 @@ class ApplicationUserAccessPolicy
   def self.action_allowed?(action, requestor, application_user)
     # Human users are not allowed
     return false if requestor.is_human?
-
-    # Apps can only call read, search, updates and updated
-    return [:read, :search, :updates, :updated].include?(action)
+    case action
+    when :read
+      # Applications can only read their own User records
+      return application_user.application == requestor
+    when :search, :updates, :updated # Apps can only call read, search, updates and updated
+      return true
+    else
+      return false
+    end
   end
 
 end

--- a/app/controllers/api/v1/application_users_controller.rb
+++ b/app/controllers/api/v1/application_users_controller.rb
@@ -95,10 +95,10 @@ class Api::V1::ApplicationUsersController < OpenStax::Api::V1::ApiController
   # find_by_username
   ###############################################################
 
-  api :GET, '/application_users/username/:username',
+  api :GET, '/application_users/find/username/:username',
       'Gets a single ApplicationUser with the specified username.'
   description <<-EOS
-    #{json_schema(Api::V1::UserSearchRepresenter, include: :readable)}
+    #{json_schema(Api::V1::ApplicationUserRepresenter, include: :readable)}
   EOS
   def find_by_username
     application_user = ApplicationUser.includes(:user).joins(:user).where({
@@ -106,7 +106,7 @@ class Api::V1::ApplicationUsersController < OpenStax::Api::V1::ApiController
       :application_id => current_api_user.application.id
     }).first!
     OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, application_user)
-    respond_with [application_user], represent_with: Api::V1::ApplicationUsersRepresenter
+    respond_with application_user, represent_with: Api::V1::ApplicationUserRepresenter
   end
 
   ###############################################################

--- a/app/controllers/api/v1/application_users_controller.rb
+++ b/app/controllers/api/v1/application_users_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ApplicationUsersController < OpenStax::Api::V1::ApiController
   #before_filter :get_app_user, :only => [:show, :update, :destroy]
-  
+
   resource_description do
     api_versions "v1"
     short_description 'Records which users interact with which applications, as well the users'' preferences for each app.'
@@ -82,13 +82,41 @@ class Api::V1::ApplicationUsersController < OpenStax::Api::V1::ApiController
 
     Example:
 
-    `last_name, username DESC` &ndash; sorts by last name ascending, then by username descending 
+    `last_name, username DESC` &ndash; sorts by last name ascending, then by username descending
   EOS
   def index
     OSU::AccessPolicy.require_action_allowed!(:search, current_api_user, ApplicationUser)
     options = params.slice(:page, :per_page, :order_by)
     outputs = SearchApplicationUsers.call(current_application, params[:q], options).outputs
     respond_with outputs, represent_with: Api::V1::UserSearchRepresenter
+  end
+
+  ###############################################################
+  # username
+  ###############################################################
+
+  api :GET, '/application_users/username/:username',
+      'Gets a single User with the specified username.'
+  description <<-EOS
+      All users of OpenStax have an associated User object.  This endpoint
+      allows querying additional data on a user when all that is known is the
+      User's username.
+
+      Admins (for Accounts only) are identified by the is_administrator boolean.
+      Some additional user information can be found in associations, such as
+      email addresses in ContactInfos and the password hash in Identity.
+
+      Users have the following String attributes:
+      username, first_name, last_name, full_name, title
+
+    #{json_schema(Api::V1::UserSearchRepresenter, include: :readable)}
+  EOS
+  def username
+    OSU::AccessPolicy.require_action_allowed!(:search, current_api_user, ApplicationUser)
+    username = params[:username]
+    # N.B. references{:user} must be added to the query when/if upgraded to Rails4
+    respond_with ApplicationUser.includes{user}.where{user.username.eq username},
+                 represent_with: Api::V1::ApplicationUsersRepresenter
   end
 
   ###############################################################

--- a/app/controllers/api/v1/application_users_controller.rb
+++ b/app/controllers/api/v1/application_users_controller.rb
@@ -112,10 +112,9 @@ class Api::V1::ApplicationUsersController < OpenStax::Api::V1::ApiController
     #{json_schema(Api::V1::UserSearchRepresenter, include: :readable)}
   EOS
   def username
-    OSU::AccessPolicy.require_action_allowed!(:search, current_api_user, ApplicationUser)
+    OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, ApplicationUser)
     username = params[:username]
-    # N.B. references{:user} must be added to the query when/if upgraded to Rails4
-    respond_with ApplicationUser.includes{user}.where{user.username.eq username},
+    respond_with ApplicationUser.includes(:user).joins(:user).where{user.username.eq username},
                  represent_with: Api::V1::ApplicationUsersRepresenter
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Accounts::Application.routes.draw do
 
     resources :application_users, only: [:index] do
       collection do
-        get 'username/:username', action: 'username'
+        get 'find/username/:username', action: 'find_by_username'
         get 'updates'
         put 'updated'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Accounts::Application.routes.draw do
 
     resources :application_users, only: [:index] do
       collection do
+        get 'username/:username', action: 'username'
         get 'updates'
         put 'updated'
       end

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -45,9 +45,9 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
     end
   end
 
-  describe "username returns" do
+  describe "find by username returns" do
     it "a single result when username matches" do
-      api_get :username, untrusted_application_token, parameters: { username: 'foo_bb' }
+      api_get :find_by_username, untrusted_application_token, parameters: { username: 'foo_bb' }
       expect(response.code).to eq('200')
       expected_response = [{
         id: bob_brown.application_users.first.id,
@@ -60,12 +60,17 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
       }].to_json
       expect(response.body).to eq(expected_response)
     end
-    it "an empty result when not found" do
-      api_get :username, untrusted_application_token, parameters: { username: 'foo' }
-      expect(response.code).to eq('200')
-      expected_response = [].to_json
-      expect(response.body).to eq(expected_response)
+    it "raises not found when when not found" do
+      expect {
+        api_get :find_by_username, untrusted_application_token, parameters: { username: 'foo' }
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
+    it "only finds users belonging to the requesting application" do
+      expect {
+        api_get :find_by_username, trusted_application_token, parameters: { username: 'billy_20' }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
   end
 
   describe "index" do

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -49,7 +49,7 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
     it "a single result when username matches" do
       api_get :find_by_username, untrusted_application_token, parameters: { username: 'foo_bb' }
       expect(response.code).to eq('200')
-      expected_response = [{
+      expected_response = {
         id: bob_brown.application_users.first.id,
         user: {
           id: bob_brown.id,
@@ -57,7 +57,7 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
           first_name: bob_brown.first_name,
           last_name: bob_brown.last_name
         }, unread_updates: 0
-      }].to_json
+      }.to_json
       expect(response.body).to eq(expected_response)
     end
     it "raises not found when when not found" do
@@ -66,8 +66,11 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
     it "only finds users belonging to the requesting application" do
+      # bob_brown is not a member of the "trusted_application"
+      expect( bob_brown.application_users.where( application_id: trusted_application.id ) ).to be_empty
+      # therefore no results will be returned
       expect {
-        api_get :find_by_username, trusted_application_token, parameters: { username: 'billy_20' }
+        api_get :find_by_username, trusted_application_token, parameters: { username: bob_brown.username }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -38,11 +38,33 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
 
   before(:each) do
     user_2.reload
-
     [bob_brown, bob_jones, tim_jones].each do |user|
       FactoryGirl.create :application_user, user: user,
                          application: untrusted_application,
                          unread_updates: 0
+    end
+  end
+
+  describe "username returns" do
+    it "a single result when username matches" do
+      api_get :username, untrusted_application_token, parameters: { username: 'foo_bb' }
+      expect(response.code).to eq('200')
+      expected_response = [{
+        id: bob_brown.application_users.first.id,
+        user: {
+          id: bob_brown.id,
+          username: bob_brown.username,
+          first_name: bob_brown.first_name,
+          last_name: bob_brown.last_name
+        }, unread_updates: 0
+      }].to_json
+      expect(response.body).to eq(expected_response)
+    end
+    it "an empty result when not found" do
+      api_get :username, untrusted_application_token, parameters: { username: 'foo' }
+      expect(response.code).to eq('200')
+      expected_response = [].to_json
+      expect(response.body).to eq(expected_response)
     end
   end
 


### PR DESCRIPTION
Intended for looking up a user's information when
all that is known is the username.  Will perform an
exact match against the username, without using
sub-string search.

Issue #134