### PR TITLE
Create users with identity and authentication in dev console

### DIFF
--- a/app/routines/dev/create_user.rb
+++ b/app/routines/dev/create_user.rb
@@ -20,6 +20,7 @@ module Dev
         user.first_name = inputs[:first_name]
         user.last_name = inputs[:last_name]
         user.username = username
+        user.is_temp = false
       end
 
       transfer_errors_from(outputs[:user], {type: :verbatim})


### PR DESCRIPTION
Dev console created only users, you can't login with just user.  Change
it to also create identity and authentication.  The password for all the
users created in the dev console is "password".  Also the users created
in the dev console are set to be not temp (not new users) and all the
contracts are automatically accepted.

@pumazi is this what you wanted?