### PR TITLE
Email verification fixes

### DIFF
--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -38,9 +38,22 @@ class ContactInfosController < ApplicationController
   def resend_confirmation
     handle_with(ContactInfosResendConfirmation,
                 complete: lambda {
-                  redirect_to :back,
-                    notice: "A verification message has been sent to \"#{
-                              @handler_result.outputs[:contact_info].value}\"" })
+                  path = :back
+                  contact_info = @handler_result.outputs[:contact_info]
+
+                  if contact_info.verified
+                    msg = 'Your email address is already verified'
+                    user = contact_info.user
+                    path = user.registration_redirect_url \
+                      if user.is_temp? && user.registration_redirect_url
+                  else
+                    msg = "A verification message has been sent to \"#{
+                           contact_info.value}\""
+                  end
+
+                  redirect_to path,
+                              notice: msg
+                })
   end
 
 

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -54,15 +54,7 @@ class ContactInfosController < ApplicationController
   def confirm
     handle_with(ContactInfosConfirm,
                 complete: lambda {
-                  user = @handler_result.outputs.contact_info.try(:user)
-                  if @handler_result.errors.any?
-                    render :confirm, status: 400
-                  elsif user.try(:is_temp?) && user.try(:registration_redirect_url).present?
-                    redirect_to user.registration_redirect_url,
-                                notice: 'Thanks for adding your email address.'
-                  else
-                    render :confirm, status: 200
-                  end
+                  render :confirm, status: @handler_result.errors.any? ? 400 : 200
                 })
   end
 

--- a/app/handlers/confirm_unclaimed_account.rb
+++ b/app/handlers/confirm_unclaimed_account.rb
@@ -9,10 +9,12 @@ class ConfirmUnclaimedAccount
   end
 
   def handle
-    fatal_error(code: :no_contact_info_for_code) if params[:code].nil?
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') if params[:code].nil?
     contact_info = ContactInfo.where(confirmation_code: params[:code]).first
-    fatal_error(code: :no_contact_info_for_code) if contact_info.nil? ||
-                                                    !contact_info.user.is_unclaimed?
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') \
+                if contact_info.nil? || !contact_info.user.is_unclaimed?
     outputs[:email_address] = contact_info.value
     if contact_info.user.identity.present?
       outputs[:can_log_in] = true

--- a/app/handlers/contact_infos_confirm.rb
+++ b/app/handlers/contact_infos_confirm.rb
@@ -12,9 +12,11 @@ class ContactInfosConfirm
   end
 
   def handle
-    fatal_error(code: :no_contact_info_for_code) if params[:code].nil?
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') if params[:code].nil?
     contact_info = ContactInfo.where(confirmation_code: params[:code]).first
-    fatal_error(code: :no_contact_info_for_code) if contact_info.nil?
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') if contact_info.nil?
     outputs[:contact_info] = contact_info
     run(MergeUnclaimedUsers, contact_info)
     run(MarkContactInfoVerified, contact_info)

--- a/app/views/contact_infos/confirm.html.erb
+++ b/app/views/contact_infos/confirm.html.erb
@@ -1,6 +1,10 @@
-<%= page_heading "Email Verification" %>
+<%= page_heading "Thank you for verifying your email address." %>
 <% if @handler_result.errors.any? %>
   <p>Sorry, we couldn't verify an email using the verification code you provided.  If you typed it in manually, please check for errors.  If you're still having trouble, please visit your profile page to resend the verification email.</p>
 <% else %>
-  <p>Success! Thanks for adding your email address.</p>
+  <% if @handler_result.outputs.contact_info.try(:user).try(:is_temp?) %>
+    <p>Please close this tab and continue your registration process in OpenStax.</p>
+  <% else %>
+    <p>Success! Thanks for adding your email address.</p>
+  <% end %>
 <% end %>

--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -2,12 +2,14 @@
 
 <p>A verification email has been sent to <%= current_user.email_addresses.first.try(:value) %>.  If you don't see the message in your inbox, check your junk or spam folder.</p>
 
-<p><%= button_to 'Resend Verification',
-                 resend_confirmation_contact_info_path(current_user.email_addresses.first),
-                 method: :put,
-                 class: 'standard' %></p>
+<p><%= link_to 'Resend Verification',
+               resend_confirmation_contact_info_path(current_user.email_addresses.first),
+               method: :put %></p>
 
 <br />
 <br />
 <br />
-<p>Already verified your email address? <a href="<%= stored_url %>">Continue</a>.</p>
+<p>Return to this page after you've verified your email address to continue your registration.</p>
+<p><%= button_to 'Continue',
+                 stored_url,
+                 class: 'standard' %></p>

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -14,11 +14,15 @@ feature 'Confirm email address', js: true do
 
   scenario 'without a confirmation code' do
     visit '/confirm'
+    expect(page).to_not have_content('Alert: no_contact_info_for_code')
+    expect(page).to have_content('Alert: Unable to verify email address')
     expect(page).to have_content("Sorry, we couldn't verify an email using the verification code you provided.")
   end
 
   scenario 'with unmatched confirmation code' do
     visit '/confirm?code=1234'
+    expect(page).to_not have_content('Alert: no_contact_info_for_code')
+    expect(page).to have_content('Alert: Unable to verify email address')
     expect(page).to have_content("Sorry, we couldn't verify an email using the verification code you provided.")
   end
 

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -8,7 +8,8 @@ feature 'Confirm email address', js: true do
 
   scenario 'successfully' do
     visit '/confirm?code=1111'
-    expect(page).to have_content('Email Verification Success!')
+    expect(page).to have_content('Thank you for verifying your email address')
+    expect(page).to have_content('Thanks for adding your email address.')
   end
 
   scenario 'without a confirmation code' do
@@ -21,14 +22,13 @@ feature 'Confirm email address', js: true do
     expect(page).to have_content("Sorry, we couldn't verify an email using the verification code you provided.")
   end
 
-  scenario 'redirects back to site afterwards' do
+  scenario 'successfully during registration' do
     # set the user state to "temp" so we can test registration
     user = create_user 'user2'
     user.state = 'temp'
     user.save
 
-    create_application
-    visit_authorize_uri
+    visit '/'
     fill_in 'Username', with: 'user2'
     fill_in 'Password', with: 'password'
     click_on 'Sign in'
@@ -40,14 +40,9 @@ feature 'Confirm email address', js: true do
     click_on 'Submit'
 
     expect(page).to have_content('A verification email has been sent')
+
     visit link_in_last_email
-
-    expect(page).to have_content('Complete your profile')
-    fill_in 'First Name', with: 'User'
-    fill_in 'Last Name', with: 'Two'
-    find(:css, '#register_i_agree').set(true)
-    click_button 'Register'
-
-    expect(page.current_url).to match(app_callback_url)
+    expect(page).to have_content(
+      'Please close this tab and continue your registration process in OpenStax')
   end
 end

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -22,7 +22,7 @@ feature 'User claims an unclaimed account', js: true do
     expect(page).to have_content('A verification email has been sent')
 
     MarkContactInfoVerified.call(new_user.email_addresses.first)
-    click_link 'Continue'
+    click_on 'Continue'
 
     fill_in 'First Name', with: 'Test'
     fill_in 'Last Name', with: 'User'

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -32,7 +32,7 @@ feature 'User claims an unclaimed account', js: true do
     expect{
       create_email_address_for new_user, "unclaimeduser@example.com", '4242'
       visit '/confirm?code=4242'
-      expect(page).to have_content('Email Verification Success!')
+      expect(page).to have_content('Thank you for verifying your email address')
     }.to change(User, :count).by(-1)
     expect{
         unclaimed_user.reload

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -20,8 +20,10 @@ feature 'User signs up as a local user', js: true do
     click_link 'Continue'
     expect(page).to have_content('A verification email has been sent')
 
-    visit link_in_last_email
-    expect(page).to have_content('Thanks for adding your email address.')
+    user = User.find_by_username('testuser')
+    MarkContactInfoVerified.call(user.email_addresses.last)
+
+    click_on 'Continue'
     expect(page).to have_content('Complete your profile information')
     find(:css, '#register_i_agree').set(true)
     click_button 'Register'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -171,7 +171,7 @@ feature 'User signs up as a local user', js: true do
 
     click_on 'Resend Verification'
 
-    expect(page).to have_content('Already verified your email address?')
+    expect(page).to have_content("Return to this page after you've verified")
     expect(page).to have_content('A verification message has been sent to "testuser@example.com"')
   end
 


### PR DESCRIPTION
  - Email verification link doesn't redirect users anymore
    
    This is a problem for concept coach which uses an iframe to login.  We
    are not able to redirect the user back to the concept coach so we
    decided to remove this functionality.

  - Change primary action (button) to "Continue" on verification sent page
    
    ... and change "Resend verification" to secondary action (link).

  - Redirect to next page if resend is clicked but email is already verified
    
    Also display a notice "Your email address is already verified"

  - Display proper alert message when email verification fails