### PR TITLE
'Verification sent' page updates

### DIFF
--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -1,15 +1,26 @@
-<%= page_heading 'Verification sent' %>
+<%= page_heading 'Check your inbox to verify your email address.' %>
 
-<p>A verification email has been sent to <%= current_user.email_addresses.first.try(:value) %>.  If you don't see the message in your inbox, check your junk or spam folder.</p>
+<style type='text/css'>
+  ol li { margin: 10px 0; }
+  input[type='submit'] { margin: 10px 0 30px 40px; }
+</style>
 
-<p><%= link_to 'Resend Verification',
-               resend_confirmation_contact_info_path(current_user.email_addresses.first),
-               method: :put %></p>
+<% flash[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
+    if request.referrer == request.original_url %>
 
-<br />
-<br />
-<br />
-<p>Return to this page after you've verified your email address to continue your registration.</p>
-<p><%= button_to 'Continue',
+<ol>
+  <li>Find the email we sent to <%= current_user.email_addresses.first.try(:value) %>.</li>
+  <li>Click the link in it.</li>
+  <li>Return here and click the button below.</li>
+</ol>
+
+<p><%= button_to 'I clicked the link in the verification email',
                  stored_url,
                  class: 'standard' %></p>
+
+<p style="margin: 80px 0 0 0">
+  Can't find the email?  Try checking your junk of spam folder, or
+  <%= link_to 'click here to <b>resend</b> the verification email'.html_safe,
+               resend_confirmation_contact_info_path(current_user.email_addresses.first),
+               method: :put %>.
+</p>

--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -10,7 +10,7 @@
 
 <ol>
   <li>Find the email we sent to <%= current_user.email_addresses.first.try(:value) %>.</li>
-  <li>Click the link in it.</li>
+  <li>Click the link in that email.</li>
   <li>Return here and click the button below.</li>
 </ol>
 

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -43,7 +43,7 @@ feature 'Confirm email address', js: true do
     fill_in 'Email Address', with: 'user2@example.com'
     click_on 'Submit'
 
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     visit link_in_last_email
     expect(page).to have_content(

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -18,10 +18,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     MarkContactInfoVerified.call(EmailAddress.order(:id).last)
-    click_on 'Continue'
+    click_on 'I clicked the link in the verification email'
 
     # No skipping
     expect(page).to have_content('I have read')
@@ -57,10 +57,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     MarkContactInfoVerified.call(EmailAddress.order(:id).last)
-    click_on 'Continue'
+    click_on 'I clicked the link in the verification email'
 
     # Skipped!
     expect(page).to_not have_content('I have read')
@@ -95,10 +95,10 @@ feature 'Skipped terms are respected', js: true do
     click_on 'Register'
 
     click_on 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     MarkContactInfoVerified.call(EmailAddress.order(:id).last)
-    click_on 'Continue'
+    click_on 'I clicked the link in the verification email'
 
     # Gotta sign
     expect(page).to have_content('I have read')

--- a/spec/features/user_claims_account_spec.rb
+++ b/spec/features/user_claims_account_spec.rb
@@ -19,10 +19,10 @@ feature 'User claims an unclaimed account', js: true do
     expect(new_user).to_not be_nil
 
     click_link 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     MarkContactInfoVerified.call(new_user.email_addresses.first)
-    click_on 'Continue'
+    click_on 'I clicked the link in the verification email'
 
     fill_in 'First Name', with: 'Test'
     fill_in 'Last Name', with: 'User'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -18,12 +18,12 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content('Welcome, testuser')
 
     click_link 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     user = User.find_by_username('testuser')
     MarkContactInfoVerified.call(user.email_addresses.last)
 
-    click_on 'Continue'
+    click_on 'I clicked the link in the verification email'
     expect(page).to have_content('Complete your profile information')
     find(:css, '#register_i_agree').set(true)
     click_button 'Register'
@@ -140,7 +140,7 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content('Welcome, testuser')
 
     click_link 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     click_link 'Sign out'
     fill_in 'Username / Email', with: 'testuser'
@@ -149,7 +149,7 @@ feature 'User signs up as a local user', js: true do
 
     expect(page).to have_content('Welcome, testuser')
     click_link 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
   end
 
   scenario 'resend confirmation email' do
@@ -167,12 +167,12 @@ feature 'User signs up as a local user', js: true do
     expect(page).to have_content('Welcome, testuser')
 
     click_link 'Continue'
-    expect(page).to have_content('A verification email has been sent')
+    expect(page).to have_content('Check your inbox to verify your email address')
 
     expect {
-      click_on 'Resend Verification'
+      click_on 'click here to resend'
 
-      expect(page).to have_content("Return to this page after you've verified")
+      expect(page).to have_content("Return here and click the button below")
       expect(page).to have_content('A verification message has been sent to "testuser@example.com"')
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
@@ -181,7 +181,7 @@ feature 'User signs up as a local user', js: true do
     MarkContactInfoVerified.call(user.email_addresses.last)
 
     expect {
-      click_on 'Resend Verification'
+      click_on 'click here to resend'
       expect(page).to have_content('Your email address is already verified')
       expect(page).to have_content('Complete your profile information')
     }.to_not change { ActionMailer::Base.deliveries.count }


### PR DESCRIPTION
Based on feedback from marcom, updated the "Verification Sent" page to hopefully improve clarity and avoid inappropriate "Continue" clicking.

Old screen looked like:

![screenshot 2015-12-14 22 27 52](https://cloud.githubusercontent.com/assets/1001691/11804124/24b320ae-a2b6-11e5-9780-983514a29f94.png)

New screen looks like:

![screenshot 2015-12-14 22 44 40](https://cloud.githubusercontent.com/assets/1001691/11804140/560f6338-a2b6-11e5-9f5d-6022796e7002.png)

Also added an error alert if the user clicks the "move on" button before verifying their email address:

![screenshot 2015-12-14 22 55 55](https://cloud.githubusercontent.com/assets/1001691/11804145/60f2b804-a2b6-11e5-9095-27a16c48411f.png)

cc @jason-holmes