### PR TITLE
Improve import users task

### DIFF
--- a/lib/import_users.rb
+++ b/lib/import_users.rb
@@ -1,41 +1,67 @@
 require 'csv'
 
 class ImportUsers
+  # Number of objects to create before creating a new transaction
+  # (if the number is too big, it uses a lot of memory, if the number is too
+  # small, it takes a long time)
+  OBJECTS_PER_TRANSACTION = 1000
+
   def initialize(csv_file, app_id)
     @csv_file = csv_file
     @app_id = app_id
   end
 
   def read
-    result = {}
-    CSV.foreach(@csv_file, headers: true) do |row|
-      @user = nil
-      username = nil
-      begin
-        username = row['username']
-        result[username] = {row_number: row['row_number']}
-        create_user(username, row['password_digest'],
-                    row['title'], row['first_name'], row['last_name'],
-                    row['full_name'], row['email_address'])
-        FindOrCreateApplicationUser.call(@app_id, @user.id) unless @app_id.nil?
-      rescue ActiveRecord::RecordInvalid => e
-        model_name = e.record.class.name
-        result[username].update({error: "#{model_name} #{e.inspect}"})
-      end
-      result[username].update({user: @user}) unless @user.nil?
-      if ($. - 1) % 10 == 0
-        puts "Imported #{$. - 1} users..."
-      end
-    end
+    # Output results to import_users_results.{timestamp}.csv
+    output_headers = [:row_number, :old_username, :new_username, :errors]
+    CSV.open("import_users_results.#{Time.now.utc.iso8601}.csv", 'wb',
+             headers: output_headers, write_headers: true) do |csv|
 
-    headers = [:row_number, :old_username, :new_username, :errors]
-    CSV.open("import_users_results.#{Time.now.utc.iso8601}.csv", 'wb', headers: headers, write_headers: true) do |csv|
-      result.each do |old_username, value|
-        row_number = value[:row_number]
-        user = value[:user] || ''
-        error = value[:error] || ''
-        csv << [row_number, old_username, user.try(:username), error]
-      end
+      csv_file_length = CSV.read(@csv_file, headers: true).length
+      i = 0
+
+      begin
+        ActiveRecord::Base.transaction do
+          CSV.foreach(@csv_file, headers: true) do |row|
+            # line number is $. - 1 because there's a header line in the csv
+            # file (line_num starts at 1)
+            line_num = $. - 1
+
+            # skip all the lines that don't belong to the current transaction
+            next if (line_num - 1) / OBJECTS_PER_TRANSACTION != i
+
+            # create the user for each line in the input csv file
+            @user = nil
+            username = nil
+            error = nil
+            begin
+              username = row['username']
+              create_user(username, row['password_digest'],
+                          row['title'], row['first_name'], row['last_name'],
+                          row['full_name'], row['email_address'])
+              FindOrCreateApplicationUser.call(@app_id, @user.id) unless @app_id.nil?
+            rescue ActiveRecord::RecordInvalid => e
+              model_name = e.record.class.name
+              error = "#{model_name} #{e.inspect}"
+            rescue ActiveRecord::StatementInvalid => e
+              error = e.inspect
+            end
+
+            if line_num % 100 == 0
+              puts "Imported #{line_num} users..."
+            end
+
+            # output result
+            csv << [row['row_number'], username, @user.try(:username), error]
+          end
+
+          # one transaction finished
+          i += 1
+        end
+
+      # the import is done if we're looking for lines beyond the end of the
+      # csv file
+      end while OBJECTS_PER_TRANSACTION * i < csv_file_length
     end
   end
 

--- a/lib/import_users.rb
+++ b/lib/import_users.rb
@@ -29,7 +29,7 @@ class ImportUsers
     end
 
     headers = [:row_number, :old_username, :new_username, :errors]
-    CSV.open('import_users_results.csv', 'wb', headers: headers, write_headers: true) do |csv|
+    CSV.open("import_users_results.#{Time.now.utc.iso8601}.csv", 'wb', headers: headers, write_headers: true) do |csv|
       result.each do |old_username, value|
         row_number = value[:row_number]
         user = value[:user] || ''

--- a/lib/tasks/import_users.rake
+++ b/lib/tasks/import_users.rake
@@ -1,10 +1,23 @@
 require 'import_users'
 
 namespace :accounts do
-  desc 'Import users from csv file, CSV_FILE=csv_filename, APP_ID=app_id, output is in import_users_results.csv'
+  desc 'Import users from csv file, CSV_FILE=csv_filename, APP_NAME=app_name, output is in import_users_results.csv'
   task :import_users => [:environment] do
-    # if APP_ID is not an integer, an Argument Error will be raised here
-    app_id = Integer(ENV['APP_ID']) unless ENV['APP_ID'].nil?
+    apps = {}
+    Doorkeeper::Application.find_each do |app|
+      apps[app.name] = { id: app.id, callback: app.redirect_uri }
+    end
+    app = apps[ENV['APP_NAME']]
+
+    if app.nil?
+      puts "Cannot find \"#{ENV['APP_NAME']}\".  Here is a list of apps:"
+      apps.each do |app_name, app|
+        puts("app name: %-20s callback: %s" % [app_name, app[:callback]])
+      end
+      raise "APP_NAME \"#{ENV['APP_NAME']}\" not found"
+    end
+
+    app_id = app[:id]
     ::ImportUsers.new(ENV['CSV_FILE'], app_id).read
   end
 end

--- a/lib/tasks/import_users.rake
+++ b/lib/tasks/import_users.rake
@@ -1,7 +1,7 @@
 require 'import_users'
 
 namespace :accounts do
-  desc 'Import users from csv file, CSV_FILE=csv_filename, APP_NAME=app_name, output is in import_users_results.csv'
+  desc 'Import users from csv file, CSV_FILE=csv_filename, APP_NAME=app_name, output is in import_users_results.{timestamp}.csv'
   task :import_users => [:environment] do
     apps = {}
     Doorkeeper::Application.find_each do |app|

--- a/spec/lib/import_users_spec.rb
+++ b/spec/lib/import_users_spec.rb
@@ -38,7 +38,7 @@ describe ImportUsers do
     expect(result[0]['row_number']).to eq('1')
     expect(result[0]['old_username']).to eq('user1')
     expect(result[0]['new_username']).to eq('user1')
-    expect(result[0]['errors']).to be_empty
+    expect(result[0]['errors']).to be_nil
 
     user1 = User.find_by_username('user1')
     expect(user1.title).to eq('Dr')
@@ -64,7 +64,7 @@ describe ImportUsers do
     expect(result[2]['row_number']).to eq('3')
     expect(result[2]['old_username']).to be_empty
     expect(result[2]['new_username']).to be_empty
-    expect(result[2]['errors']).not_to be_empty
+    expect(result[2]['errors']).not_to be_nil
   end
 
   it 'creates users from a csv file and links them to an application' do

--- a/spec/lib/import_users_spec.rb
+++ b/spec/lib/import_users_spec.rb
@@ -5,12 +5,6 @@ require 'spec_helper'
 require 'import_users'
 
 describe ImportUsers do
-  before :all do
-    if File.exists?('import_users_results.csv')
-      raise "import_users_results.csv is going to be overwritten by tests"
-    end
-  end
-
   before :each do
     @file = Tempfile.new('users.csv')
     @file.close
@@ -18,7 +12,7 @@ describe ImportUsers do
 
   after :each do
     @file.unlink
-    File.unlink('import_users_results.csv') rescue nil
+    File.unlink("import_users_results.#{@timestamp}.csv") rescue nil
   end
 
   it 'raises exception if the csv file does not exist' do
@@ -34,9 +28,11 @@ describe ImportUsers do
       csv << [3, '', '']
     end
 
+    @timestamp = '2015-03-20T14:58:17Z'
+    Time.stub(:now).and_return(Time.parse(@timestamp))
     ImportUsers.new(@file.path, nil).read
 
-    result = CSV.read('import_users_results.csv', headers: true)
+    result = CSV.read("import_users_results.#{@timestamp}.csv", headers: true)
     expect(result.length).to eq(3)
 
     expect(result[0]['row_number']).to eq('1')


### PR DESCRIPTION
Having only one transaction for all the users increased the memory usage by a lot.  So changed the code to have one transaction per 1000 (configurable) users.

The benchmarks are as follows:

|                  | Original   | No transaction | One transaction | Multiple transactions |
| ---------------  | ----------:| --------------:| ---------------:| ---------------------:|
| **Time (real)**  |            |                |                 |                       |
| 4000 users       |  6m52.556s |       8m8.919s |       3m17.362s |             2m50.438s |
| 10000 users      | 18m11.743s |     18m48.104s |      11m23.677s |              8m4.523s |
| **Memory (rsz)** |            |                |                 |                       |
| 4000 users       |   89.132MB |       10.128MB |       18.2220MB |              59.080MB |
| 10000 users      |  207.560MB |       14.704MB |       451.980MB |              65.008MB |