### PR TITLE
fix for third part account creation getting stuck in popup

### DIFF
--- a/app/assets/javascripts/application/iframe-access-helpers.coffee
+++ b/app/assets/javascripts/application/iframe-access-helpers.coffee
@@ -54,6 +54,13 @@ openSocial = (ev) ->
   ev.preventDefault()
 
 $(document).ready ->
+  if window.opener
+    # if we're inside a popup window, it's because a social login
+    # has completed and we're attempting to get more info from the user
+    # in order to complete the profile
+    window.opener.parent?.OxAccount?.Host.completeRegistration(window.location.pathname)
+    window.close()
+    return
   return unless isIframed() # don't do anything if not inside an iframe
 
   relayHeading()

--- a/app/assets/javascripts/remote-access/host.coffee
+++ b/app/assets/javascripts/remote-access/host.coffee
@@ -7,6 +7,11 @@ OxAccount.Host = {
   loginComplete: (back) ->
     @setUrl(back)
 
+  # we could inspect the url in order to suss out the best action
+  # but the sessions controller will also do it for us
+  completeRegistration: (url) ->
+    @setUrl('/ask_new_or_returning')
+
   setUrl: (url) ->
     $('#content').attr(src: url)
 

--- a/app/assets/stylesheets/iframe.css.scss
+++ b/app/assets/stylesheets/iframe.css.scss
@@ -27,4 +27,14 @@ body.iframe {
     float: inherit;
     margin: 0 auto 20px auto;
   }
+
+  // Page that asks if account is new after a third party login
+  .new-or-returning {
+    .new-or-returning-option {
+      width: inherit;
+    }
+    .middle-space {
+      margin-left: 20px;
+    }
+  }
 }

--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -3,6 +3,8 @@ class RemoteController < ApplicationController
   skip_before_filter :authenticate_user!, only: [:iframe, :start_login]
   skip_before_filter :registration,       only: [:iframe]
   skip_before_filter :expired_password,   only: [:iframe]
+  fine_print_skip :general_terms_of_use, :privacy_policy,
+                  only: [:iframe]
 
   before_filter :validate_iframe_parent, :only=>:iframe
 


### PR DESCRIPTION
When a new social login is created the "ask-new-or-returning" page was being displayed inside the tiny pop-up window.  This catches that flow and re-opens the page inside the iframe.

Note that this is tricky to test, since it only occurs the first time that a third party login is presented to accounts.  To test I found it helpful to just `delete from authentications` on the db before a login.