### PR TITLE
Adjust layout of forms so they fit smaller screens

### DIFF
--- a/app/assets/stylesheets/application_layout.css.scss
+++ b/app/assets/stylesheets/application_layout.css.scss
@@ -1,9 +1,9 @@
-// Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+// Copyright 2011-2013 Rice University. Licensed under the Affero General Public
 // License version 3 or later.  See the COPYRIGHT file for details.
 
 @import "common";
 
-body { 
+body {
   background-color: $application_background_color;
   color:            $os_gray;
   margin-top:       0px;
@@ -15,7 +15,7 @@ body, p, ol, ul, td, a {
 }
 
 #application-container {
-  width: $application_master_width;
+  min-width: $application_master_width;
 
   margin: 0px auto;
 

--- a/app/assets/stylesheets/common_dimensions.css.scss
+++ b/app/assets/stylesheets/common_dimensions.css.scss
@@ -1,7 +1,7 @@
-// Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+// Copyright 2011-2013 Rice University. Licensed under the Affero General Public
 // License version 3 or later.  See the COPYRIGHT file for details.
 
-$application_master_width: 960px;
+$application_master_width: 775px;
 
 $application_edge_distance: 54px;
 

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1,4 +1,4 @@
-// Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+// Copyright 2011-2013 Rice University. Licensed under the Affero General Public
 // License version 3 or later.  See the COPYRIGHT file for details.
 
 @import "common";
@@ -42,3 +42,7 @@ table.std-list-1 {
     float: right;
   }
 }
+
+// adds top margin to the submit so that
+.horizontal-submit input { margin-top: 25px; }
+form .nowrap label { white-space: nowrap; }

--- a/app/views/identities/_form.html.erb
+++ b/app/views/identities/_form.html.erb
@@ -4,34 +4,26 @@
 
 <%= form_for identity, url: identity_path,
              html: {class: 'form-horizontal'} do |f| %>
-  <div class="row">
-    <span class="col-sm-3">
-      <%= f.label :current_password, "Current Password" %>
-    </span>
+<div class="row">
 
-    <span class="col-sm-3">
-      <%= f.label :password, "New Password" %>
-    </span>
-
-    <span class="col-sm-3">
-      <%= f.label :password_confirmation, "New Password Confirmation" %>
-    </span>
+  <div class="col-sm-3">
+    <%= f.label :current_password, "Current Password" %>
+    <%= f.password_field :current_password %>
   </div>
-  <div class="row">
-    <span class="col-sm-3">
-      <%= f.password_field :current_password %>
-    </span>
 
-    <span class="col-sm-3">
-      <%= f.password_field :password %>
-    </span>
-
-    <span class="col-sm-3">
-      <%= f.password_field :password_confirmation %>
-    </span>
-
-    <span class="col-sm-3">
-      <%= f.submit "Change Password", class: 'standard' %>
-    </span>
+  <div class="col-sm-3">
+    <%= f.label :password, "New Password" %>
+    <%= f.password_field :password %>
   </div>
+
+  <div class="col-sm-3 nowrap">
+    <%= f.label :password_confirmation, "New Password Confirmation" %>
+    <%= f.password_field :password_confirmation %>
+  </div>
+
+  <div class="horizontal-submit col-sm-3">
+    <%= f.submit "Change Password", class: 'standard' %>
+  </div>
+
+</div>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,44 +2,34 @@
    # user
 %>
 
-<%= form_for user, url: profile_path, html: {class: 'form-horizontal'} do |f| %>
+<%= form_for user, url: profile_path, html: {class: 'form-horizontal profile-edit'} do |f| %>
   <div class="row">
-    <span class="col-sm-1">
+
+    <div class="col-sm-1">
       <%= f.label :title, "Title" %>
-    </span>
-
-    <span class="col-sm-3">
-      <%= f.label :first_name, "First Name" %>
-    </span>
-
-    <span class="col-sm-3">
-      <%= f.label :last_name, "Last Name" %>
-    </span>
-
-    <span class="col-sm-2">
-      <%= f.label :suffix, 'Suffix' %>
-    </span>
-  </div>
-  <div class="row">
-    <span class="col-sm-1">
       <%= f.text_field :title %>
-    </span>
+    </div>
 
-    <span class="col-sm-3">
+    <div class="col-sm-3">
+      <%= f.label :first_name, "First Name" %>
       <%= f.text_field :first_name, value: user.first_name || \
-                                           user.guessed_first_name %>
-    </span>
+          user.guessed_first_name %>
+    </div>
 
-    <span class="col-sm-3">
+    <div class="col-sm-3">
+      <%= f.label :last_name, "Last Name" %>
       <%= f.text_field :last_name, value: user.last_name || \
-                                          user.guessed_last_name %>
-    </span>
+          user.guessed_last_name %>
+    </div>
 
-    <span class="col-sm-2">
+    <div class="col-sm-2">
+      <%= f.label :suffix, 'Suffix' %>
       <%= f.text_field :suffix, value: user.suffix %>
-    </span>
-    <span class="col-sm-3">
+    </div>
+
+    <div class="horizontal-submit col-sm-3">
       <%= f.submit "Update Profile", class: 'standard' %>
-    </span>
+    </div>
+
   </div>
 <% end %>


### PR DESCRIPTION
CC iframe is the driver of this, but the changes will benefit everyone (that's on a small screen).

Currently a 750px screen looks like:

![image](https://cloud.githubusercontent.com/assets/79566/11642529/d8578842-9d03-11e5-967b-3536fa7c310a.png)


With changes it wraps:


![image](https://cloud.githubusercontent.com/assets/79566/11642494/ac7adfa8-9d03-11e5-84d6-59cabdaf17ea.png)
