### PR TITLE
Only close the window if displaying after a social login

### DIFF
--- a/app/assets/javascripts/application/iframe-access-helpers.coffee
+++ b/app/assets/javascripts/application/iframe-access-helpers.coffee
@@ -54,10 +54,8 @@ openSocial = (ev) ->
   ev.preventDefault()
 
 $(document).ready ->
-  if window.opener
-    # if we're inside a popup window, it's because a social login
-    # has completed and we're attempting to get more info from the user
-    # in order to complete the profile
+  if window.opener and window.location.pathname.match(/^\/auth\//)
+    # we're inside a popup window that's being displayed when a social login has completed
     window.opener.parent?.OxAccount?.Host.completeRegistration(window.location.pathname)
     window.close()
     return


### PR DESCRIPTION
Apparently Tutor also uses the window.open method.  It shouldn't (and I'm fixing that also), but accounts should be careful about closing itself.