### PR TITLE
Iframe updates - tweak styles & use SecurityTransgression exception

### DIFF
--- a/app/assets/stylesheets/iframe.css.scss
+++ b/app/assets/stylesheets/iframe.css.scss
@@ -17,41 +17,14 @@ body.iframe {
     padding: 0;
   }
 
-  .login-options {
-    width: 100%;
-    float: none;
-  }
-
-  #login-explanation {
-    padding: 0;
-    width: 100%;
-  }
-  // login page
-  .login-options {
-    .or-bar {
-      width: 100%;
-      .or-text {
-        display: inline;
-        margin-left: auto;
-        margin-rigth: auto;
-      }
-    }
-    .password-login {
-      input[type='text'], input[type='password'] {
-        width: 100%;
-      }
-      .password-actions .sign-up {
-        float: inherit;
-        margin-left: 35px;
-      }
-    }
-
-  }
-
   //signup page
   #signup-alternatives {
     float: inherit;
     width: 80%;
+    margin: 0 auto 20px auto;
+  }
+  #identity-register {
+    float: inherit;
     margin: 0 auto 20px auto;
   }
 }

--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -41,7 +41,7 @@ class RemoteController < ApplicationController
     @iframe_parent = params[:parent]
     valid_origins = SECRET_SETTINGS[:valid_iframe_origins] || []
     unless valid_origins.any?{|origin| @iframe_parent =~ /^#{origin}/ }
-      raise SecurityError.new("#{@iframe_parent} is not allowed to iframe content")
+      raise SecurityTransgression.new("#{@iframe_parent} is not allowed to iframe content")
     end
   end
 

--- a/spec/controllers/remote_controller_spec.rb
+++ b/spec/controllers/remote_controller_spec.rb
@@ -8,8 +8,8 @@ describe RemoteController do
     render_views
 
     it 'throws when parent is not present or invalid' do
-      expect { get(:iframe) }.to raise_error(SecurityError)
-      expect { get(:iframe, parent: 'foo') }.to raise_error(SecurityError)
+      expect { get(:iframe) }.to raise_error(SecurityTransgression)
+      expect { get(:iframe, parent: 'foo') }.to raise_error(SecurityTransgression)
     end
 
     it 'loads and sets parent as context' do


### PR DESCRIPTION
Since the iframe is large enough, we can display the login as a regular two panel view so we no longer need the custom styles.

Also switch to using SecurityTransgression

