### PR TITLE
Add seeding tasks

### DIFF
--- a/db/seeds/hanna_barbera.rb
+++ b/db/seeds/hanna_barbera.rb
@@ -1,0 +1,44 @@
+# Creates a number of users themed from Hanna-Barbera cartoon characters.
+
+PASSWORD = 'password'
+filepath = File.join(Rails.root, 'db', 'seeds', 'hanna_barbera.yml')
+
+
+yaml_root = YAML.load_file(filepath)
+master_group = Group.find_or_create_by_name('hanna_barbera_group')
+
+yaml_root['users'].each do |username, values|
+  user_info = values.slice('first_name', 'last_name', 'full_name',
+                           'title', 'suffix')
+  # Create users...
+  user = User.find_or_create_by_username(username)
+  user.update_attributes(user_info)
+  identity = Identity.find_or_create_by_user_id(user.id) do |identity|
+    identity.password = PASSWORD
+    identity.password_confirmation = PASSWORD
+    identity.save!
+  end
+  user.is_administrator = values['is_administrator']
+  user.state = 'activated'
+  master_group.add_member(user)
+  identity_uid = user.identity.id.to_s
+  auth = Authentication.find_or_create_by_uid(identity_uid) do |auth|
+    auth.provider = 'identity'
+    auth.user_id = user.id
+    auth.save!
+  end
+  user.save
+end
+
+yaml_root['groups'].each do |groupname, values|
+  # Create groups
+  group = Group.find_or_create_by_name(groupname)
+  values['owners'].each do |username|
+    user = User.find_by_username(username)
+    group.add_owner(user)
+  end
+  values['members'].each do |username|
+    user = User.find_by_username(username)
+    group.add_member(user)
+  end
+end

--- a/db/seeds/hanna_barbera.yml
+++ b/db/seeds/hanna_barbera.yml
@@ -1,0 +1,110 @@
+# https://en.wikipedia.org/wiki/List_of_Hanna-Barbera_characters
+#
+# users:
+#   <username>:
+#     is_administrator
+#     first_name
+#     last_name
+#     full_name
+#     title
+#     suffix
+# groups:
+#   <groupname>:
+#     owners: []
+#     members: []
+
+users:
+  whanna:
+    is_administrator: true
+    first_name: William
+    last_name: Hanna
+  jbarbera:
+    is_administrator: true
+    first_name: Joseph
+    last_name: Barbera
+  yogi:
+    first_name: Yogi
+    last_name: Bear
+    full_name: Yogi Bear
+  booboo:
+    first_name: Boo Boo
+    last_name: Bear
+  ranger_smith:
+    last_name: Smith
+    full_name: Ranger Smith
+  huckleberry:
+    first_name: Huckleberry
+    last_name: Hound
+  ppitstop:
+    first_name: Penelope
+    last_name: Pitstop
+  dastardly:
+    first_name: Dick
+    last_name: Dastardly
+  muttley:
+    first_name: Muttley
+    full_name: Muttley Dastardly
+  squirrel:
+    full_name: Secret Squirrel
+  mole:
+    full_name: Morocco Mole
+  scooby:
+    first_name: Scoobert
+    last_name: Doo
+    full_name: Scoobert "Scooby" Doo
+  scrappy:
+    full_name: Scrappy-Doo
+  shaggy:
+    fullname: Norville "Shaggy" Rogers
+  velma:
+    first_name: Velma
+    last_name: Dinkley
+  daphne:
+    first_name: Daphne
+    last_name: Blake
+  freddie:
+    first_name: Fred
+    last_name: Jones
+    full_name: Fred "Freddie" Jones
+  fred:
+    first_name: Fred
+    last_name: Flintstone
+  wilma:
+    first_name: Wilma
+    last_name: Flinstone
+    full_name: Wilma Slaghoople Flinstone
+  pebbles:
+    first_name: Pebbles
+    last_name: Flinstone
+  barney:
+    first_name: Barney
+    last_name: Rubble
+  betty:
+    first_name: Betty
+    last_name: Rubble
+    full_name: Betty McBrickner Rubble
+  bammbamm:
+    first_name: Bamm Bamm
+    last_name: Rubble
+  gazoo:
+    full_name: The Great Gazoo
+  birdman:
+    first_name: Harvey
+    last_name: Birdman
+    suffix: Attorney at Law
+groups:
+  JellyStone:
+    owners: [ranger_smith]
+    members: [yogi, booboo, huckleberry]
+  WackyRacers:
+    owners: [whanna, jbarbera]
+    members: [ppitstop, dastardly, muttley]
+  Secret:
+    owners: [whanna, jbarbera]
+    members: [squirrel, mole]
+  MysteryInc:
+    owners: [whanna, jbarbera]
+    members: [scooby, scrappy, shaggy, velma, daphne, freddie]
+  StoneAge:
+    owners: [whanna, jbarbera, gazoo]
+    members: [fred, wilma, pebbles, barney, betty, bammbamm, gazoo]

--- a/lib/tasks/custom_seed.rake
+++ b/lib/tasks/custom_seed.rake
@@ -1,0 +1,12 @@
+# This rake task enables one to run a specific seed found at db/seeds/*.rb
+
+namespace :db do
+  namespace :seed do
+    Dir[File.join(Rails.root, 'db', 'seeds', '*.rb')].each do |filename|
+      task_name = File.basename(filename, '.rb').intern    
+      task task_name => :environment do
+        load(filename) if File.exist?(filename)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds two tasks. The first is a task for creating an admin user. The second is a task for invoking custom seed files. For example, this pull request contains a custom seed called 'hanna_barbera'. This can be invoked using ``rake db:seed:hanna_barbera``.
