### PR TITLE
Logout via iframe

### DIFF
--- a/app/assets/javascripts/remote-access/api.coffee
+++ b/app/assets/javascripts/remote-access/api.coffee
@@ -1,22 +1,19 @@
-# The pages listed here may be loaded at their given urls
-# This allows the iframe user to only request valid urls
-PAGES = {
-  profile: '/profile'
-}
-
 # Methods defined here are executed in the accounts side of the iframe
 # in response to a message sent from a trusted host who's iframing the page
 OxAccount.Api = {
 
-  loadPage: (page) ->
-    return unless PAGES[page]
-    OxAccount.Host.setUrl(PAGES[page])
+  displayProfile: ->
+    OxAccount.Host.setUrl("/profile")
 
   displayLogin: (url) ->
     OxAccount.Host.setUrl("/remote/start_login?start=#{url}")
+
+  displayLogout: (url) ->
+    OxAccount.Host.setUrl("/remote/start_logout?start=#{url}")
 
   # onLogin is actually called by our login completion handler,
   # we just forward data onto listening parent
   onLogin: (data) ->
     OxAccount.proxy.post(onLogin: data)
+
 }

--- a/app/assets/javascripts/remote-access/init.coffee
+++ b/app/assets/javascripts/remote-access/init.coffee
@@ -8,7 +8,4 @@ $(document).ready ->
     OxAccount.Api[name]?(args) for name, args of msg.data
   )
 
-  if window.OX_BOOTSTRAP_INFO.user
-    OxAccount.proxy.post(setUser: window.OX_BOOTSTRAP_INFO.user)
-
   OxAccount.proxy.post(iFrameReady: true)

--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -21,11 +21,15 @@ class RemoteController < ApplicationController
   # Login then comences. Once it completes, we once again redirect back
   # to the client site where it can relay tokens or whatever
   def start_login
-    # store the url that we are going to redirect to
-    # This way we can redirect back to it once login is complete
-    session[:from_iframe] = true
-    store_url(url: params[:start])
+    store_iframe_session
     redirect_to params[:start]
+  end
+
+  # Logout works like logging in except the account is first logged out
+  # The login page is then displayed and the flow is identical to login
+  def start_logout
+    store_iframe_session
+    redirect_to logout_url
   end
 
   # view contains html/javascript to redirect to client url
@@ -36,6 +40,13 @@ class RemoteController < ApplicationController
   end
 
   private
+
+  # store the url that we are going to redirect to
+  # This way we can redirect back to it once login is complete
+  def store_iframe_session
+    session[:from_iframe] = true
+    store_url(url: params[:start])
+  end
 
   def validate_iframe_parent
     @iframe_parent = params[:parent]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,6 +52,9 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    if session[:from_iframe]
+      url = iframe_start_login_path(start: stored_url)
+    end
     session[ActionInterceptor.config.default_key] = nil
     session[:registration_return_to] = nil
     session[:client_id] = nil
@@ -63,7 +66,7 @@ class SessionsController < ApplicationController
     # that are not at the root of their host after logout
     # TODO: Replace with signed or registered return urls
     #       Need to provide web views to sign or register those urls
-    url = begin
+    url ||= begin
       uri = URI(request.referer)
       "#{uri.scheme}://#{uri.host}:#{uri.port}/"
     rescue # in case the referer is bad (see #179)

--- a/app/views/remote/iframe.html.erb
+++ b/app/views/remote/iframe.html.erb
@@ -4,8 +4,7 @@
     <title></title>
     <script>
       window.OX_BOOTSTRAP_INFO = {
-         parentLocation: '<%= @iframe_parent %>',
-         user: <%=raw current_user.is_anonymous? ? false : Api::V1::UserRepresenter.new(current_user).to_json %>
+         parentLocation: '<%= @iframe_parent %>'
       };
     </script>
     <%= javascript_include_tag  "remote-access" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,8 @@ Accounts::Application.routes.draw do
   # routes for access via an iframe
   scope 'remote', controller: 'remote' do
     get 'iframe'
-    get 'start_login'
+    get 'start_login', as: 'iframe_start_login'
+    get 'start_logout'
     get 'finish_login', as: 'iframe_after_login'
   end
 

--- a/spec/features/iframe_sign_in_spec.rb
+++ b/spec/features/iframe_sign_in_spec.rb
@@ -13,8 +13,8 @@ feature 'Login inside an iframe', js: true do
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'password'
       click_button 'Sign in'
-      user_id = page.evaluate_script("window.OX_BOOTSTRAP_INFO.user.id")
-      expect(user_id).to equal(user.id)
+      parent = page.evaluate_script("window.OX_BOOTSTRAP_INFO.parentLocation")
+      expect(parent).to eq('https://openstax.org') # default
     end
   end
 


### PR DESCRIPTION
After thinking it over, a logout will almost always be followed by a login, or at least a "close browser tab".  Since that's the case it seems to make sense to handle losing out inside the iframe and then displaying the login page.