### PR TITLE
Fix global before_filters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,8 @@ class ApplicationController < ActionController::Base
 
   layout 'application_body_only'
 
-  skip_before_filter :authenticate_user!, only: [:routing_error]
+  # skip all filters defined so far
+  skip_filter *_process_action_callbacks.map(&:filter), only: [:routing_error]
 
   def routing_error
     raise ActionController::RoutingError.new(params[:path])

--- a/spec/features/unknown_route_spec.rb
+++ b/spec/features/unknown_route_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+feature 'Unknown route used' do
+
+  scenario 'when it is a JSON request' do
+    expect{
+      visit '/lkajsdlkjdklfsjldkfjsl.json'
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  scenario 'when it is an HTML request' do
+    expect{
+      visit '/lkajsdlkjdklfsjldkfjsl'
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+end


### PR DESCRIPTION
1. skip all filters for special 'routing_error' action
2. correct global before_filters to not use non-existent `current_human_user` method

Addresses this exception

```
A NameError occurred in application#routing_error:

 undefined local variable or method `current_human_user' for #<ApplicationController:0x00000004eb6438>
 config/initializers/controllers.rb:41:in `registration'
```