### PR TITLE
Update therubyracer version to fix os x 10.10 problems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       hashie
       transaction_isolation
       transaction_retry
-    libv8 (3.11.8.17)
+    libv8 (3.16.14.7)
     lograge (0.3.0)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -288,8 +288,8 @@ GEM
       tins (~> 1.0)
     test_xml (0.1.6)
       nokogiri (>= 1.3.2)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
       ref
     thin (1.5.1)
       daemons (>= 1.0.9)


### PR DESCRIPTION
Updating *just* the gem `therubyracer` fixed my issues with this app on OS X 10.10