### PR TITLE
Accept terms and unexpire passwords

### DIFF
--- a/lib/accept_all_terms.rb
+++ b/lib/accept_all_terms.rb
@@ -1,0 +1,12 @@
+class AcceptAllTerms
+  BATCH_SIZE = 1000
+
+  def run
+    contracts = FinePrint::Contract.all
+    User.find_each(batch_size: BATCH_SIZE) do |user|
+      contracts.each do |contract|
+        FinePrint.sign_contract(user, contract)
+      end
+    end
+  end
+end

--- a/lib/tasks/accept_all_terms.rake
+++ b/lib/tasks/accept_all_terms.rake
@@ -1,0 +1,8 @@
+require 'accept_all_terms'
+
+namespace :accounts do
+  desc 'Accept all terms and licenses for all users'
+  task :accept_all_terms => [:environment] do
+    ::AcceptTerms.new.run
+  end
+end

--- a/lib/tasks/unexpire_all_passwords.rake
+++ b/lib/tasks/unexpire_all_passwords.rake
@@ -1,0 +1,8 @@
+require 'unexpire_all_passwords'
+
+namespace :accounts do
+  desc 'Unexpire all passwords for all users'
+  task :unexpire_all_passwords => [:environment] do
+    ::UnexpireAllPasswords.new.run
+  end
+end

--- a/lib/unexpire_all_passwords.rb
+++ b/lib/unexpire_all_passwords.rb
@@ -1,0 +1,11 @@
+class UnexpireAllPasswords
+  BATCH_SIZE = 1000
+
+  def run
+    Identity.find_each(batch_size: BATCH_SIZE) do |identity|
+      # Calling update_attribute which bypasses the password /
+      # password_confirmation validation (since we're not changing passwords)
+      identity.update_attribute(:password_expires_at, nil)
+    end
+  end
+end

--- a/spec/lib/accept_all_terms_spec.rb
+++ b/spec/lib/accept_all_terms_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'accept_all_terms'
+
+describe AcceptAllTerms do
+  let!(:users) { (1..15).collect { |i| FactoryGirl.create(:user) } }
+
+  it 'accept all fine print contracts for users' do
+    expect {
+      AcceptAllTerms.new.run
+    }.to change(FinePrint::Signature, :count).by(User.count * FinePrint::Contract.count)
+  end
+end

--- a/spec/lib/unexpire_all_passwords_spec.rb
+++ b/spec/lib/unexpire_all_passwords_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'unexpire_all_passwords'
+
+describe UnexpireAllPasswords do
+  let!(:users) { (1..5).collect { |i| FactoryGirl.create(:user) } }
+  let!(:identities) {
+    users.collect { |user| FactoryGirl.create(:identity, user: user,
+                                              password_expires_at: 1.year.from_now) }
+  }
+
+  it 'unexpire all passwords for all users' do
+    expect(identities.first.password_expires_at).not_to be_nil
+    UnexpireAllPasswords.new.run
+    identities.each do |identity|
+      identity.reload
+      expect(identity.password_expires_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- Add accounts:accept_all_terms rake task
  
  Accept all terms and licenses for all users

- Add accounts:unexpire_all_passwords rake task

  Unexpire all passwords for all identities (local users).  This means
that users won't be forced to change their passwords.  (For demo)