### PR TITLE
Use smarter_csv in import users task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'lev', '~> 2.0.4'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
+gem 'smarter_csv'
+
 # API documentation
 gem 'apipie-rails', '~> 0.1.2'
 gem 'maruku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    smarter_csv (1.0.19)
     sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -364,6 +365,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 3.2.6)
   schema_plus (~> 1.7.1)
+  smarter_csv
   sqlite3
   squeel
   therubyracer


### PR DESCRIPTION
Use smarter_csv instead of the built in ruby csv library because
smarter_csv allows reading the csv file in chunks.

It didn't improve the execution time or the memory usage of the import
users task, but it simplifies the code and makes it easier to read.

Towards #152