### PR TITLE
Added skipping of terms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,3 +375,6 @@ DEPENDENCIES
   thin
   uglifier (>= 1.0.3)
   unicorn
+
+BUNDLED WITH
+   1.10.1

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,6 +14,7 @@ class SessionsController < ApplicationController
     store_fallback
     referer = request.referer
     session[:from_cnx] = (referer =~ /cnx\.org/) unless referer.blank?
+    session[:client_id] = params[:client_id]
     @application = Doorkeeper::Application.where(uid: params[:client_id]).first
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
     handle_with(SessionsCallback, user_state: self,
       complete: lambda {
         case @handler_result.outputs[:status]
-        when :returning_user    then redirect_back
+        when :returning_user    then redirect_to action: :returning_user
         when :new_user          then render :ask_new_or_returning
         when :multiple_accounts then render :ask_which_account
         else                    raise IllegalState
@@ -31,6 +31,10 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    session[ActionInterceptor.config.default_key] = nil
+    session[:registration_return_to] = nil
+    session[:client_id] = nil
+
     sign_out!
 
     # Hack to find root of referer
@@ -38,8 +42,12 @@ class SessionsController < ApplicationController
     # that are not at the root of their host after logout
     # TODO: Replace with signed or registered return urls
     #       Need to provide web views to sign or register those urls
-    uri = URI(request.referer)
-    url = "#{uri.scheme}://#{uri.host}:#{uri.port}/"
+    url = begin
+      uri = URI(request.referer)
+      "#{uri.scheme}://#{uri.host}:#{uri.port}/"
+    rescue # in case the referer is bad (see #179)
+      root_url
+    end
 
     redirect_to url, notice: "Signed out!"
   end
@@ -48,6 +56,12 @@ class SessionsController < ApplicationController
   end
 
   def i_am_returning
+  end
+
+  # This is an official action instead of just doing `redirect_back` in callback
+  # handler so that fine_print can check to see if terms need to be signed.
+  def returning_user
+    redirect_back
   end
 
   # Omniauth failure endpoint

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,7 @@ class UsersController < ApplicationController
   def register
     if request.put?
       handle_with(UsersRegister,
+                  contracts_required: !contracts_not_required,
                   success: lambda {
                     redirect_back key: :registration_return_to
                   },
@@ -33,7 +34,7 @@ class UsersController < ApplicationController
                     render :register, status: errors ? 400 : 200
                   })
     else
-      store_fallback key: :registration_return_to 
+      store_fallback key: :registration_return_to
     end
   end
 

--- a/app/handlers/users_register.rb
+++ b/app/handlers/users_register.rb
@@ -11,9 +11,7 @@ class UsersRegister
     attribute :suffix, type: String
     attribute :full_name, type: String
     attribute :contract_1_id, type: Integer
-    validates :contract_1_id, presence: true
     attribute :contract_2_id, type: Integer
-    validates :contract_2_id, presence: true
   end
 
   uses_routine AgreeToTerms
@@ -26,8 +24,8 @@ class UsersRegister
   end
 
   def handle
-    if !register_params.i_agree
-      fatal_error(code: :did_not_agree, message: 'You must agree to the terms to register') 
+    if options[:contracts_required] && !register_params.i_agree
+      fatal_error(code: :did_not_agree, message: 'You must agree to the terms to register')
     end
 
     caller.username = register_params.username
@@ -40,8 +38,10 @@ class UsersRegister
 
     transfer_errors_from(caller, {type: :verbatim}, true)
 
-    run(AgreeToTerms, register_params.contract_1_id, caller, no_error_if_already_signed: true)
-    run(AgreeToTerms, register_params.contract_2_id, caller, no_error_if_already_signed: true)
+    if options[:contracts_required]
+      run(AgreeToTerms, register_params.contract_1_id, caller, no_error_if_already_signed: true)
+      run(AgreeToTerms, register_params.contract_2_id, caller, no_error_if_already_signed: true)
+    end
 
     run(FinishUserCreation, caller)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
 
   has_many :authentications, dependent: :destroy, inverse_of: :user
   has_many :application_users, dependent: :destroy, inverse_of: :user
+  has_many :applications, through: :application_users
   has_many :contact_infos, dependent: :destroy, inverse_of: :user
   has_many :email_addresses, inverse_of: :user
 
@@ -29,7 +30,7 @@ class User < ActiveRecord::Base
                        uniqueness: { case_sensitive: true },
                        length: { minimum: 3, maximum: USERNAME_MAX_LENGTH },
                        format: { with: /\A[A-Za-z\d_]+\z/,
-                                 message: "Usernames can only contain letters, numbers, and underscores." } 
+                                 message: "Usernames can only contain letters, numbers, and underscores." }
 
   validates :username, uniqueness: { case_sensitive: false },
                        if: :username_changed?
@@ -125,15 +126,15 @@ class User < ActiveRecord::Base
   def can_read?(resource)
     resource.can_be_read_by?(self)
   end
-  
+
   def can_create?(resource)
     resource.can_be_created_by?(self)
   end
-  
+
   def can_update?(resource)
     resource.can_be_updated_by?(self)
   end
-  
+
   def can_destroy?(resource)
     resource.can_be_destroyed_by?(self)
   end

--- a/app/routines/agree_to_terms.rb
+++ b/app/routines/agree_to_terms.rb
@@ -5,8 +5,10 @@ class AgreeToTerms
   protected
 
   def exec(contract_or_id, user, options={})
+    fatal_error(code: :contract_not_specified) if contract_or_id.nil?
+
     return if options[:no_error_if_already_signed] && FinePrint.signed_contract?(user, contract_or_id)
-    
+
     signature = FinePrint.sign_contract(user, contract_or_id)
     transfer_errors_from(signature, {type: :verbatim})
   end

--- a/app/views/users/register.html.erb
+++ b/app/views/users/register.html.erb
@@ -2,7 +2,7 @@
 
 <%= lev_form_for :register, url: register_path, method: :put, html: {id: 'profile-form'} do |f| %>
 
-  <%= standard_field form: f, name: :username, type: :text_field, label: "Username", 
+  <%= standard_field form: f, name: :username, type: :text_field, label: "Username",
                      options: {value: current_user.username} %>
   <%= standard_field form: f, name: :title, type: :text_field, label: "Title",
                      options: {value: current_user.title} %>
@@ -15,28 +15,32 @@
   <%= standard_field form: f, name: :full_name, type: :text_field, label: "Full Name",
                      options: {value: current_user.full_name || current_user.guessed_full_name} %>
 
-  <% 
-    contracts = [FinePrint.get_contract(:general_terms_of_use),
-                 FinePrint.get_contract(:privacy_policy)]
+  <% unless @contracts_not_required %>
+    <%
+      contracts = [FinePrint.get_contract(:general_terms_of_use),
+                   FinePrint.get_contract(:privacy_policy)]
 
-    contract_links = contracts.collect do |contract|
-      link_to contract.title, term_path(contract), remote: true
-    end 
-  %>
-  
-  <div class="checkbox">
-    <label>
-      <%= f.check_box :i_agree %> I have read the <%= contract_links[0] %> and the <%= contract_links[1] %> and I agree to be bound by their terms. <br/> <i>Note that other OpenStax sites may have terms of their own.</i>
-    </label>
-  </div>
-    
-  <%= f.hidden_field :contract_1_id, value: contracts[0].id %>
-  <%= f.hidden_field :contract_2_id, value: contracts[1].id %>
-  
+      contract_links = contracts.collect do |contract|
+        link_to contract.title, term_path(contract), remote: true
+      end
+    %>
+
+    <div class="checkbox">
+      <label>
+        <%= f.check_box :i_agree %> I have read the <%= contract_links[0] %> and the <%= contract_links[1] %> and I agree to be bound by their terms. <br/> <i>Note that other OpenStax sites may have terms of their own.</i>
+      </label>
+    </div>
+
+    <%= f.hidden_field :contract_1_id, value: contracts[0].id %>
+    <%= f.hidden_field :contract_2_id, value: contracts[1].id %>
+  <% end %>
+
   <%= f.submit "Register", id: "register_submit", class: 'standard' %>
-  
+
 <% end %>
 
-<script type="text/javascript">
-  Accounts.Ui.enableOnChecked('#register_submit', '#register_i_agree');
-</script>
+<% unless @contracts_not_required %>
+  <script type="text/javascript">
+    Accounts.Ui.enableOnChecked('#register_submit', '#register_i_agree');
+  </script>
+<% end %>

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -21,7 +21,7 @@ ActionController::Base.class_exec do
   protected
 
   def contracts_not_required
-    @contracts_not_required ||=
+    @contracts_not_required =
       # Skip for API calls
       (request.format == :json) ||
       # Anonymous users can't sign contracts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Accounts::Application.routes.draw do
     get 'login', action: :new
     get 'logout', action: :destroy
     get 'i_am_returning'
+    get 'returning_user'
 
     if Rails.env.development?
       get 'ask_new_or_returning'

--- a/db/migrate/20150722224253_add_skip_terms_to_oauth_applications.rb
+++ b/db/migrate/20150722224253_add_skip_terms_to_oauth_applications.rb
@@ -1,0 +1,6 @@
+class AddSkipTermsToOauthApplications < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :skip_terms, :boolean,
+                                    :default => false, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150323113650) do
+ActiveRecord::Schema.define(:version => 20150722224253) do
 
   create_table "application_groups", :force => true do |t|
     t.integer  "application_id",                :null => false
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(:version => 20150323113650) do
     t.string   "owner_type"
     t.string   "email_from_address",   :default => "",    :null => false
     t.string   "email_subject_prefix", :default => "",    :null => false
+    t.boolean  "skip_terms",           :default => false, :null => false
     t.index ["owner_id", "owner_type"], :name => "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], :name => "index_oauth_applications_on_uid", :unique => true
   end

--- a/lib/tasks/add_ost_apps.rake
+++ b/lib/tasks/add_ost_apps.rake
@@ -6,7 +6,7 @@ namespace :accounts do
   namespace :ost do
     # These are the apps that we want to create
     app_data = [{:name => "OpenStax Exercises", :prefix => "exercises"},
-                {:name => "OpenStax Tutor", :prefix => "tutor"},
+                {:name => "OpenStax Tutor", :prefix => "tutor", skip_terms: true},
                 {:name => "OpenStax Exchange", :prefix => "exchange"},
                 {:name => "OpenStax BigLearn", :prefix => "biglearn"}]
     desc "Manage applications for exercises, exchange, tutor and biglearn"
@@ -58,6 +58,7 @@ namespace :accounts do
               application.trusted = true
               application.email_from_address = "noreply@#{app[:prefix]}.openstax.org"
               application.email_subject_prefix = "[#{app[:name]}]"
+              application.skip_terms = app[:skip_terms] || false
               application.save!
               puts "Created #{app[:name]} with return url @ #{url}"
             end

--- a/spec/controllers/api/v1/application_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/application_groups_controller_spec.rb
@@ -179,8 +179,7 @@ describe Api::V1::ApplicationGroupsController, :type => :api, :version => :v1 do
     end
 
     it "should not let a user call it through an app" do
-      api_get :updates, user_2_token
-      expect(response.status).to eq(403)
+      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
     end
 
   end
@@ -235,10 +234,8 @@ describe Api::V1::ApplicationGroupsController, :type => :api, :version => :v1 do
     end
 
     it "should not let a user call it through an app" do
-      api_get :updates, user_2_token
-      expect(response.status).to eq(403)
-      api_put :updated, user_2_token
-      expect(response.status).to eq(403)
+      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
+      expect{api_put :updated, user_2_token}.to raise_error(SecurityTransgression)
     end
 
   end

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -263,8 +263,7 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
     end
 
     it "should not let a user call it through an app" do
-      api_get :updates, user_2_token
-      expect(response.status).to eq(403)
+      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
     end
 
   end
@@ -323,10 +322,8 @@ describe Api::V1::ApplicationUsersController, :type => :api, :version => :v1 do
     end
 
     it "should not let a user call it through an app" do
-      api_get :updates, user_2_token
-      expect(response.status).to eq(403)
-      api_put :updated, user_2_token
-      expect(response.status).to eq(403)
+      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
+      expect{api_put :updated, user_2_token}.to raise_error(SecurityTransgression)
     end
 
   end

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -71,14 +71,17 @@ describe Api::V1::MessagesController, :type => :api, :version => :v1 do
     it "does not allow users or untrusted applications to send messages" do
       Mail::TestMailer.deliveries.clear
 
-      api_post :create, user_1_untrusted_token, parameters: message_params
-      expect(response.code).to eq('403')
+      expect{
+        api_post :create, user_1_untrusted_token, parameters: message_params
+      }.to raise_error(Lev::SecurityTransgression)
 
-      api_post :create, user_1_trusted_token, parameters: message_params
-      expect(response.code).to eq('403')
+      expect{
+        api_post :create, user_1_trusted_token, parameters: message_params
+      }.to raise_error(Lev::SecurityTransgression)
 
-      api_post :create, untrusted_application_token, parameters: message_params
-      expect(response.code).to eq('403')
+      expect{
+        api_post :create, untrusted_application_token, parameters: message_params
+      }.to raise_error(Lev::SecurityTransgression)
 
       expect(Mail::TestMailer.deliveries).to be_empty
     end

--- a/spec/factories/doorkeeper_application.rb
+++ b/spec/factories/doorkeeper_application.rb
@@ -5,6 +5,8 @@ FactoryGirl.define do
     association :owner, factory: :group
     email_from_address 'app@app.com'
     email_subject_prefix '[Application]'
+    skip_terms false
+    uid { SecureRandom.hex(8) }
 
     trait :trusted do
       trusted true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -12,6 +12,8 @@ FactoryGirl.define do
       state 'temp'
     end
 
+    trait :terms_not_agreed do; end
+
     trait :terms_agreed do
       after(:create) do |user, evaluator|
         FinePrint::Contract.all.each do |contract|

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+feature 'Skipped terms are respected', js: true do
+
+  background do
+    @app_with_skip    = FactoryGirl.create :doorkeeper_application, skip_terms: true
+    @app_without_skip = FactoryGirl.create :doorkeeper_application, skip_terms: false
+  end
+
+  scenario 'when signing up/in under one application WITHOUT skip' do
+    visit_authorize_uri(@app_without_skip) # simulate arriving from an app
+    click_on 'Sign up'
+
+    fill_in 'Username', with: 'bob'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_on 'Register'
+
+    click_on 'Finish setting up my account'
+
+    # No skipping
+    expect(page).to have_content('I have read')
+
+    fill_in 'First Name', with: 'Bob'
+    fill_in 'Last Name', with: 'Dillon'
+    check 'register_i_agree'
+    click_on 'Register'
+
+    click_on 'Sign out'
+
+    # While the user is signed out, a new contract version is published
+    make_new_contract_version
+
+    visit_authorize_uri(@app_without_skip)
+
+    fill_in 'Username', with: 'bob'
+    fill_in 'Password', with: 'password'
+    click_on 'Sign in'
+
+    # Gotta sign the new version
+    expect(current_path).to eq "/terms/pose"
+  end
+
+  scenario 'when signing up in under one application WITH skip' do
+    visit_authorize_uri(@app_with_skip)
+    click_on 'Sign up'
+
+    fill_in 'Username', with: 'bobby'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_on 'Register'
+
+    click_on 'Finish setting up my account'
+
+    # Skipped!
+    expect(page).to_not have_content('I have read')
+
+    fill_in 'First Name', with: 'Bobby'
+    fill_in 'Last Name', with: 'Kennedy'
+    click_on 'Register'
+
+    click_on 'Sign out'
+
+    # While the user is signed out, a new contract version is published
+    make_new_contract_version
+
+    visit_authorize_uri(@app_with_skip)
+
+    fill_in 'Username', with: 'bobby'
+    fill_in 'Password', with: 'password'
+    click_on 'Sign in'
+
+    # Shouldn't have to sign the new version
+    expect(current_path).to eq "/oauth/authorize"
+  end
+
+end

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -74,4 +74,39 @@ feature 'Skipped terms are respected', js: true do
     expect(current_path).to eq "/oauth/authorize"
   end
 
+  scenario 'no skipping when signing up/in without a particular application' do
+    visit '/'
+    click_on 'Sign up'
+
+    fill_in 'Username', with: 'bobby'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_on 'Register'
+
+    click_on 'Finish setting up my account'
+
+    # Gotta sign
+    expect(page).to have_content('I have read')
+
+    fill_in 'First Name', with: 'Bobby'
+    fill_in 'Last Name', with: 'Kennedy'
+    check 'register_i_agree'
+    click_on 'Register'
+
+    click_on 'Sign out'
+
+    # While the user is signed out, a new contract version is published
+    make_new_contract_version
+
+    visit '/'
+    click_on 'Sign in'
+
+    fill_in 'Username', with: 'bobby'
+    fill_in 'Password', with: 'password'
+    click_on 'Sign in'
+
+    # Gotta sign the new version
+    expect(current_path).to eq "/terms/pose"
+  end
+
 end


### PR DESCRIPTION
* Lets terms of use be skipped for users from certain applications (to avoid double signing when that application's terms subsume Accounts terms)
* Set Tutor to be one of these skipped terms apps (in rake setup file)
* Cleaned up session state on sign out (getting rid of `return_to`, `client_id`, etc).
* Fixed #179 