### PR TITLE
Add task to create the an admin user.

### DIFF
--- a/lib/tasks/create_admin.rake
+++ b/lib/tasks/create_admin.rake
@@ -1,0 +1,31 @@
+namespace :accounts do
+  desc 'Create an administrative user and/or set the password for said user'
+  # Task specifically to create an administrative user and/or set the
+  # password for said user. This task accepts to arguments, the username
+  # and optionally a password. If the password is not supplied, the
+  # username will be used for the password.
+  task :create_admin, [:username, :password] => :environment do |t, args|
+    ActiveRecord::Base.transaction do
+      begin
+        username = args[:username]
+        password = args[:password] || args[:username]
+        user = User.find_or_create_by_username(username)
+        identity = Identity.find_or_create_by_user_id(user.id) do |identity|
+          identity.password = password
+          identity.password_confirmation = password
+          identity.save!
+        end
+        user.is_administrator = true
+        user.save!
+        auth = Authentication.find_or_create_by_uid(user.identity.id.to_s) do |auth|
+          auth.provider = 'identity'
+          auth.user_id = user.id
+          auth.save!
+        end
+      rescue Exception => e
+        puts e
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/create_admin_spec.rb
+++ b/spec/lib/tasks/create_admin_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'accounts:create_admin rake task' do
+  before :all do
+    Accounts::Application.load_tasks
+  end
+
+  before :each do
+    Rake::Task['accounts:create_admin'].reenable
+    # create the first user so User#make_first_user_an_admin doesn't interfere
+    # with the tests
+    FactoryGirl.create :user
+  end
+
+  it 'creates an admin user' do
+    expect {
+      Rake::Task['accounts:create_admin'].invoke('admin', 'password')
+    }.to change { User.count }.by(1)
+    user = User.order(:id).last
+    expect(user.username).to eq('admin')
+    expect(user.is_administrator).to be true
+    expect(user.identity.authenticate('password')).to eq(user.identity)
+    expect(user.authentications.first.provider).to eq('identity')
+  end
+
+  it 'makes an existing user an admin user' do
+    user = FactoryGirl.create :user
+    expect {
+      Rake::Task['accounts:create_admin'].invoke(user.username, 'passw0rd')
+    }.to_not change { User.count }
+    user.reload
+    expect(user.is_administrator).to be true
+    expect(user.identity.authenticate('passw0rd')).to eq(user.identity)
+    expect(user.authentications.first.provider).to eq('identity')
+  end
+end


### PR DESCRIPTION
`rake accounts:create_admin[admin,password]`

Taken from #180, slightly modified and added tests.