### PR TITLE
Fix login exception (got it in an email)

### DIFF
--- a/app/handlers/contact_infos_resend_confirmation.rb
+++ b/app/handlers/contact_infos_resend_confirmation.rb
@@ -11,8 +11,7 @@ class ContactInfosResendConfirmation
   end
 
   def authorized?
-    OSU::AccessPolicy.action_allowed?(:resend_confirmation,
-                                      caller, @contact_info)
+    OSU::AccessPolicy.action_allowed?(:resend_confirmation, caller, @contact_info)
   end
 
   def handle


### PR DESCRIPTION
- Fix accounts exception when someone is already logged in and linked directly to the login page

It's basically a two line change... the rest is comments/whitespace.