### PR TITLE
Do not store iframe info on logout

### DIFF
--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -30,7 +30,6 @@ class RemoteController < ApplicationController
   # Logout works like logging in except the account is first logged out
   # The login page is then displayed and the flow is identical to login
   def start_logout
-    store_iframe_session
     redirect_to logout_url
   end
 


### PR DESCRIPTION
When CC logouts out it shouldn't store the iframe session info because it causes a new login from tutor to get and redirect to the iframe handlers when it re-logs in.