### PR TITLE
Ask for email page changes, autocaps off for mobile

### DIFF
--- a/app/assets/stylesheets/iframe.css.scss
+++ b/app/assets/stylesheets/iframe.css.scss
@@ -23,7 +23,7 @@ body.iframe {
     width: 80%;
     margin: 0 auto 20px auto;
   }
-  #identity-register {
+  #identity-register, #ask-for-email {
     float: inherit;
     margin: 0 auto 20px auto;
   }

--- a/app/assets/stylesheets/sessions.css.scss
+++ b/app/assets/stylesheets/sessions.css.scss
@@ -88,7 +88,7 @@ $login-options-width: 300px;
   }
 }
 
-#identity-register {
+#identity-register, #ask-for-email {
   width: 350px;
 
   input[type='submit'] {

--- a/app/views/sessions/_login.html.erb
+++ b/app/views/sessions/_login.html.erb
@@ -46,7 +46,7 @@
   <% unless has_password %>
     <div class="password-login">
       <%= form_tag '/auth/identity/callback' do %>
-        <label for='auth_key'>Username / Email</label><input type='text' id='auth_key' name='auth_key'/>
+        <label for='auth_key'>Username / Email</label><input type='text' id='auth_key' name='auth_key' autocapitalize="off" autocorrect="off"/>
         <label for='password'>Password</label><input type='password' id='password' name='password'/>
         <div class='password-actions'>
           <button class='standard'>Sign in</button>

--- a/app/views/users/ask_for_email.html.erb
+++ b/app/views/users/ask_for_email.html.erb
@@ -1,6 +1,8 @@
-<%= page_heading 'Give us an email address' %>
+<%= page_heading 'Please add an email address to your account.' %>
 
-<%= lev_form_for :contact_info, method: :put do |f| %>
+<p>Having an email address on your account is important should you ever need to reset your password.</p>
+
+<%= lev_form_for :contact_info, method: :put, html: {class: 'form-horizontal', id: 'ask-for-email'} do |f| %>
   <%= standard_field form: f, name: :value, type: :email_field, label: 'Email Address' %>
   <%= f.hidden_field :type, value: 'EmailAddress' %>
   <%= submit_tag 'Submit', class: 'standard' %>

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -190,7 +190,7 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content('Merge Logins')
     click_on 'Continue'
 
-    expect(page).to have_content('Give us an email address')
+    expect(page).to have_content('Please add an email address to your account.')
     fill_in 'Email Address', with: 'user@example.org'
     click_on 'Submit'
 


### PR DESCRIPTION
Adjusts phrasing on "ask for email" page.  Tries to make styling on that page match new account page.  Also, unrelatedly turns off autocaps for mobile devices (chrome and safari support)