### PR TITLE
Add remote-access JS to asset pipeline compilation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Accounts::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
+  config.assets.precompile += %w( application.js remote-access.js )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Accounts::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+  # Assets that are precompiled
   config.assets.precompile += %w( application.js remote-access.js )
 
   # Disable delivery errors, bad email addresses will be ignored
@@ -69,7 +69,7 @@ Accounts::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Lograge configuration (one-line logs in production)
-  
+
   config.lograge.enabled = true
   config.log_tags = [ :remote_ip ]
   config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
This is needed for running in production.  I missed that on the earlier PR