### PR TITLE
removed application name from sign in page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,9 +2,7 @@
   #top-nav-account { display: none;}
 </style>
 
-<%= page_heading("Sign in 
-     #{'to ' + @application.name if @application} 
-     with your one OpenStax account!".html_safe) %>
+<%= page_heading("Sign in to your one OpenStax account!".html_safe) %>
 
 <%= render 'sessions/login', hide_signup: session[:from_cnx] %>
 

--- a/spec/features/add_application_spec.rb
+++ b/spec/features/add_application_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Add application to accounts', js: true do
   scenario 'without logging in' do
     visit '/oauth/applications'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
   end
 
   scenario 'as an admin user' do

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -7,7 +7,7 @@ feature 'User logs in as a local user', js: true do
       create_application
       create_user 'user'
       visit_authorize_uri
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
 
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'pass'
@@ -27,7 +27,7 @@ feature 'User logs in as a local user', js: true do
       create_user_with_plone_password
       visit_authorize_uri
 
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
       fill_in 'Username', with: 'plone_user'
       fill_in 'Password', with: 'pass'
       click_button 'Sign in'
@@ -44,7 +44,7 @@ feature 'User logs in as a local user', js: true do
     with_forgery_protection do
       create_application
       visit_authorize_uri
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
 
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'password'
@@ -62,7 +62,7 @@ feature 'User logs in as a local user', js: true do
     with_forgery_protection do
       create_application
       visit_authorize_uri
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
 
       fill_in 'Username', with: 'expired_password'
       fill_in 'Password', with: 'password'
@@ -85,7 +85,7 @@ feature 'User logs in as a local user', js: true do
     with_forgery_protection do
       create_application
       visit_authorize_uri
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
 
       fill_in 'Username', with: 'imported_user'
       fill_in 'Password', with: 'password'
@@ -115,7 +115,7 @@ feature 'User logs in as a local user', js: true do
     user = create_user('jimbo')
 
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account')
+    expect(page).to have_content('Sign in to your one OpenStax account')
 
     login_as 'jimbo', 'password'
 
@@ -127,7 +127,7 @@ feature 'User logs in as a local user', js: true do
     create_user('jimbo')
 
     visit '/login'
-    expect(page).to have_content("Sign in with your one OpenStax account!")
+    expect(page).to have_content("Sign in to your one OpenStax account!")
 
     click_omniauth_link('twitter')
 
@@ -154,7 +154,7 @@ feature 'User logs in as a local user', js: true do
     click_button 'Sign in'
 
     expect(page).to have_no_content('Nice to meet')
-    expect(page).to have_no_content('Sign in with your one')
+    expect(page).to have_no_content('Sign in to your one')
   end
 
   scenario 'a user signs into an account that has been created by an admin for them', js: true do
@@ -168,7 +168,7 @@ feature 'User logs in as a local user', js: true do
     with_forgery_protection do
       create_application
       visit_authorize_uri
-      expect(page).to have_content("Sign in to #{@app.name} with your one OpenStax account!")
+      expect(page).to have_content("Sign in to your one OpenStax account!")
 
       fill_in 'Username', with: 'therulerofallthings'
       fill_in 'Password', with: 'apassword'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'User signs up as a local user', js: true do
   scenario 'success' do
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -26,12 +26,12 @@ feature 'User signs up as a local user', js: true do
     click_link 'Sign out'
     expect(page).to have_content('Signed out!')
     expect(page).not_to have_content('Welcome, testuser')
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
   end
 
   scenario 'with incorrect password confirmation', js: true do
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -46,7 +46,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with empty username', js: true do
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -61,7 +61,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with empty password', js: true do
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
@@ -76,7 +76,7 @@ feature 'User signs up as a local user', js: true do
 
   scenario 'with short password', js: true do
     visit '/'
-    expect(page).to have_content('Sign in with your one OpenStax account!')
+    expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
     expect(page).to have_content('Register with a username and password')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')


### PR DESCRIPTION
Application name didn't work for Tutor vs Concept Coach; decision was to simplify message (remove app name).

