### PR TITLE
Remove ask_for_email page from the registration workflow

### DIFF
--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -43,12 +43,10 @@ ActionController::Base.class_exec do
     return unless current_user.is_temp?
     store_url key: :registration_return_to
     flash.keep
-    if current_user.email_addresses.empty?
-      redirect_to ask_for_email_path
-    elsif !current_user.email_addresses.any?(&:verified)
-      redirect_to verification_sent_path
-    else
+    if current_user.email_addresses.empty? || current_user.email_addresses.any?(&:verified)
       redirect_to register_path
+    else
+      redirect_to verification_sent_path
     end
   end
 

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -20,4 +20,34 @@ feature 'Confirm email address', js: true do
     visit '/confirm?code=1234'
     expect(page).to have_content("Sorry, we couldn't verify an email using the verification code you provided.")
   end
+
+  scenario 'redirects back to site afterwards' do
+    # set the user state to "temp" so we can test registration
+    user = create_user 'user2'
+    user.state = 'temp'
+    user.save
+
+    create_application
+    visit_authorize_uri
+    fill_in 'Username', with: 'user2'
+    fill_in 'Password', with: 'password'
+    click_on 'Sign in'
+
+    # this page is not being used in the current registration workflow
+    # but the code is there in case we want to use it
+    visit '/ask_for_email'
+    fill_in 'Email Address', with: 'user2@example.com'
+    click_on 'Submit'
+
+    expect(page).to have_content('A verification email has been sent')
+    visit link_in_last_email
+
+    expect(page).to have_content('Complete your profile')
+    fill_in 'First Name', with: 'User'
+    fill_in 'Last Name', with: 'Two'
+    find(:css, '#register_i_agree').set(true)
+    click_button 'Register'
+
+    expect(page.current_url).to match(app_callback_url)
+  end
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -174,6 +174,7 @@ feature 'User signs up as a local user', js: true do
   end
 
   scenario 'without any email addresses' do
+    # this is a test for twitter users who have no email addresses
     create_application
     user = create_user 'user'
     # set the user state to "temp" so we can test registration
@@ -189,13 +190,6 @@ feature 'User signs up as a local user', js: true do
 
     expect(page).to have_content('Merge Logins')
     click_on 'Continue'
-
-    expect(page).to have_content('Please add an email address to your account.')
-    fill_in 'Email Address', with: 'user@example.org'
-    click_on 'Submit'
-
-    expect(page).to have_content('Verification sent')
-    visit link_in_last_email
 
     expect(page).to have_content('Complete your profile information')
     fill_in 'First Name', with: 'First'


### PR DESCRIPTION
The page was originally created for twitter users because twitter
doesn't give us an email address.  We require email address verification
in order for users to be able to reset their own passwords, but that's
not necessary for twitter users.  So this page is removed from the
registration workflow for now.