### PR TITLE
Sign up email

### DIFF
--- a/app/assets/stylesheets/bootstrap_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_overrides.css.scss
@@ -2,7 +2,8 @@
 @import 'bootstrap';
 
 
-select, input[type='text'], input[type='search'], input[type='password'] {
+select, input[type='text'], input[type='search'], input[type='password'],
+input[type='email'] {
   @extend .form-control;
 }
 

--- a/app/assets/stylesheets/sessions.css.scss
+++ b/app/assets/stylesheets/sessions.css.scss
@@ -142,27 +142,18 @@ $login-options-width: 300px;
     width: 40%;
 
     .situation {
-      font-size: 16px;
-      font-weight: bold;
-      height: 60px;
+      height: auto;
       color: $os_gray;
-      margin-top:10px;
+      margin-top: 30px;
       margin-bottom: 20px;
     }
 
     &.left {
       float: left;
-      .situation {
-        padding-top: 10px;  
-      }
     }
 
     &.right {
       float: right; 
-
-      .situation {
-        padding-top: 20px;  
-      }
 
       a {
         margin-top: 165px;
@@ -173,7 +164,8 @@ $login-options-width: 300px;
     }
 
     .well {
-      height: 415px;
+      height: auto;
+      text-align: center;
     }
 
     .login-options {

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -1,6 +1,6 @@
 class ContactInfosController < ApplicationController
 
-  skip_before_filter :authenticate_user!, only: [:confirm, :confirm_unclaimed]
+  skip_before_filter :authenticate_user!, :registration, only: [:confirm, :confirm_unclaimed]
 
   fine_print_skip :general_terms_of_use, :privacy_policy, only: [:confirm, :confirm_unclaimed]
 

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -1,8 +1,10 @@
 class ContactInfosController < ApplicationController
 
-  skip_before_filter :authenticate_user!, :registration, only: [:confirm, :confirm_unclaimed]
+  skip_before_filter :authenticate_user!, :registration, only: [:confirm, :confirm_unclaimed,
+                                                                :resend_confirmation]
 
-  fine_print_skip :general_terms_of_use, :privacy_policy, only: [:confirm, :confirm_unclaimed]
+  fine_print_skip :general_terms_of_use, :privacy_policy, only: [:confirm, :confirm_unclaimed,
+                                                                 :resend_confirmation]
 
   before_filter :get_contact_info, only: [:destroy, :toggle_is_searchable]
 
@@ -36,7 +38,9 @@ class ContactInfosController < ApplicationController
   def resend_confirmation
     handle_with(ContactInfosResendConfirmation,
                 complete: lambda {
-                  redirect_to profile_path(active_tab: :email),
+                  path = current_user.is_email_pending? ? verification_sent_path :
+                                                          profile_path(active_tab: :email)
+                  redirect_to path,
                     notice: "A confirmation message has been sent to \"#{
                               @handler_result.outputs[:contact_info].value}\"" })
   end

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -10,7 +10,7 @@ class IdentitiesController < ApplicationController
     @errors ||= env['errors']
 
     if !current_user.is_anonymous? && current_user.authentications.any?{|auth| auth.provider == 'identity'}
-      redirect_to root_path, alert: "You are already have a simple username and password on your account!"
+      redirect_to root_path, alert: "You already have a simple username and password on your account!"
     else
       store_fallback
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -98,7 +98,7 @@ class SessionsController < ApplicationController
   # Omniauth failure endpoint
   def failure
     flash.now[:alert] = params[:message] == 'invalid_credentials' ? \
-                          'Incorrect username or password' : \
+                          'Incorrect username, email, or password' : \
                           params[:message]
     render 'new'
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,9 +1,9 @@
 class StaticPagesController < ApplicationController
   skip_before_filter :authenticate_user!, :registration,
-                     only: [:api, :copyright, :home, :status]
+                     only: [:api, :copyright, :home, :status, :verification_sent]
 
   fine_print_skip :general_terms_of_use, :privacy_policy,
-                  only: [:api, :copyright, :home, :status]
+                  only: [:api, :copyright, :home, :status, :verification_sent]
 
   skip_protect_beta :only => [:status]
 
@@ -24,6 +24,9 @@ class StaticPagesController < ApplicationController
       store_url # needed for happy login flow, authenticate_user! does it too
       redirect_to login_path
     end
+  end
+
+  def verification_sent
   end
 
   # Used by AWS (and others) to make sure the site is still up.

--- a/app/handlers/identities_forgot_password.rb
+++ b/app/handlers/identities_forgot_password.rb
@@ -5,8 +5,8 @@ class IdentitiesForgotPassword
   uses_routine GeneratePasswordResetCode
 
   paramify :forgot_password do
-    attribute :username, type: String
-    validates :username, presence: true
+    attribute :username_or_email, type: String
+    validates :username_or_email, presence: true
   end
 
   protected
@@ -16,8 +16,9 @@ class IdentitiesForgotPassword
   end
 
   def handle
-    username = forgot_password_params.username
-    user = User.find_by_username(username)
+    username_or_email = forgot_password_params.username_or_email
+    user = User.find_by_username(username_or_email) ||
+           ContactInfo.find_by_value(username_or_email).try(:user)
     if user.nil?
       fatal_error(code: 'Username not found',
                   offending_inputs: [:username])

--- a/app/handlers/identities_register.rb
+++ b/app/handlers/identities_register.rb
@@ -3,6 +3,8 @@ class IdentitiesRegister
   lev_handler
 
   paramify :register do
+    attribute :email, type: String
+    validates :email, presence: true
     attribute :username, type: String
     attribute :first_name, type: String
     attribute :last_name, type: String
@@ -16,6 +18,9 @@ class IdentitiesRegister
   uses_routine CreateIdentity,
                translations: { inputs:  {scope: :register}, 
                                outputs: {type: :verbatim}  }
+
+  uses_routine AddEmailToUser,
+               translations: { inputs: {scope: :register} }
 
   protected
 
@@ -34,6 +39,8 @@ class IdentitiesRegister
       )
       user = outputs[[:create_user, :user]]
     end
+
+    run(AddEmailToUser, register_params.email, user)
 
     run(CreateIdentity, 
         password:              register_params.password,

--- a/app/handlers/users_register.rb
+++ b/app/handlers/users_register.rb
@@ -7,7 +7,9 @@ class UsersRegister
     attribute :username, type: String
     attribute :title, type: String
     attribute :first_name, type: String
+    validates :first_name, presence: true
     attribute :last_name, type: String
+    validates :last_name, presence: true
     attribute :suffix, type: String
     attribute :full_name, type: String
     attribute :contract_1_id, type: Integer
@@ -30,8 +32,8 @@ class UsersRegister
 
     caller.username = register_params.username
     caller.title = register_params.title if !register_params.title.blank?
-    caller.first_name = register_params.first_name if !register_params.first_name.blank?
-    caller.last_name = register_params.last_name if !register_params.last_name.blank?
+    caller.first_name = register_params.first_name
+    caller.last_name = register_params.last_name
     caller.suffix = register_params.suffix if !register_params.suffix.blank?
     caller.full_name = register_params.full_name if !register_params.full_name.blank?
     caller.save

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,6 +95,8 @@ module ApplicationHelper
           options[:form].password_field(options[:name], options[:options])
         when :hidden_field
           options[:form].hidden_field(options[:name], options[:options])
+        when :email_field
+          options[:form].email_field(options[:name], options[:options])
         else
           raise IllegalArgument, "Unknown field type #{options[:type]}"
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,10 @@ class User < ActiveRecord::Base
     'unclaimed' == state
   end
 
+  def is_email_pending?
+    !email_addresses.any?(&:verified)
+  end
+
   def name
     result = full_name.present? ? full_name : guessed_full_name || username
     title.present? ? "#{title} #{result}" : result

--- a/app/views/identities/forgot_password.html.erb
+++ b/app/views/identities/forgot_password.html.erb
@@ -1,5 +1,5 @@
 <%= page_heading 'Forgot Password?' %>
 <%= lev_form_for :forgot_password, url: '' do |f| %>
-  <%= standard_field form: f, name: :username, type: :text_field, label: 'Username' %>
+  <%= standard_field form: f, name: :username_or_email, type: :text_field, label: 'Username / Email' %>
   <%= submit_tag 'Submit' %>
 <% end %>

--- a/app/views/identities/new.html.erb
+++ b/app/views/identities/new.html.erb
@@ -1,4 +1,4 @@
-<%= page_heading 'Register with a username and password' %>
+<%= page_heading 'Sign up' %>
 
 
 <div id="signup-alternatives">
@@ -18,7 +18,13 @@
 
 <%= lev_form_for :register, url: '/auth/identity/register', html: {id: 'identity-register'} do |f| %>
 
-<p>Please choose a <%= 'username and ' if !signed_in? %> password.</p>
+<% if signed_in? %>
+  <p>Please choose a password.</p>
+<% else %>
+  <p>When you create an OpenStax account, we'll send a verification link to the email address you use to create the account. If you don't verify your address, you may not be able to access certain OpenStax features.</p>
+<% end %>
+
+  <%= standard_field form: f, name: :email, type: :email_field, label: 'Email Address' %>
 
 <% if !signed_in? %>
   <%= standard_field form: f, name: :username, type: :text_field, label: "Username" %>

--- a/app/views/sessions/_login.html.erb
+++ b/app/views/sessions/_login.html.erb
@@ -46,7 +46,7 @@
   <% unless has_password %>
     <div class="password-login">
       <%= form_tag '/auth/identity/callback' do %>
-        <label for='auth_key'>Username</label><input type='text' id='auth_key' name='auth_key'/>
+        <label for='auth_key'>Username / Email</label><input type='text' id='auth_key' name='auth_key'/>
         <label for='password'>Password</label><input type='password' id='password' name='password'/>
         <div class='password-actions'>
           <button class='standard'>Sign in</button>

--- a/app/views/sessions/ask_new_or_returning.html.erb
+++ b/app/views/sessions/ask_new_or_returning.html.erb
@@ -1,12 +1,12 @@
 <% authentications = current_user.authentications %>
 
-<%= page_heading "Nice to meet you#{' (again)' if authentications.size > 1 }, #{current_user.username}"  %>
+<%= page_heading 'Merge Logins'  %>
 
+<% if false %>
 <p>Is this your first time making an OpenStax account? If so, choose the option on the right to complete your registration.</p>
 
 <p>If you think you have an existing OpenStax account using a different login, sign in on the left using that login so we can find the existing account and connect all of your logins to it.</p>
 
-<% if false %>
 <p>Do you have another OpenStax account using a different login?</p>
 
 <p>If so,
@@ -22,21 +22,22 @@ profile.</p>
 
 <div class='new-or-returning'>
 
-  <div class='new-or-returning-option right' style='text-align: center'>
+  <div class='new-or-returning-option left'>
     <div class='situation'>
-      I'm a brand new user
+      If this is your first time logging in to OpenStax, continue setting up your account.
     </div>
     <div class='well'>
-    <%= link_to "Finish setting up my account".html_safe, 
+    <%= link_to "Continue".html_safe,
                 stored_url, class: 'standard' %>
     </div>
 
   </div>
 
-  <div class='new-or-returning-option left' style='display:inline-block; text-align:center'>
+  <div class='new-or-returning-option right' style='display:inline-block'>
     <div class='situation'>
-      I think I already have an account<br/>
-      using a different login
+      If you've previously logged into OpenStax using one of the social network logins, we already have an account for you.<br />
+      <br />
+      Sign in using the same social network you used before.  We'll find your existing account and connect all of your logins for you.
     </div>
 
     <div class='well'>

--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -1,0 +1,5 @@
+<%= page_heading 'Verification sent' %>
+
+<p>A verification email has been sent to <%= current_user.email_addresses.first.try(:value) %>.  If you don't see the message in your inbox, check your junk or spam folder.</p>
+
+<p>Once you have verified your email address, click <a href="<%= stored_url %>">here</a> to continue.</p>

--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -2,4 +2,9 @@
 
 <p>A verification email has been sent to <%= current_user.email_addresses.first.try(:value) %>.  If you don't see the message in your inbox, check your junk or spam folder.</p>
 
+<p><%= button_to 'Resend Confirmation',
+                 resend_confirmation_contact_info_path(current_user.email_addresses.first),
+                 method: :put,
+                 class: 'standard' %></p>
+
 <p>Once you have verified your email address, click <a href="<%= stored_url %>">here</a> to continue.</p>

--- a/app/views/users/register.html.erb
+++ b/app/views/users/register.html.erb
@@ -1,14 +1,16 @@
 <%= page_heading 'Complete your profile information to create your account' %>
 
+<p>* indicates required field.</p>
+
 <%= lev_form_for :register, url: register_path, method: :put, html: {id: 'profile-form'} do |f| %>
 
-  <%= standard_field form: f, name: :username, type: :text_field, label: "Username",
+  <%= standard_field form: f, name: :username, type: :text_field, label: "Username *",
                      options: {value: current_user.username} %>
   <%= standard_field form: f, name: :title, type: :text_field, label: "Title",
                      options: {value: current_user.title} %>
-  <%= standard_field form: f, name: :first_name, type: :text_field, label: "First Name",
+  <%= standard_field form: f, name: :first_name, type: :text_field, label: "First Name *",
                      options: {value: current_user.first_name || current_user.guessed_first_name} %>
-  <%= standard_field form: f, name: :last_name, type: :text_field, label: "Last Name",
+  <%= standard_field form: f, name: :last_name, type: :text_field, label: "Last Name *",
                      options: {value: current_user.last_name || current_user.guessed_last_name} %>
   <%= standard_field form: f, name: :suffix, type: :text_field, label: "Suffix",
                      options: {value: current_user.suffix} %>

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -42,7 +42,7 @@ ActionController::Base.class_exec do
 
     return unless current_user.is_temp?
     store_url key: :registration_return_to
-    redirect_to register_path
+    redirect_to(current_user.is_email_pending? ? verification_sent_path : register_path)
   end
 
   def expired_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Accounts::Application.routes.draw do
   scope controller: 'static_pages' do
     get 'copyright'
     get 'status'
+    get 'verification_sent'
   end
 
   apipie

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe UsersController, type: :controller do
 
       controller.sign_in! temp_user
       put 'register', register: {i_agree: true,
+                                 first_name: 'My',
+                                 last_name: 'Username',
                                  username: "my_username",
                                  contract_1_id: contract_1.id,
                                  contract_2_id: contract_2.id}
@@ -95,6 +97,8 @@ RSpec.describe UsersController, type: :controller do
       contract_1 = FinePrint::Contract.first
       contract_2 = FinePrint::Contract.last
       put 'register', register: {i_agree: true,
+                                 first_name: 'My',
+                                 last_name: 'Username',
                                  username: "my_username",
                                  contract_1_id: contract_1.id,
                                  contract_2_id: contract_2.id}

--- a/spec/features/forgot_password_spec.rb
+++ b/spec/features/forgot_password_spec.rb
@@ -14,7 +14,7 @@ feature 'User forgot password', js: true do
 
   scenario 'username is not given' do
     click_button 'Submit'
-    expect(page.text).to include("Username can't be blank")
+    expect(page.text).to include("Username or email can't be blank")
   end
 
   scenario 'username not found' do
@@ -40,6 +40,23 @@ feature 'User forgot password', js: true do
 
   scenario 'user gets a password reset email' do
     fill_in 'Username', with: 'user1'
+    click_button 'Submit'
+    expect(page.text).to include('Password reset instructions sent')
+    @user.identity.reload
+    password_reset_email_sent? @user
+
+    visit @reset_link
+    expect(page.text).to include('Reset Password')
+    expect(page.text).not_to include('Reset password link is invalid')
+    fill_in 'Password', with: 'Pazzw0rd!'
+    fill_in 'Password Again', with: 'Pazzw0rd!'
+    click_button 'Set Password'
+    expect(page.text).to include('Your password has been reset successfully!')
+    expect(page.text).to include('You have been signed in automatically.')
+  end
+
+  scenario 'user enters an email address' do
+    fill_in 'Username / Email', with: @email.value
     click_button 'Submit'
     expect(page.text).to include('Password reset instructions sent')
     @user.identity.reload

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -74,7 +74,7 @@ feature 'User resets password', js: true do
     fill_in 'Username', with: 'user'
     fill_in 'Password', with: 'password'
     click_button 'Sign in'
-    expect(page).to have_content('Incorrect username or password')
+    expect(page).to have_content('Incorrect username, email, or password')
 
     # try logging in with the new password
     fill_in 'Username', with: 'user'

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -17,7 +17,7 @@ feature 'Skipped terms are respected', js: true do
     fill_in 'Password Again', with: 'password'
     click_on 'Register'
 
-    click_on 'Finish setting up my account'
+    click_on 'Continue'
 
     # No skipping
     expect(page).to have_content('I have read')
@@ -52,7 +52,7 @@ feature 'Skipped terms are respected', js: true do
     fill_in 'Password Again', with: 'password'
     click_on 'Register'
 
-    click_on 'Finish setting up my account'
+    click_on 'Continue'
 
     # Skipped!
     expect(page).to_not have_content('I have read')
@@ -86,7 +86,7 @@ feature 'Skipped terms are respected', js: true do
     fill_in 'Password Again', with: 'password'
     click_on 'Register'
 
-    click_on 'Finish setting up my account'
+    click_on 'Continue'
 
     # Gotta sign
     expect(page).to have_content('I have read')

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -18,6 +18,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    MarkContactInfoVerified.call(EmailAddress.order(:id).last)
+    click_on 'here'
 
     # No skipping
     expect(page).to have_content('I have read')
@@ -53,6 +57,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    MarkContactInfoVerified.call(EmailAddress.order(:id).last)
+    click_on 'here'
 
     # Skipped!
     expect(page).to_not have_content('I have read')
@@ -87,6 +95,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    MarkContactInfoVerified.call(EmailAddress.order(:id).last)
+    click_on 'here'
 
     # Gotta sign
     expect(page).to have_content('I have read')

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -11,6 +11,7 @@ feature 'Skipped terms are respected', js: true do
     visit_authorize_uri(@app_without_skip) # simulate arriving from an app
     click_on 'Sign up'
 
+    fill_in 'Email Address', with: 'bob@example.com'
     fill_in 'Username', with: 'bob'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'
@@ -45,6 +46,7 @@ feature 'Skipped terms are respected', js: true do
     visit_authorize_uri(@app_with_skip)
     click_on 'Sign up'
 
+    fill_in 'Email Address', with: 'bobby@example.com'
     fill_in 'Username', with: 'bobby'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'
@@ -78,6 +80,7 @@ feature 'Skipped terms are respected', js: true do
     visit '/'
     click_on 'Sign up'
 
+    fill_in 'Email Address', with: 'bobby@example.com'
     fill_in 'Username', with: 'bobby'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -19,6 +19,11 @@ feature 'User claims an unclaimed account', js: true do
     expect(new_user).to_not be_nil
 
     click_link 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    MarkContactInfoVerified.call(new_user.email_addresses.first)
+    click_link 'here'
+
     fill_in 'First Name', with: 'Test'
     fill_in 'Last Name', with: 'User'
     find(:css, '#register_i_agree').set(true)

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -9,6 +9,7 @@ feature 'User claims an unclaimed account', js: true do
     ).outputs[:user]
     visit '/'
     click_link 'Sign up'
+    fill_in 'Email Address', with: 'unclaimedtestuser@example.com'
     fill_in 'Username', with: 'unclaimedtestuser'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -18,7 +18,7 @@ feature 'User claims an unclaimed account', js: true do
     new_user = User.find_by_username('unclaimedtestuser')
     expect(new_user).to_not be_nil
 
-    click_link 'Finish setting up my account'
+    click_link 'Continue'
     fill_in 'First Name', with: 'Test'
     fill_in 'Last Name', with: 'User'
     find(:css, '#register_i_agree').set(true)

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -131,18 +131,18 @@ feature 'User logs in as a local user', js: true do
 
     click_omniauth_link('twitter')
 
-    expect(page).to have_content('Nice to meet you,')
+    expect(page).to have_content('Merge Logins')
     expect(page).to have_no_link('twitter-login-button')
 
     click_omniauth_link('google_oauth2')
 
-    expect(page).to have_content('Nice to meet you (again),')
+    expect(page).to have_content('Merge Logins')
     expect(page).to have_no_link('twitter-login-button')
     expect(page).to have_no_link('google_oauth2-login-button')
 
     click_omniauth_link('facebook')
 
-    expect(page).to have_content('Nice to meet you (again),')
+    expect(page).to have_content('Merge Logins')
     expect(page).to have_no_link('twitter-login-button')
     expect(page).to have_no_link('google_oauth2-login-button')
     expect(page).to have_no_link('facebook-login-button')
@@ -153,7 +153,7 @@ feature 'User logs in as a local user', js: true do
 
     click_button 'Sign in'
 
-    expect(page).to have_no_content('Nice to meet')
+    expect(page).to have_no_content('Merge Logins')
     expect(page).to have_no_content('Sign in to your one')
   end
 

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -12,7 +12,7 @@ feature 'User logs in as a local user', js: true do
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'pass'
       click_button 'Sign in'
-      expect(page).to have_content('Incorrect username or password')
+      expect(page).to have_content('Incorrect username, email, or password')
 
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'password'
@@ -31,7 +31,7 @@ feature 'User logs in as a local user', js: true do
       fill_in 'Username', with: 'plone_user'
       fill_in 'Password', with: 'pass'
       click_button 'Sign in'
-      expect(page).to have_content('Incorrect username or password')
+      expect(page).to have_content('Incorrect username, email, or password')
 
       fill_in 'Username', with: 'plone_user'
       fill_in 'Password', with: 'password'
@@ -49,7 +49,7 @@ feature 'User logs in as a local user', js: true do
       fill_in 'Username', with: 'user'
       fill_in 'Password', with: 'password'
       click_button 'Sign in'
-      expect(page).to have_content('Incorrect username or password')
+      expect(page).to have_content('Incorrect username, email, or password')
     end
   end
 
@@ -178,5 +178,25 @@ feature 'User logs in as a local user', js: true do
       expect(new_user.reload.state).to eq("activated")
     end
 
+  end
+
+  scenario 'with an email address and password' do
+    with_forgery_protection do
+      create_application
+      user = create_user 'user'
+      create_email_address_for user, 'user@example.com'
+      visit_authorize_uri
+      expect(page).to have_content("Sign in to your one OpenStax account!")
+
+      fill_in 'Username', with: 'user'
+      fill_in 'Password', with: 'pass'
+      click_button 'Sign in'
+      expect(page).to have_content('Incorrect username, email, or password')
+
+      fill_in 'Username / Email', with: 'user@example.com'
+      fill_in 'Password', with: 'password'
+      click_button 'Sign in'
+      expect(page.current_url).to match(app_callback_url)
+    end
   end
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -120,6 +120,33 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content("Email can't be blank")
     expect(page).not_to have_content('Welcome, testuser')
   end
+
+  scenario 'without confirming email' do
+    visit '/'
+    expect(page).to have_content('Sign in to your one OpenStax account!')
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
+
+    fill_in 'Email Address', with: 'testuser@example.com'
+    fill_in 'Username', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_button 'Register'
+    expect(page).to have_content('Welcome, testuser')
+
+    click_link 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    click_link 'Sign out'
+    fill_in 'Username / Email', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    click_button 'Sign in'
+
+    expect(page).to have_content('Welcome, testuser')
+    click_link 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+  end
 end
 
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -147,7 +147,26 @@ feature 'User signs up as a local user', js: true do
     click_link 'Continue'
     expect(page).to have_content('A verification email has been sent')
   end
+
+  scenario 'resend confirmation email' do
+    visit '/'
+    expect(page).to have_content('Sign in to your one OpenStax account!')
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
+
+    fill_in 'Email Address', with: 'testuser@example.com'
+    fill_in 'Username', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_button 'Register'
+    expect(page).to have_content('Welcome, testuser')
+
+    click_link 'Continue'
+    expect(page).to have_content('A verification email has been sent')
+
+    click_on 'Resend Confirmation'
+
+    expect(page).to have_content('A confirmation message has been sent to "testuser@example.com"')
+  end
 end
-
-
-

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -15,7 +15,7 @@ feature 'User signs up as a local user', js: true do
     click_button 'Register'
     expect(page).to have_content('Welcome, testuser')
 
-    click_link 'Finish setting up my account'
+    click_link 'Continue'
     expect(page).to have_content('Welcome, testuser')
 
     expect(page).to have_content('Complete your profile information')

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -5,9 +5,10 @@ feature 'User signs up as a local user', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
-    expect(page).to have_content('Register with a username and password')
+    expect(page).to have_content('Sign up')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
 
+    fill_in 'Email Address', with: 'testuser@example.com'
     fill_in 'Username', with: 'testuser'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'
@@ -33,9 +34,10 @@ feature 'User signs up as a local user', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
-    expect(page).to have_content('Register with a username and password')
+    expect(page).to have_content('Sign up')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
 
+    fill_in 'Email Address', with: 'testuser@example.com'
     fill_in 'Username', with: 'testuser'
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'pass'
@@ -48,9 +50,10 @@ feature 'User signs up as a local user', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
-    expect(page).to have_content('Register with a username and password')
+    expect(page).to have_content('Sign up')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
 
+    fill_in 'Email Address', with: 'testuser@example.com'
     fill_in 'Username', with: ''
     fill_in 'Password', with: 'password'
     fill_in 'Password Again', with: 'password'
@@ -63,9 +66,10 @@ feature 'User signs up as a local user', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
-    expect(page).to have_content('Register with a username and password')
+    expect(page).to have_content('Sign up')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
 
+    fill_in 'Email Address', with: 'testuser@example.com'
     fill_in 'Username', with: 'testuser'
     fill_in 'Password', with: ''
     fill_in 'Password Again', with: ''
@@ -78,14 +82,31 @@ feature 'User signs up as a local user', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')
     click_link 'Sign up'
-    expect(page).to have_content('Register with a username and password')
+    expect(page).to have_content('Sign up')
     expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
 
+    fill_in 'Email Address', with: 'testuser@example.com'
     fill_in 'Username', with: 'testuser'
     fill_in 'Password', with: 'pass'
     fill_in 'Password Again', with: 'pass'
     click_button 'Register'
     expect(page).to have_content("Password is too short (minimum is 8 characters)")
+    expect(page).not_to have_content('Welcome, testuser')
+  end
+
+  scenario 'with empty email address', js: true do
+    visit '/'
+    expect(page).to have_content('Sign in to your one OpenStax account!')
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
+
+    fill_in 'Email Address', with: ''
+    fill_in 'Username', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_button 'Register'
+    expect(page).to have_content("Email can't be blank")
     expect(page).not_to have_content('Welcome, testuser')
   end
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -16,7 +16,12 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content('Welcome, testuser')
 
     click_link 'Continue'
-    expect(page).to have_content('Welcome, testuser')
+    expect(page).to have_content('A verification email has been sent')
+
+    visit confirm_path(code: EmailAddress.last.confirmation_code)
+    expect(page).to have_content('Success!')
+
+    visit '/'
 
     expect(page).to have_content('Complete your profile information')
     fill_in 'First Name', with: 'Test'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -24,6 +24,12 @@ feature 'User signs up as a local user', js: true do
     visit '/'
 
     expect(page).to have_content('Complete your profile information')
+    find(:css, '#register_i_agree').set(true)
+    click_button 'Register'
+
+    expect(page).to have_content("First name can't be blank")
+    expect(page).to have_content("Last name can't be blank")
+
     fill_in 'First Name', with: 'Test'
     fill_in 'Last Name', with: 'User'
     find(:css, '#register_i_agree').set(true)


### PR DESCRIPTION
- Fix typo in an alert message in identities controller

- Add email address field to sign up form

- Update text and layout on merge logins page

- Add verification email sent page if user has not confirmed email address

    The verification email sent page is after the "merge logins" page and
    before the terms and profile/registration page.

- Make first and last name mandatory at registration

- Change label to "Username / Email" on login page and add test

- Allow users to reset their password using username or email address

- Add spec for user signing in without confirming their email address

- Add resend confirmation button to "verification email sent" page