### PR TITLE
Remove duplicate username taken error message at sign up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,6 @@ class User < ActiveRecord::Base
   has_many :oauth_applications, through: :member_groups
 
   validates :username, presence: true,
-                       uniqueness: { case_sensitive: true },
                        length: { minimum: 3, maximum: USERNAME_MAX_LENGTH },
                        format: { with: /\A[A-Za-z\d_]+\z/,
                                  message: "Usernames can only contain letters, numbers, and underscores." }

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -104,6 +104,22 @@ feature 'User signs up as a local user', js: true do
     expect(page).not_to have_content('Welcome, testuser')
   end
 
+  scenario 'with a username already taken' do
+    create_user 'testuser'
+    visit '/'
+    expect(page).to have_content('Sign in to your one OpenStax account!')
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
+
+    fill_in 'Email Address', with: 'testuser@example.com'
+    fill_in 'Username', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_button 'Continue'
+    expect(page).to have_content('Username has already been taken', count: 1)
+  end
+
   scenario 'with empty email address', js: true do
     visit '/'
     expect(page).to have_content('Sign in to your one OpenStax account!')


### PR DESCRIPTION
User sees "Username has already been taken" twice if the username chosen
at sign up is taken.  The reason is we have uniqueness check in the user
model twice because we changed from case sensitive unique usernames to
case insensitive unique usernames without affecting the validation of
existing users.

I've removed the case sensitive uniqueness check because I think it's
redundant.