### PR TITLE
More concept coach login style tweaks

### DIFF
--- a/app/assets/stylesheets/iframe.css.scss
+++ b/app/assets/stylesheets/iframe.css.scss
@@ -28,13 +28,36 @@ body.iframe {
     margin: 0 auto 20px auto;
   }
 
+  .new-login {
+    display: flex;
+    justify-content: space-around;
+    .login-explanation { order: 1; }
+    .login-options{ order: 2; }
+  }
+
+
   // Page that asks if account is new after a third party login
   .new-or-returning {
-    .new-or-returning-option {
-      width: inherit;
-    }
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    .left { order: 1; }
     .middle-space {
-      margin-left: 20px;
+      order: 2;
+      display: flex !important; // inline-block is set as style attribute
+      flex-direction: column;
+      align-self: stretch;
+      margin: 0;
+      .or-bar {
+        height: inherit;
+        flex: 1;
+        margin: 0;
+        .or-text {
+          left: -25px;
+          top: 50%;
+        }
+      }
     }
+    .right { order: 3; }
   }
 }

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,20 +3,19 @@
 </style>
 
 <%= page_heading("Sign in to your one OpenStax account!".html_safe) %>
+<div class="new-login">
+  <%= render 'sessions/login', hide_signup: (session[:from_cnx] && !session[:from_iframe]) %>
 
-<%= render 'sessions/login', hide_signup: (session[:from_cnx] && !session[:from_iframe]) %>
+  <div id="login-explanation">
+    <p>Use the buttons at the right to sign in using your Facebook, Twitter, or Google account.</p>
+    <% if session[:from_cnx] %>
+      <p>If you have a legacy Connexions account, you can enter your username and password instead.</p>
+    <% else %>
+      <p>Prefer to use a plain old username and password?  You can do that too.</p>
+    <% end %>
 
-
-<div id="login-explanation">
-  <p>Use the buttons at the right to sign in using your Facebook, Twitter, or Google account.</p>
-  <% if session[:from_cnx] %>
-    <p>If you have a legacy Connexions account, you can enter your username and password instead.</p>
-  <% else %>
-    <p>Prefer to use a plain old username and password?  You can do that too.</p>
-  <% end %>
-
-  <div id="logout-reminder">
-    <p>Don't forget Internet 101: if you're on a public computer, be sure to log out when you're done!</p>
+    <div id="logout-reminder">
+      <p>Don't forget Internet 101: if you're on a public computer, be sure to log out when you're done!</p>
+    </div>
   </div>
 </div>
-


### PR DESCRIPTION
The "ask-new-or-returning page" was pretty janked at certain sizes, and the signup's boxes had quite a bit of space between them

This uses flexbox to align items since it'll adjust to arbitrary width / heights the best.  Note that it's IE 10+, but that's OK for concept coach audience.   As soon as accounts itself can drop legacy browser support we should move these styles over to the main site.


![screen shot 2015-12-03 at 1 35 15 pm](https://cloud.githubusercontent.com/assets/79566/11571783/b13ceb5a-99c3-11e5-9181-7e63ee61d3dc.png)
![screen shot 2015-12-03 at 1 25 39 pm](https://cloud.githubusercontent.com/assets/79566/11571784/b15e29a0-99c3-11e5-8046-0277dc362508.png)

