### PR TITLE
Assorted cleanup

### DIFF
--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -3,7 +3,7 @@ class ContactInfosController < ApplicationController
   skip_before_filter :authenticate_user!, only: [:confirm, :confirm_unclaimed]
 
   fine_print_skip :general_terms_of_use, :privacy_policy, only: [:confirm, :confirm_unclaimed]
-  
+
   before_filter :get_contact_info, only: [:destroy, :toggle_is_searchable]
 
   def create
@@ -12,7 +12,7 @@ class ContactInfosController < ApplicationController
                   redirect_to profile_path,
                     notice: "A confirmation message has been sent to \"#{
                               @handler_result.outputs[:contact_info].value}\"" },
-                failure: lambda { render 'users/edit', status: 400 })
+                failure: lambda { @active_tab = :email; render 'users/edit', status: 400 })
   end
 
   def destroy

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -9,7 +9,7 @@ class ContactInfosController < ApplicationController
   def create
     handle_with(ContactInfosCreate,
                 success: lambda {
-                  redirect_to profile_path,
+                  redirect_to profile_path(active_tab: :email),
                     notice: "A confirmation message has been sent to \"#{
                               @handler_result.outputs[:contact_info].value}\"" },
                 failure: lambda { @active_tab = :email; render 'users/edit', status: 400 })
@@ -19,7 +19,7 @@ class ContactInfosController < ApplicationController
     OSU::AccessPolicy.require_action_allowed!(:destroy, current_user,
                                               @contact_info)
     @contact_info.destroy
-    redirect_to profile_path,
+    redirect_to profile_path(active_tab: :email),
                 notice: "#{@contact_info.type.underscore.humanize} deleted"
   end
 
@@ -28,14 +28,15 @@ class ContactInfosController < ApplicationController
                                               current_user, @contact_info)
     @contact_info.update_attribute(:is_searchable,
                                    !@contact_info.is_searchable)
-    redirect_to profile_path,
+
+    redirect_to profile_path(active_tab: :email),
                 notice: "Search settings updated"
   end
 
   def resend_confirmation
     handle_with(ContactInfosResendConfirmation,
                 complete: lambda {
-                  redirect_to profile_path,
+                  redirect_to profile_path(active_tab: :email),
                     notice: "A confirmation message has been sent to \"#{
                               @handler_result.outputs[:contact_info].value}\"" })
   end

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -17,6 +17,7 @@ class IdentitiesController < ApplicationController
   end
 
   def update
+    @active_tab = :password
     handle_with(IdentitiesUpdate,
                 success: lambda { redirect_to profile_path, notice: 'Password changed' },
                 failure: lambda { render 'users/edit', status: 400 })

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -16,6 +16,7 @@ class StaticPagesController < ApplicationController
   end
 
   def home
+    redirect_to(signed_in? ? profile_path : login_path)
   end
 
   # Used by AWS (and others) to make sure the site is still up.

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_filter :authenticate_user!,
+  skip_before_filter :authenticate_user!, :registration,
                      only: [:api, :copyright, :home, :status]
 
   fine_print_skip :general_terms_of_use, :privacy_policy,
@@ -16,7 +16,14 @@ class StaticPagesController < ApplicationController
   end
 
   def home
-    redirect_to(signed_in? ? profile_path : login_path)
+    flash.keep # keep notices and errors through to the redirects below
+
+    if signed_in?
+      redirect_to profile_path
+    else
+      store_url # needed for happy login flow, authenticate_user! does it too
+      redirect_to login_path
+    end
   end
 
   # Used by AWS (and others) to make sure the site is still up.

--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -1,5 +1,5 @@
 module Api::V1
-  class UnclaimedUserRepresenter < Roar::Decorator
+  class FindOrCreateUserRepresenter < Roar::Decorator
     include Roar::Representer::JSON
 
     property :id,

--- a/app/views/layouts/_application_top_nav.html.erb
+++ b/app/views/layouts/_application_top_nav.html.erb
@@ -1,4 +1,4 @@
-<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <div id="top-nav-frame" class="<%= yield :top_nav_class %>">
@@ -10,7 +10,7 @@
 
     <div id="top-nav-account">
       <% if signed_in? %>
-        Welcome, <%= current_user.username %>&nbsp;&nbsp;&nbsp;<%= link_to 'Sign out', main_app.logout_path %>
+        Welcome, <%= link_to current_user.username, profile_path %>&nbsp;&nbsp;&nbsp;<%= link_to 'Sign out', main_app.logout_path %>
       <% else %>
         <% unless session[:from_cnx] %>
           <%= link_to 'Sign up', main_app.signup_path %> or
@@ -23,21 +23,21 @@
       <% if false %>
       <ul>
         <li>
-          <%= render "layouts/application_top_nav_link", 
+          <%= render "layouts/application_top_nav_link",
                      target_text:            "ABOUT",
                      target_id:              "top-nav-about-link",
                      target_path:            "#",
                      target_current_symbol:  :top_nav_about_current %>
         </li>
         <li>
-          <%= render "layouts/application_top_nav_link", 
+          <%= render "layouts/application_top_nav_link",
                      target_text:            "API",
                      target_id:              "top-nav-api-link",
                      target_path:            main_app.api_path,
                      target_current_symbol:  :top_nav_api_current %>
         </li>
         <li>
-          <%= render "layouts/application_top_nav_link", 
+          <%= render "layouts/application_top_nav_link",
                      target_text:            "SIGN IN",
                      target_id:              "top-nav-account-link",
                      target_path:            "#",

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,6 @@
 <%= page_heading("Your Account") %>
 
-<% @active_tab ||= :name %>
+<% @active_tab ||= params[:active_tab].try(:to_sym) || :name %>
 
 <ul class="nav nav-tabs" role="tablist" style="margin-bottom: 30px">
   <li role="presentation" <% if @active_tab == :name %>class="active"<% end %>><a href="#name" aria-controls="name" role="tab" data-toggle="tab">Profile Settings</a></li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,30 +1,32 @@
 <%= page_heading("Your Account") %>
 
+<% @active_tab ||= :name %>
+
 <ul class="nav nav-tabs" role="tablist" style="margin-bottom: 30px">
-  <li role="presentation" class="active"><a href="#name" aria-controls="name" role="tab" data-toggle="tab">Profile Settings</a></li>
+  <li role="presentation" <% if @active_tab == :name %>class="active"<% end %>><a href="#name" aria-controls="name" role="tab" data-toggle="tab">Profile Settings</a></li>
 
   <% unless current_user.identity.nil? %>
-  <li role="presentation"><a href="#password" aria-controls="password" role="tab" data-toggle="tab">Change Your Password</a></li>
+  <li role="presentation" <% if @active_tab == :password %>class="active"<% end %>><a href="#password" aria-controls="password" role="tab" data-toggle="tab">Change Your Password</a></li>
   <% end %>
 
-  <li role="presentation"><a href="#email" aria-controls="email" role="tab" data-toggle="tab">Manage Email Addresses</a></li>
+  <li role="presentation" <% if @active_tab == :email %>class="active"<% end %>><a href="#email" aria-controls="email" role="tab" data-toggle="tab">Manage Email Addresses</a></li>
 </ul>
 
 <!-- Tab panes -->
 <div class="tab-content" style="margin-bottom: 30px; padding: 5px;">
 
-  <div role="tabpanel" class="tab-pane active" id="name">
+  <div role="tabpanel" class="tab-pane <% if @active_tab == :name %>active<% end %>" id="name">
     <%= render partial: 'users/form', locals: {user: current_user} %>
   </div>
 
 <% unless current_user.identity.nil? %>
-  <div role="tabpanel" class="tab-pane" id="password">
+  <div role="tabpanel" class="tab-pane <% if @active_tab == :password %>active<% end %>" id="password">
     <%= render partial: 'identities/form',
                locals: { identity: current_user.identity } %>
   </div>
 <% end %>
 
-  <div role="tabpanel" class="tab-pane" id="email">
+  <div role="tabpanel" class="tab-pane <% if @active_tab == :email %>active<% end %>" id="email">
     <%= render partial: 'contact_infos/email_addresses', locals: {
                email_addresses: current_user.email_addresses } %>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,14 +1,31 @@
-<h2>Your Name</h2>
-<%= render partial: 'users/form', locals: {user: current_user} %>
+<%= page_heading("Your Account") %>
+
+<ul class="nav nav-tabs" role="tablist" style="margin-bottom: 30px">
+  <li role="presentation" class="active"><a href="#name" aria-controls="name" role="tab" data-toggle="tab">Profile Settings</a></li>
+
+  <% unless current_user.identity.nil? %>
+  <li role="presentation"><a href="#password" aria-controls="password" role="tab" data-toggle="tab">Change Your Password</a></li>
+  <% end %>
+
+  <li role="presentation"><a href="#email" aria-controls="email" role="tab" data-toggle="tab">Manage Email Addresses</a></li>
+</ul>
+
+<!-- Tab panes -->
+<div class="tab-content" style="margin-bottom: 30px; padding: 5px;">
+
+  <div role="tabpanel" class="tab-pane active" id="name">
+    <%= render partial: 'users/form', locals: {user: current_user} %>
+  </div>
 
 <% unless current_user.identity.nil? %>
-  <h2>Change Your Password</h2>
-  <%= render partial: 'identities/form',
-             locals: { identity: current_user.identity } %>
+  <div role="tabpanel" class="tab-pane" id="password">
+    <%= render partial: 'identities/form',
+               locals: { identity: current_user.identity } %>
+  </div>
 <% end %>
 
-<h2>Your Email addresses</h2>
-<%= render partial: 'contact_infos/email_addresses', locals: {
-             email_addresses: current_user.email_addresses } %>
-
-<%= link_to 'Back', :back %>
+  <div role="tabpanel" class="tab-pane" id="email">
+    <%= render partial: 'contact_infos/email_addresses', locals: {
+               email_addresses: current_user.email_addresses } %>
+  </div>
+</div>

--- a/spec/features/forgot_password_spec.rb
+++ b/spec/features/forgot_password_spec.rb
@@ -8,7 +8,7 @@ feature 'User forgot password', js: true do
     @email.save!
 
     visit '/'
-    click_link 'Sign in'
+    click_button 'Sign in'
     click_link 'Forgot password?'
   end
 

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -71,7 +71,6 @@ feature 'User resets password', js: true do
     click_link 'Sign out'
 
     # try logging in with the old password
-    click_link 'Sign in'
     fill_in 'Username', with: 'user'
     fill_in 'Password', with: 'password'
     click_button 'Sign in'

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -10,7 +10,8 @@ feature 'User manages emails' do
     expect(page).to have_content('Welcome, user')
 
     visit '/profile'
-    expect(page).to have_content('Your Email addresses')
+    expect(page).to have_content('Manage Email Addresses')
+    click_link 'Manage Email Addresses'
   end
 
   context 'create' do

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -111,13 +111,22 @@ feature 'User logs in as a local user', js: true do
     end
   end
 
-  scenario 'keeps trying to find existing account when signing in' do
+  scenario 'redirect home page visitors' do
     user = create_user('jimbo')
-    i = user.identity
 
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
-    click_link 'Sign in'
+    expect(page).to have_content('Sign in with your one OpenStax account')
+
+    login_as 'jimbo', 'password'
+
+    visit '/'
+    expect(page).to have_content('Your Account')
+  end
+
+  scenario 'keeps trying to find existing account when signing in' do
+    create_user('jimbo')
+
+    visit '/login'
     expect(page).to have_content("Sign in with your one OpenStax account!")
 
     click_omniauth_link('twitter')

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'User signs up as a local user', js: true do
   scenario 'success' do
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -26,12 +26,12 @@ feature 'User signs up as a local user', js: true do
     click_link 'Sign out'
     expect(page).to have_content('Signed out!')
     expect(page).not_to have_content('Welcome, testuser')
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
   end
 
   scenario 'with incorrect password confirmation', js: true do
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -46,7 +46,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with empty username', js: true do
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -61,7 +61,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with empty password', js: true do
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -76,7 +76,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with short password', js: true do
     visit '/'
-    expect(page).to have_content('Sign up or Sign in')
+    expect(page).to have_content('Sign in with your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')

--- a/spec/features/user_updates_password_spec.rb
+++ b/spec/features/user_updates_password_spec.rb
@@ -15,16 +15,17 @@ feature 'User updates password' do
 
     scenario 'password form is invisible', js: true do
       visit '/profile'
-      expect(page).to have_content('Your Name')
-      expect(page).not_to have_content('New Password')
+      expect(page).to have_content('First Name')
+      expect(page).not_to have_content('Change Your Password')
     end
   end
 
   context 'with local password' do
     before(:each) do
       visit '/profile'
-      expect(page).to have_content('Your Name')
-      expect(page).to have_content('New Password')
+      click_link 'Change Your Password'
+      expect(page).to have_content('Current Password')
+      expect(page).to have_content('Change Your Password')
     end
 
     scenario 'success', js: true do

--- a/spec/features/user_updates_profile_spec.rb
+++ b/spec/features/user_updates_profile_spec.rb
@@ -8,10 +8,11 @@ feature 'User updates profile' do
     expect(page).to have_content('Welcome, user')
 
     visit '/profile'
-    expect(page).to have_content('Your Name')
+    expect(page).to have_content('Your Account')
   end
 
   scenario 'success', js: true do
+    click_link 'Profile Settings'
     fill_in 'First Name', with: 'testuser'
     click_button 'Update Profile'
     expect(page).to have_content('Profile updated')


### PR DESCRIPTION
* Avoids blank home page -- signed in users go to the profile page; signed out users go to the sign in page
* Correct out-of-date class names: specifically those around the users/find-or-create capability still had old names that only made sense w.r.t a prior implementation.
* Corrected API docs
* Added tabs to the profile page
* Link to profile page from username in header

Fixes #98 