### PR TITLE
Filter email addresses from logs and exception emails

### DIFF
--- a/config/initializers/filter_parameters.rb
+++ b/config/initializers/filter_parameters.rb
@@ -33,7 +33,8 @@ non_string_filters = filter_parameters - string_filters
 # Implement a filter proc that filters out JSON parameters and include existing
 # string filters
 json_key_filters = [:password]
-filter = JsonAndStringParameterFilter.new(string_filters, json_key_filters)
+value_filters = [Proc.new { |value| value =~ /^[^@]+@[^.]+\..+/ }]
+filter = JsonAndStringParameterFilter.new(string_filters, json_key_filters, value_filters)
 
 Rails.application.config.filter_parameters = [Proc.new do |k, v|
   filter.run(k, v)

--- a/lib/json_and_string_parameter_filter.rb
+++ b/lib/json_and_string_parameter_filter.rb
@@ -1,24 +1,54 @@
 class JsonAndStringParameterFilter
-  def initialize(string_filters, json_key_filters)
+  def initialize(string_filters, json_key_filters, value_filters)
     @string_filters = string_filters.collect { |f| f.to_s }
     @json_key_filters = json_key_filters.collect { |f| f.to_s }
+    @value_filters = value_filters
 
     @string_regexp = Regexp.new(@string_filters.join('|'), true)
     @json_key_regexp = Regexp.new(@json_key_filters.join('|'), true)
+  end
+
+  def filter_data_by_key(data, key_regexp)
+    data.keys.each do |key|
+      if data[key].is_a?(Hash)
+        filter_data_by_key(data[key], key_regexp)
+      elsif data[key].is_a?(String)
+        data[key] = '[FILTERED]' if key =~ key_regexp
+      end
+    end
+  end
+
+  def filter_data_by_value(data, value_filters)
+    data.keys.each do |key|
+      if data[key].is_a?(Hash)
+        filter_data_by_value(data[key], value_filters)
+      elsif data[key].is_a?(String)
+        value_filters.each do |value_filter|
+          data[key] = '[FILTERED]' if value_filter.call(data[key])
+        end
+      end
+    end
   end
 
   def run(param_key, param_value)
     json_data = JSON.parse(param_key) rescue nil
 
     if json_data
-      json_data.keys.each do |key|
-        json_data[key] = '[FILTERED]' if @json_key_regexp =~ key
-      end
+      filter_data_by_key(json_data, @json_key_regexp)
+      filter_data_by_value(json_data, @value_filters)
       param_key.gsub!(/^.*$/, json_data.to_json)
       # no need to do anything with param_value as it's nil
-
-    elsif @string_regexp =~ param_key
-      param_value.gsub!(/^.*$/, '[FILTERED]')
+    elsif param_value.is_a?(String)
+      if param_key =~ @string_regexp
+        param_value.gsub!(/^.*$/, '[FILTERED]')
+      else
+        @value_filters.each do |value_filter|
+          param_value.gsub!(/^.*$/, '[FILTERED]') if value_filter.call(param_value)
+        end
+      end
+    elsif param_value.is_a?(Hash)
+      filter_data_by_key(param_value, @string_regexp)
+      filter_data_by_value(param_value, @value_filters)
     end
   end
 end

--- a/spec/lib/json_and_string_parameter_filter_spec.rb
+++ b/spec/lib/json_and_string_parameter_filter_spec.rb
@@ -5,10 +5,11 @@ require 'json_and_string_parameter_filter'
 RSpec.describe JsonAndStringParameterFilter do
   let!(:string_filters) { [:Email, :last_name, :password] }
   let!(:json_key_filters) { [:password] }
+  let!(:value_filters) { [Proc.new { |value| value =~ /^[^@]+@[^.]+\..+/ }] }
 
   let!(:filter) {
     JsonAndStringParameterFilter.new(
-      string_filters, json_key_filters)
+      string_filters, json_key_filters, value_filters)
   }
 
   let!(:params_1) {
@@ -16,42 +17,68 @@ RSpec.describe JsonAndStringParameterFilter do
       "username" => "admin",
       "password" => "Pa$$word",
       "provider" => "identity",
-      "email_address" => "admin@example.com" }
+      "email_address" => "admin@example.com",
+      "other" => {
+        "something" => "test@an.example.com"
+      }
+    }
   }
 
   let!(:params_2) { {
-      "{\"email\":null,\"username\":\"student16\",\"password\":\"password\"}" => nil
+      "{\"email\":null,\"username\":\"student16\",\"password\":\"password\",\"other\":{\"me\":\"me@example.com\"}}" => nil
   } }
 
-  it 'filters string parameters' do
+  let!(:params_3) { {
+    "utf8" => "✓",
+    "contact_info" => {
+      "type" => "EmailAddress",
+      "value" => "test@example.org" },
+    "commit"=>"Add Email address"
+  } }
+
+  def do_filter(params)
     filtered_params = {}
-    params_1.each do |key, value|
+    params.each do |key, value|
       key = key.dup
       value = value.dup if value.duplicable?
       filter.run(key, value)
       filtered_params[key] = value
     end
+    filtered_params
+  end
+
+  it 'filters string parameters' do
+    filtered_params = do_filter(params_1)
 
     expect(filtered_params).to eq({
       "utf8" => "✓",
       "username" => "admin",
       "password" => "[FILTERED]",
       "provider" => "identity",
-      "email_address" => "[FILTERED]"
+      "email_address" => "[FILTERED]",
+      "other" => {
+        "something" => "[FILTERED]"
+      }
     })
   end
 
   it 'filters json parameters' do
-    filtered_params = {}
-    params_2.each do |key, value|
-      key = key.dup
-      value = value.dup if value.duplicable?
-      filter.run(key, value)
-      filtered_params[key] = value
-    end
+    filtered_params = do_filter(params_2)
 
     expect(filtered_params).to eq({
-      "{\"email\":null,\"username\":\"student16\",\"password\":\"[FILTERED]\"}" => nil
+      "{\"email\":null,\"username\":\"student16\",\"password\":\"[FILTERED]\",\"other\":{\"me\":\"[FILTERED]\"}}" => nil
+    })
+  end
+
+  it 'filters by value' do
+    filtered_params = do_filter(params_3)
+
+    expect(filtered_params).to eq({
+      "utf8" => "✓",
+      "contact_info" => {
+        "type" => "EmailAddress",
+        "value" => "[FILTERED]" },
+      "commit"=>"Add Email address"
     })
   end
 end


### PR DESCRIPTION
For example, our logs used to show:

```
Started POST "/contact_infos" for 127.0.0.1 at 2015-08-31 22:06:26 +0200
Processing by ContactInfosController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"[FILTERED]",
  "contact_info"=>{"type"=>"EmailAddress", "value"=>"test@example.com"},
  "commit"=>"Add Email address"}
```

Now it becomes:

```
Started POST "/contact_infos" for 127.0.0.1 at 2015-08-31 22:06:26 +0200
Processing by ContactInfosController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"[FILTERED]",
  "contact_info"=>{"type"=>"EmailAddress", "value"=>"[FILTERED]"},
  "commit"=>"Add Email address"}
```