### PR TITLE
Support multiple accounts per authentication provider

### DIFF
--- a/app/assets/stylesheets/sessions.css.scss
+++ b/app/assets/stylesheets/sessions.css.scss
@@ -13,12 +13,27 @@ $login-options-width: 300px;
   float: right;
   text-align: center;
 
-  .no-more-login-options {
-    font-style: italic;
-  }
-
   .login-button {
-    padding: 10px;
+      padding: 10px;
+      position: relative;
+      &.adding {
+          img {
+
+          }
+          &:before{
+              content: "+";
+              display: block;
+              border: 1px solid grey;
+              width: 25px;
+              height: 25px;
+              position: absolute;
+              bottom: 23px;
+              right: 10px;
+              background: darkblue;
+              border-bottom-left-radius: 5px;
+              opacity: 0.6;
+          }
+      }
   }
 
   .or-bar {
@@ -177,10 +192,6 @@ $login-options-width: 300px;
     }
 
     .login-options {
-      .no-more-login-options {
-        margin-top: 150px;
-      }
-      
       .or-text {
         background-color: whitesmoke;
       }

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,5 +1,17 @@
 module SessionsHelper
 
+
+  def oauth_login_link(service, options)
+    title = options[:title] || service.capitalize
+    has_login  = current_user.authentications.any?{|auth| auth.provider == service }
+    css_class  = has_login ? "login-button adding" : 'login-button'
+    link_title = has_login ? "Sign in with a different #{title} account" : "Sign in using your #{title} account"
+
+    link_to( "/auth/#{service}", { class: css_class, id: "#{service}-login-button" } ) do
+      image_tag( options[:icon], title: link_title )
+    end
+  end
+
   def authentications_list(authentications)
     providers = authentications.collect{|auth| auth.provider}
     provider_list(providers, 'and')
@@ -17,11 +29,11 @@ module SessionsHelper
     list.push('Twitter')           if providers.include?('twitter')
     list.push('Google')            if providers.include?('google_oauth2')
     list.push('a simple password') if providers.include?('identity')
-    
+
     if list.size >= 2
       list[list.size-1] = "#{conjunction} " + list[list.size-1]
     end
-    
+
     list.size >= 3 ? list.join(', ') : list.join(' ')
   end
 end

--- a/app/views/sessions/_login.html.erb
+++ b/app/views/sessions/_login.html.erb
@@ -1,49 +1,27 @@
 <%
-  hide_signup ||= false
-  has_facebook ||= false
-  has_google ||= false
-  has_twitter ||= false
+  hide_signup  ||= false
   has_password ||= false
 %>
 
 <div class="login-options">
 
   <%
-    has_facebook = current_user.authentications.one?{|auth| auth.provider == 'facebook'}
-    has_google   = current_user.authentications.one?{|auth| auth.provider == 'google_oauth2'}
-    has_twitter  = current_user.authentications.one?{|auth| auth.provider == 'twitter'}
     has_password = current_user.authentications.one?{|auth| auth.provider == 'identity'}
-
-    has_all_social = has_facebook && has_google && has_twitter
   %>
 
-  <% unless has_all_social %>
-    <% unless has_facebook %>
-      <%= link_to "/auth/facebook", {class: 'login-button', id: 'facebook-login-button'} do %>
-        <%= image_tag "fb_64.png", title: "Sign in using your Facebook account" -%>
-      <% end %>
-    <% end %>
+  <%= oauth_login_link( "facebook", icon: 'fb_64.png' ) %>
 
-    <% unless has_twitter %>
-      <%= link_to "/auth/twitter", {class: 'login-button', id: 'twitter-login-button'} do %>
-        <%= image_tag "twitter_64.png", title: "Sign in using your Twitter account" -%>
-      <% end %>
-    <% end %>
+  <%= oauth_login_link( "twitter", icon: 'twitter_64.png' ) %>
 
-    <% unless has_google %>
-      <%= link_to "/auth/google_oauth2", {class: 'login-button', id: 'google_oauth2-login-button'} do %>
-        <%= image_tag "g_64.png", title: "Sign in using your Google account" -%>
-      <% end %>
-    <% end %>
-  <% end %>
+  <%= oauth_login_link( "google_oauth2", title: "Google", icon: 'g_64.png' ) %>
 
-  <% unless has_all_social || has_password %>
+
+
+  <% unless has_password %>
     <div class="or-bar">
       <div class="or-text">OR</div>
     </div>
-  <% end %>
 
-  <% unless has_password %>
     <div class="password-login">
       <%= form_tag '/auth/identity/callback' do %>
         <label for='auth_key'>Username</label><input type='text' id='auth_key' name='auth_key'/>
@@ -61,9 +39,4 @@
     </div>
   <% end %>
 
-  <% if has_all_social && has_password %>
-    <div class='no-more-login-options'>
-      There are no more login options available!
-    </div>
-  <% end %>
 </div>

--- a/db/migrate/20150303204158_relax_user_auth_identities.rb
+++ b/db/migrate/20150303204158_relax_user_auth_identities.rb
@@ -1,0 +1,19 @@
+class RelaxUserAuthIdentities < ActiveRecord::Migration
+  def up
+    # While these seem identical, the original index is :unique
+    remove_index :authentications, name: 'index_authentications_on_user_id_scoped'
+
+    add_index :authentications, [:user_id, :provider],
+              :name => 'index_authentications_on_user_id_scoped'
+  end
+
+  def down
+    remove_index :authentications, name: 'index_authentications_on_user_id_scoped'
+
+    # This may fail if there have been any non-uniqe records added
+    add_index :authentications,
+              [:user_id, :provider],
+              :name => 'index_authentications_on_user_id_scoped',
+              :unique => true
+  end
+end

--- a/db/migrate/20150303204158_relax_user_auth_identities.rb
+++ b/db/migrate/20150303204158_relax_user_auth_identities.rb
@@ -1,19 +1,22 @@
 class RelaxUserAuthIdentities < ActiveRecord::Migration
   def up
-    # While these seem identical, the original index is :unique
+    # Remove unique index that was on [:user_id,:provider], which prevented multiple authentications from same provider
     remove_index :authentications, name: 'index_authentications_on_user_id_scoped'
 
-    add_index :authentications, [:user_id, :provider],
-              :name => 'index_authentications_on_user_id_scoped'
+    # Replace it with unique index on that also includes the provider's uid field.
+    # This will allow multiple authentications from the same provider, as long as
+    # they aren't referring to the same account at the provider.
+    add_index :authentications, [:user_id, :provider, :uid],
+              name: 'index_authentications_on_provider_uid_scoped'
   end
 
   def down
-    remove_index :authentications, name: 'index_authentications_on_user_id_scoped'
+    remove_index :authentications, name: 'index_authentications_on_provider_uid_scoped'
 
-    # This may fail if there have been any non-uniqe records added
+    # This will fail if there have been any non-unique records added
     add_index :authentications,
               [:user_id, :provider],
-              :name => 'index_authentications_on_user_id_scoped',
-              :unique => true
+              name:   'index_authentications_on_user_id_scoped',
+              unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(:version => 20150303204158) do
     t.string   "uid"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
-    t.index ["user_id", "provider"], :name => "index_authentications_on_user_id_scoped"
+    t.index ["user_id", "provider", "uid"], :name => "index_authentications_on_provider_uid_scoped"
   end
 
   create_table "contact_infos", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150128173719) do
+ActiveRecord::Schema.define(:version => 20150303204158) do
 
   create_table "application_groups", :force => true do |t|
     t.integer  "application_id",                :null => false
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(:version => 20150128173719) do
     t.string   "uid"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
-    t.index ["user_id", "provider"], :name => "index_authentications_on_user_id_scoped", :unique => true
+    t.index ["user_id", "provider"], :name => "index_authentications_on_user_id_scoped"
   end
 
   create_table "contact_infos", :force => true do |t|

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -122,24 +122,18 @@ feature 'User logs in as a local user', js: true do
     click_link 'Sign in'
     expect(page).to have_content("Sign in with your one OpenStax account!")
 
+    expect(page).to have_css("a[id='twitter-login-button'] img[title='Sign in using your Twitter account']")
     click_omniauth_link('twitter')
-
     expect(page).to have_content('Nice to meet you,')
-    expect(page).to have_no_link('twitter-login-button')
+    expect(page).to have_css("a.adding[id='twitter-login-button'] img[title='Sign in with a different Twitter account']")
 
+    expect(page).to have_css("a[id='google_oauth2-login-button'] img[title='Sign in using your Google account']")
     click_omniauth_link('google_oauth2')
+    expect(page).to have_css("a.adding[id='google_oauth2-login-button'] img[title='Sign in with a different Google account']")
 
-    expect(page).to have_content('Nice to meet you (again),')
-    expect(page).to have_no_link('twitter-login-button')
-    expect(page).to have_no_link('google_oauth2-login-button')
-
+    expect(page).to have_css("a[id='facebook-login-button'] img[title='Sign in using your Facebook account']")
     click_omniauth_link('facebook')
-
-    expect(page).to have_content('Nice to meet you (again),')
-    expect(page).to have_no_link('twitter-login-button')
-    expect(page).to have_no_link('google_oauth2-login-button')
-    expect(page).to have_no_link('facebook-login-button')
-    expect(page).to have_no_content('left-or-block')
+    expect(page).to have_css("a.adding[id='facebook-login-button'] img[title='Sign in with a different Facebook account']")
 
     fill_in 'Username', with: 'jimbo'
     fill_in 'Password', with: 'password'

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Authentication do
-  
+
   let!(:authentication) { FactoryGirl.create(:authentication) }
 
   context "when an authentication exists" do
@@ -21,12 +21,13 @@ describe Authentication do
   end
 
   context "when an authentication doesn't exist" do
+    let(:provider){ SecureRandom.hex(4) }
+
     it "returns nil from by_provider_and_uid" do
       expect(Authentication.find_by_provider_and_uid("foo", "bar")).to be_nil
     end
 
     it "is created by by_provider_and_uid!" do
-      provider = SecureRandom.hex(4)
       value = nil
       expect{value = Authentication.find_or_create_by_provider_and_uid(
         provider, "42")}.to change{Authentication.count}.by(1)
@@ -34,6 +35,26 @@ describe Authentication do
       expect(value.provider).to eq provider
       expect(value.uid).to eq "42"
     end
+    it "can be created multiple times for a single provider" do
+      expect{
+        Authentication.find_or_create_by_provider_and_uid(provider, "40")
+      }.to change{Authentication.count}.by(1)
+      expect{
+        Authentication.find_or_create_by_provider_and_uid(provider, "41")
+      }.to change{Authentication.count}.by(1)
+      expect{
+        Authentication.find_or_create_by_provider_and_uid(provider, "42")
+      }.to change{Authentication.count}.by(1)
+    end
+    it "can only be created once with an identical provider and uid combination" do
+      expect{
+        Authentication.find_or_create_by_provider_and_uid(provider, "42")
+      }.to change{Authentication.count}.by(1)
+      expect{
+        Authentication.find_or_create_by_provider_and_uid(provider, "42")
+      }.to change{Authentication.count}.by(0)
+    end
+
   end
 
 end


### PR DESCRIPTION
This allows a person to login using multiple accounts from
the same provider, as when a person has multiple gmail
accounts and wants to associate them all with a single
openstax one.

In response to issue #119
