### PR TITLE
Revert back to fixed width container

### DIFF
--- a/app/assets/stylesheets/application_layout.css.scss
+++ b/app/assets/stylesheets/application_layout.css.scss
@@ -15,7 +15,7 @@ body, p, ol, ul, td, a {
 }
 
 #application-container {
-  min-width: $application_master_width;
+  width: $application_master_width;
 
   margin: 0px auto;
 

--- a/app/assets/stylesheets/common_dimensions.css.scss
+++ b/app/assets/stylesheets/common_dimensions.css.scss
@@ -1,7 +1,7 @@
 // Copyright 2011-2013 Rice University. Licensed under the Affero General Public
 // License version 3 or later.  See the COPYRIGHT file for details.
 
-$application_master_width: 775px;
+$application_master_width: 960px;
 
 $application_edge_distance: 54px;
 


### PR DESCRIPTION
We'd relaxed the fixed width earlier in order to support smaller width devices, but that also allowed the pages to be too wide on high resolutions.  

We could also put a max-width in to alleviate that, but that'd also have the possibility of mucking something else up.   It's probably best just to go back the way things were for right now.

Iframe access is fine since it overrides the fixed width.