### PR TITLE
removed redundant 'Please log in.' notices

### DIFF
--- a/lib/sign_in_state.rb
+++ b/lib/sign_in_state.rb
@@ -16,7 +16,7 @@ module SignInState
 
     @current_user
   end
- 
+
   def sign_in!(user)
     @current_user = user || AnonymousUser.instance
     if @current_user.is_anonymous?
@@ -42,16 +42,14 @@ module SignInState
   def authenticate_user!
     unless signed_in?
       store_url
-      redirect_to main_app.login_path(params.slice(:client_id)),
-                  notice: "Please log in." 
+      redirect_to main_app.login_path(params.slice(:client_id))
     end
   end
 
   def authenticate_admin!
     unless current_user.is_administrator?
       store_url
-      redirect_to main_app.login_path(params.slice(:client_id)),
-                  notice: "Please log in."
+      redirect_to main_app.login_path(params.slice(:client_id))
     end
   end
 

--- a/spec/features/user_updates_profile_spec.rb
+++ b/spec/features/user_updates_profile_spec.rb
@@ -15,7 +15,7 @@ feature 'User updates profile' do
     click_link 'Profile Settings'
     fill_in 'First Name', with: 'testuser'
     click_button 'Update Profile'
-    expect(page).to have_content('Profile updated')
+    expect(page).to have_content('Your profile has been updated')
     expect(User.find_by_username('user').first_name).to eq 'testuser'
   end
 end


### PR DESCRIPTION
The 'Please log in.' notice messages appeared right above messages like "Sign in with your one OpenStax account".  This PR removes the redundant notice.

@Dantemss can you review.  Don't merge yet.