### PR TITLE
Admin edit user page

### DIFF
--- a/app/controllers/admin/contact_infos_controller.rb
+++ b/app/controllers/admin/contact_infos_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class ContactInfosController < BaseController
+
+    def verify
+      contact_info = ContactInfo.find(params[:id])
+      result = MarkContactInfoVerified.call(contact_info)
+      if result.errors.any?
+        return render text: '(Unable to verify)'
+      else
+        return render text: '(Verified)'
+      end
+    end
+
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,8 +10,9 @@ module Admin
 
     def update
       respond_to do |format|
-        if @user.update_attributes(params[:user])
-          format.html { redirect_to @user, notice: 'User profile was successfully updated.' }
+        if add_email_to_user && update_user
+          format.html { redirect_to edit_admin_user_path(@user),
+                        notice: 'User profile was successfully updated.' }
         else
           format.html { render action: "edit" }
         end
@@ -42,5 +43,18 @@ module Admin
       @user = User.find(params[:id])
     end
 
+    def add_email_to_user
+      result = AddEmailToUser.call(params[:user][:email_address], @user)
+      return true unless result.errors.any?
+      flash[:alert] = "Failed to add new email address: #{result.errors.collect(&:translate)}"
+      return false
+    end
+
+    def update_user
+      @user.is_administrator = params[:user][:is_administrator]
+
+      user_params = params[:user].slice(:first_name, :last_name, :full_name)
+      @user.update_attributes(user_params)
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,7 +10,7 @@ module Admin
 
     def update
       respond_to do |format|
-        if add_email_to_user && update_user
+        if change_user_password && add_email_to_user && update_user
           format.html { redirect_to edit_admin_user_path(@user),
                         notice: 'User profile was successfully updated.' }
         else
@@ -47,6 +47,16 @@ module Admin
       result = AddEmailToUser.call(params[:user][:email_address], @user)
       return true unless result.errors.any?
       flash[:alert] = "Failed to add new email address: #{result.errors.collect(&:translate)}"
+      return false
+    end
+
+    def change_user_password
+      return true if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
+
+      @user.identity.password = params[:user][:password]
+      @user.identity.password_confirmation = params[:user][:password_confirmation]
+      return true if @user.identity.save
+      flash[:alert] = "Failed to change password: #{@user.identity.errors.full_messages}"
       return false
     end
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -40,11 +40,6 @@
     <%= f.check_box :is_administrator %>
   </div>
 
-  <div class="checkbox">
-    <%= f.label :disable, 'Disabled Account?' %>
-    <%= check_box_tag 'user[disable]', !@user.is_activated? %>
-  </div>
-
   <div class="actions">
     <%= f.submit 'Save', class: 'btn btn-default' %>
   </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -32,6 +32,18 @@
     <%= f.text_field :full_name, value: params[:user].nil? ? @user.full_name : params[:user][:full_name] %>
   </div>
 
+  <% unless @user.identity.nil? %>
+    <div class="form-group">
+      <%= f.label :password %>
+      <%= password_field_tag 'user[password]' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :password_confirmation %>
+      <%= password_field_tag 'user[password_confirmation]' %>
+    </div>
+  <% end %>
+
   <div class="form-group">
     <%= f.label :existing_email_addresses %>
     <ul>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -10,22 +10,26 @@
         <td><%= @user.name %></td>
      </tr>
      <tr>
-        <th>Email</th>
-        <td><%= @user.email %></td>
+        <th>Email Addresses</th>
+        <td>
+        <% @user.email_addresses.each do |email| %>
+          <div><%= email.value %></div>
+        <% end %>
+        </td>
      </tr>
      <tr>
         <th>Administrator?</th>
-        <td><%= f.check_box :is_admin %></td>
+        <td><%= f.check_box :is_administrator %></td>
      </tr>
      <tr>
         <th>Disable Account?</th>
-        <td><%= check_box_tag "user[disable]", "1", @user.is_disabled? %></td>
+        <td><%= check_box_tag "user[disable]", "1", !@user.is_activated? %></td>
      </tr>
   </table>
   
   <p>
      
   <div class="actions">
-    <%= f.submit :class => submit_classes %>
+    <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -13,6 +13,11 @@
   <%= render "shared/error_messages", :target => @user %> 
 
   <div class="form-group">
+    <%= f.label :username %>
+    <div><%= @user.username %></div>
+  </div>
+
+  <div class="form-group">
     <%= f.label :name %>
     <div><%= @user.name %></div>
   </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -18,6 +18,21 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :first_name %>
+    <%= f.text_field :first_name, value: params[:user].nil? ? @user.first_name : params[:user][:first_name] %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :last_name %>
+    <%= f.text_field :last_name, value: params[:user].nil? ? @user.last_name : params[:user][:last_name] %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :full_name %>
+    <%= f.text_field :full_name, value: params[:user].nil? ? @user.full_name : params[:user][:full_name] %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :existing_email_addresses %>
     <ul>
     <% @user.email_addresses.each do |email| %>
@@ -33,6 +48,9 @@
       </li>
     <% end %>
     </ul>
+
+    <%= f.label :email_address, 'New email address' %>
+    <%= text_field_tag 'user[email_address]', params[:user].try(:[], :email_address) %>
   </div>
 
   <div class="checkbox">

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,6 +1,14 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    $('.verify-email').bind('ajax:complete', function(evt, xhr, status) {
+      $(this).replaceWith(xhr.responseText);
+    });
+  </script>
+<% end %>
+
 <%= form_for([:admin, @user]) do |f| %>
   <%= render "shared/error_messages", :target => @user %> 
 
@@ -13,7 +21,16 @@
     <%= f.label :existing_email_addresses %>
     <ul>
     <% @user.email_addresses.each do |email| %>
-      <li><%= email.value %></li>
+      <li>
+      <%= email.value %>
+      <% if email.verified %>
+        (Verified)
+      <% else %>
+        <%= link_to 'Mark this email address as verified', admin_verify_contact_info_path(email),
+                    remote: true, method: :post, class: 'btn btn-default btn-xs verify-email'
+        %>
+      <% end %>
+      </li>
     <% end %>
     </ul>
   </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -4,32 +4,31 @@
 <%= form_for([:admin, @user]) do |f| %>
   <%= render "shared/error_messages", :target => @user %> 
 
-  <table class="left_heading left_heading_offset">
-     <tr>
-        <th>Name</th>
-        <td><%= @user.name %></td>
-     </tr>
-     <tr>
-        <th>Email Addresses</th>
-        <td>
-        <% @user.email_addresses.each do |email| %>
-          <div><%= email.value %></div>
-        <% end %>
-        </td>
-     </tr>
-     <tr>
-        <th>Administrator?</th>
-        <td><%= f.check_box :is_administrator %></td>
-     </tr>
-     <tr>
-        <th>Disable Account?</th>
-        <td><%= check_box_tag "user[disable]", "1", !@user.is_activated? %></td>
-     </tr>
-  </table>
-  
-  <p>
-     
+  <div class="form-group">
+    <%= f.label :name %>
+    <div><%= @user.name %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :existing_email_addresses %>
+    <ul>
+    <% @user.email_addresses.each do |email| %>
+      <li><%= email.value %></li>
+    <% end %>
+    </ul>
+  </div>
+
+  <div class="checkbox">
+    <%= f.label :is_administrator, 'Administrator?' %>
+    <%= f.check_box :is_administrator %>
+  </div>
+
+  <div class="checkbox">
+    <%= f.label :disable, 'Disabled Account?' %>
+    <%= check_box_tag 'user[disable]', !@user.is_activated? %>
+  </div>
+
   <div class="actions">
-    <%= f.submit %>
+    <%= f.submit 'Save', class: 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,13 +1,6 @@
 <%# Copyright 2011-2012 Rice University. Licensed under the Affero General Public 
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<div id="upperCornerLinks">
-   <%= link_to 'Show', admin_user_path(@user) %> |
-   <%= link_to 'Back', admin_users_path %>   
-</div>
-
 <%= page_heading 'User Detail' %>
 
 <%= render 'form' %>
-
-Updating the information above will send the changes to the user. [TODO]

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -7,18 +7,13 @@
   contents = osu.action_list(
     records: users,
     list: {
-      headings: ['Username', 'First Name', 'Last Name', '', 'Is Admin?'],
+      headings: ['Username', 'First Name', 'Last Name', 'Is Admin?', ''],
       widths: ['20%', '20%', '20%', '20%', '20%'],
       data_procs:
         [
           Proc.new { |user| user.username },
           Proc.new { |user| user.first_name || '---' },
           Proc.new { |user| user.last_name || '---' },
-          Proc.new { |user| 
-            link_to 'Sign in as', 
-                    become_admin_user_path(user),
-                    method: :post 
-          },
           Proc.new { |user|
             if user.is_administrator
               'Yes'
@@ -30,6 +25,11 @@
                       class: 'make-admin'
             end
           },
+          Proc.new { |user|
+            link_to 'Sign in as',
+                    become_admin_user_path(user),
+                    method: :post
+          }
         ]
     }
   ) %>

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -7,7 +7,7 @@
   contents = osu.action_list(
     records: users,
     list: {
-      headings: ['Username', 'First Name', 'Last Name', 'Is Admin?', ''],
+      headings: ['Username', 'First Name', 'Last Name', 'Is Admin?', 'Actions'],
       widths: ['20%', '20%', '20%', '20%', '20%'],
       data_procs:
         [
@@ -26,9 +26,12 @@
             end
           },
           Proc.new { |user|
-            link_to 'Sign in as',
-                    become_admin_user_path(user),
-                    method: :post
+            sign_in_link = link_to 'Sign in as',
+                                   become_admin_user_path(user),
+                                   method: :post
+            edit_link = link_to 'Edit',
+                                edit_admin_user_path(user)
+            "#{sign_in_link} | #{edit_link}".html_safe
           }
         ]
     }

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -30,7 +30,8 @@
                                    become_admin_user_path(user),
                                    method: :post
             edit_link = link_to 'Edit',
-                                edit_admin_user_path(user)
+                                edit_admin_user_path(user),
+                                target: '_blank'
             "#{sign_in_link} | #{edit_link}".html_safe
           }
         ]

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<%# Copyright 2011-2015 Rice University. Licensed under the Affero General Public 
+    License version 3 or later.  See the COPYRIGHT file for details. %>
+
+<% if target.errors.any? %>
+  <div id="error_explanation">
+    <ul>
+    <% target.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,9 @@ Accounts::Application.routes.draw do
       post 'become', on: :member
       post 'make_admin', on: :member
     end
+
+    post :verify_contact_info, path: '/contact_infos/:id/verify',
+         controller: :contact_infos, action: :verify
   end
 
   namespace 'dev' do

--- a/spec/controllers/admin/contact_infos_controller_spec.rb
+++ b/spec/controllers/admin/contact_infos_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe Admin::ContactInfosController do
+  let!(:user) { FactoryGirl.create :user_with_emails }
+
+  it 'marks contact info as verified' do
+    email = user.email_addresses.first
+    post :verify, id: email.id
+    expect(email.reload.verified).to be true
+    expect(response.body).to eq '(Verified)'
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Admin::UsersController do
+  let!(:user) { FactoryGirl.create :user }
+
+  describe 'PUT #update' do
+    it 'updates a user' do
+      put :update, id: user.id,
+                   user: {
+                     first_name: 'Malik',
+                     last_name: 'Kristensen',
+                     full_name: 'Malik A. Kristensen',
+                     email_address: 'malik@example.org',
+                     is_administrator: '1'
+                   }
+      user.reload
+      expect(user.first_name).to eq 'Malik'
+      expect(user.last_name).to eq 'Kristensen'
+      expect(user.full_name).to eq 'Malik A. Kristensen'
+      expect(user.email_addresses.first.value).to eq 'malik@example.org'
+      expect(user.is_administrator).to be true
+    end
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Admin::UsersController do
   let!(:user) { FactoryGirl.create :user }
+  let!(:identity) { FactoryGirl.create :identity, user: user }
 
   describe 'PUT #update' do
     it 'updates a user' do
@@ -11,7 +12,9 @@ RSpec.describe Admin::UsersController do
                      last_name: 'Kristensen',
                      full_name: 'Malik A. Kristensen',
                      email_address: 'malik@example.org',
-                     is_administrator: '1'
+                     is_administrator: '1',
+                     password: 'si4eeSai',
+                     password_confirmation: 'si4eeSai'
                    }
       user.reload
       expect(user.first_name).to eq 'Malik'
@@ -19,6 +22,7 @@ RSpec.describe Admin::UsersController do
       expect(user.full_name).to eq 'Malik A. Kristensen'
       expect(user.email_addresses.first.value).to eq 'malik@example.org'
       expect(user.is_administrator).to be true
+      expect(user.identity.authenticate('si4eeSai')).to eq user.identity
     end
   end
 end


### PR DESCRIPTION
![Screenshot](https://cloud.githubusercontent.com/assets/153353/8857558/4f352e8e-316a-11e5-8e3a-cd263b39d819.jpg)

- Move user search column "Sign in as" to right most column


- Add "edit" to actions on admin user search page


- Fix existing admin edit user form so it displays without errors

  - Add app/views/shared/_error_messages.html.erb
  - User can now have multiple email addresses, change @user.email to
    @user.email_addresses
  - Change is_admin field to is_administrator
  - Change @user.is_disabled? to !@user.is_activated?
  - Remove undefined variable "submit_classes"

- Change admin edit user page to use bootstrap styles


- Add verify email button in admin edit user page


- Add controller tests for admin verifying user email addresses


- Remove "Disable Account?" checkbox from admin edit user form


- Add first/last/full names and new email address to admin user edit form

  - Add code to admin users controller #update so it now saves the data
    when the form is submitted
  - Remove "show" and "back" links from admin user edit page, instead
    opens a new browser tab when the user wants to edit a user

- Add user edit tests for admin users controller

- Add password fields to admin user edit form

- Add update password tests for admin users controller