### PR TITLE
Add "back" link on profile form

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -31,3 +31,7 @@
                email_addresses: current_user.email_addresses } %>
   </div>
 </div>
+
+<% if controller.request.env["HTTP_REFERER"].present? %>
+  <%= link_to 'Back', :back %>
+<% end %>


### PR DESCRIPTION
Was removed when tabbifying the profile form.

The condition `if controller.request.env["HTTP_REFERER"].present?` is
added because we don't want rails to use "history.back()" in case the
referer is empty.

![accounts-profile-back-link](https://cloud.githubusercontent.com/assets/153353/9171141/1756674e-3f61-11e5-9a87-159d6f2a49d1.jpg)
