### PR TITLE
Add rake task to manage and list oauth apps

### DIFF
--- a/lib/tasks/oauth_apps.rake
+++ b/lib/tasks/oauth_apps.rake
@@ -1,0 +1,54 @@
+namespace :accounts do
+  namespace :oauth_apps do
+
+    create_or_update_description = 'Create or update an oauth application in accounts, arguments USERNAME (application owner username), APP_NAME, REDIRECT_URI (separated by commas for multiple uris), EMAIL_FROM_ADDRESS, EMAIL_SUBJECT_PREFIX, TRUSTED (default true)'
+
+    desc create_or_update_description
+    task :create => [:environment] do
+      user = User.find_by_username(ENV['USERNAME'])
+      name = ENV['APP_NAME']
+      # one redirect uri per line
+      redirect_uri = ENV['REDIRECT_URI'].try(:split, ',').try(:join, "\r\n")
+      trusted = ENV['TRUSTED'].nil? || ENV['TRUSTED'].downcase == 'true'
+      from_address = ENV['EMAIL_FROM_ADDRESS']
+      subject_prefix = ENV['EMAIL_SUBJECT_PREFIX']
+
+      ActiveRecord::Base.transaction do
+        application = Doorkeeper::Application.find_or_create_by_name(name)
+        application.redirect_uri = redirect_uri if redirect_uri.present?
+        raise ArgumentError.new("User not found: #{ENV['USERNAME']}") \
+          if application.owner.nil? && user.nil?
+        unless user.nil? || application.owner.try(:has_owner?, user)
+          group = Group.create
+          group.add_owner(user)
+          application.owner = group
+        end
+        application.trusted = trusted
+        application.email_from_address = from_address if from_address.present?
+        application.email_subject_prefix = subject_prefix if subject_prefix.present?
+        action = application.new_record? ? 'Created' : 'Updated'
+        application.save!
+        puts "#{action} oauth application \"#{application.name}\""
+      end
+    end
+
+    # the update task is an alias of the create task
+    desc create_or_update_description
+    task update: :create
+
+    desc 'List tokens and secrets for all the oauth applications in accounts, optional argument APP_NAME'
+    task :list => [:environment] do
+      app_name = "#{ENV['APP_NAME']}".downcase
+      if app_name.present?
+        apps = Doorkeeper::Application.where { lower(name) == app_name }
+      else
+        apps = Doorkeeper::Application
+      end
+      apps = apps.order(:name)
+      apps.each do |application|
+        puts "#{application.name}: #{application.uid} #{application.secret}"
+      end
+      puts 'No applications found.' if apps.empty?
+    end
+  end
+end

--- a/spec/lib/tasks/create_admin_spec.rb
+++ b/spec/lib/tasks/create_admin_spec.rb
@@ -3,7 +3,7 @@ require 'rake'
 
 describe 'accounts:create_admin rake task' do
   before :all do
-    Accounts::Application.load_tasks
+    Rake::Task['accounts:create_admin'] rescue Accounts::Application.load_tasks
   end
 
   before :each do

--- a/spec/lib/tasks/oauth_apps_spec.rb
+++ b/spec/lib/tasks/oauth_apps_spec.rb
@@ -1,0 +1,260 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'accounts:oauth_apps rake tasks' do
+  before :all do
+    Rake::Task['accounts:oauth_apps:create'] rescue Accounts::Application.load_tasks
+  end
+
+  describe 'accounts:oauth_apps:create' do
+    let(:admin) { FactoryGirl.create :user, :admin }
+    let(:app) { FactoryGirl.create :doorkeeper_application }
+
+    before :each do
+      Rake::Task['accounts:oauth_apps:create'].reenable
+      Rake::Task['accounts:oauth_apps:update'].reenable
+    end
+
+    it 'creates an oauth application' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'new app',
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'USERNAME' => admin.username,
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]',
+        'TRUSTED' => 'true'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      end
+      expect(stdout).to eq("Created oauth application \"new app\"\n")
+      expect(stderr).to be_empty
+
+      new_app = Doorkeeper::Application.order(:id).last
+      expect(new_app.name).to eq('new app')
+      expect(new_app.redirect_uri).to eq(
+        "http://localhost:4000/\r\nhttp://localhost:8000")
+      expect(new_app.owner.has_owner? admin).to be true
+      expect(new_app.email_from_address).to eq('new-app@example.org')
+      expect(new_app.email_subject_prefix).to eq('[new-app]')
+      expect(new_app.trusted).to be true
+    end
+
+    it 'creates an untrusted oauth application' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'new app',
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'USERNAME' => admin.username,
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]',
+        'TRUSTED' => 'false'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      end
+      expect(stdout).to eq("Created oauth application \"new app\"\n")
+      expect(stderr).to be_empty
+
+      new_app = Doorkeeper::Application.order(:id).last
+      expect(new_app.name).to eq('new app')
+      expect(new_app.redirect_uri).to eq(
+        "http://localhost:4000/\r\nhttp://localhost:8000")
+      expect(new_app.owner.has_owner? admin).to be true
+      expect(new_app.email_from_address).to eq('new-app@example.org')
+      expect(new_app.email_subject_prefix).to eq('[new-app]')
+      expect(new_app.trusted).to be false
+    end
+
+    it 'raises an error if APP_NAME is missing' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'USERNAME' => admin.username,
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      expect {
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'raises an error if REDIRECT_URI is missing' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'new app',
+        'USERNAME' => admin.username,
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      expect {
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'raises an error if USERNAME is missing' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'new app',
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      expect {
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      }.to raise_error(ArgumentError, 'User not found: ')
+    end
+
+    it 'raises an error if USERNAME is not found' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'USERNAME' => 'random',
+        'APP_NAME' => 'new app',
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      expect {
+        Rake::Task['accounts:oauth_apps:create'].invoke
+      }.to raise_error(ArgumentError, 'User not found: random')
+    end
+
+    it 'updates an oauth application' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'USERNAME' => admin.username,
+        'APP_NAME' => app.name,
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:update'].invoke
+      end
+      expect(stdout).to eq("Updated oauth application \"#{app.name}\"\n")
+      updated_app = Doorkeeper::Application.find_by_name(app.name)
+      expect(updated_app.id).to eq(app.id)
+      expect(updated_app.uid).to eq(app.uid)
+      expect(updated_app.secret).to eq(app.secret)
+      expect(updated_app.owner).to_not eq(app.owner)
+      expect(updated_app.owner.has_owner? admin).to be true
+      expect(updated_app.redirect_uri).to eq(
+        "http://localhost:4000/\r\nhttp://localhost:8000")
+      expect(updated_app.email_from_address).to eq('new-app@example.org')
+      expect(updated_app.email_subject_prefix).to eq('[new-app]')
+    end
+
+    it 'updates just the owner' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'USERNAME' => admin.username,
+        'APP_NAME' => app.name,
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:update'].invoke
+      end
+      expect(stdout).to eq("Updated oauth application \"#{app.name}\"\n")
+      updated_app = Doorkeeper::Application.find_by_name(app.name)
+      expect(updated_app.id).to eq(app.id)
+      expect(updated_app.uid).to eq(app.uid)
+      expect(updated_app.secret).to eq(app.secret)
+      expect(updated_app.owner).to_not eq(app.owner)
+      expect(updated_app.owner.has_owner? admin).to be true
+      expect(updated_app.redirect_uri).to eq(app.redirect_uri)
+      expect(updated_app.email_from_address).to eq(app.email_from_address)
+      expect(updated_app.email_subject_prefix).to eq(app.email_subject_prefix)
+    end
+
+    it 'updates just the redirect uri' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => app.name,
+        'REDIRECT_URI' => 'http://localhost:4000/,http://localhost:8000',
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:update'].invoke
+      end
+      expect(stdout).to eq("Updated oauth application \"#{app.name}\"\n")
+      updated_app = Doorkeeper::Application.find_by_name(app.name)
+      expect(updated_app.id).to eq(app.id)
+      expect(updated_app.uid).to eq(app.uid)
+      expect(updated_app.secret).to eq(app.secret)
+      expect(updated_app.owner).to eq(app.owner)
+      expect(updated_app.redirect_uri).to eq(
+        "http://localhost:4000/\r\nhttp://localhost:8000")
+      expect(updated_app.email_from_address).to eq(app.email_from_address)
+      expect(updated_app.email_subject_prefix).to eq(app.email_subject_prefix)
+    end
+
+    it 'updates just the email from address' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => app.name,
+        'EMAIL_FROM_ADDRESS' => 'new-app@example.org',
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:update'].invoke
+      end
+      expect(stdout).to eq("Updated oauth application \"#{app.name}\"\n")
+      updated_app = Doorkeeper::Application.find_by_name(app.name)
+      expect(updated_app.id).to eq(app.id)
+      expect(updated_app.uid).to eq(app.uid)
+      expect(updated_app.secret).to eq(app.secret)
+      expect(updated_app.owner).to eq(app.owner)
+      expect(updated_app.redirect_uri).to eq(app.redirect_uri)
+      expect(updated_app.email_from_address).to eq('new-app@example.org')
+      expect(updated_app.email_subject_prefix).to eq(app.email_subject_prefix)
+    end
+
+    it 'updates just the email subject prefix' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => app.name,
+        'EMAIL_SUBJECT_PREFIX' => '[new-app]'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:update'].invoke
+      end
+      expect(stdout).to eq("Updated oauth application \"#{app.name}\"\n")
+      updated_app = Doorkeeper::Application.find_by_name(app.name)
+      expect(updated_app.id).to eq(app.id)
+      expect(updated_app.uid).to eq(app.uid)
+      expect(updated_app.secret).to eq(app.secret)
+      expect(updated_app.owner).to eq(app.owner)
+      expect(updated_app.redirect_uri).to eq(app.redirect_uri)
+      expect(updated_app.email_from_address).to eq(app.email_from_address)
+      expect(updated_app.email_subject_prefix).to eq('[new-app]')
+    end
+  end
+
+  describe 'accounts:oauth_apps:list' do
+    let!(:tutor) { FactoryGirl.create :doorkeeper_application, name: 'OpenStax Tutor' }
+    let!(:biglearn) { FactoryGirl.create :doorkeeper_application, name: 'OpenStax Biglearn' }
+
+    before :each do
+      Rake::Task['accounts:oauth_apps:list'].reenable
+    end
+
+    it 'lists all application names, tokens and secrets' do
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:list'].invoke
+      end
+      expect(stdout).to eq(
+        "OpenStax Biglearn: #{biglearn.uid} #{biglearn.secret}\n" <<
+        "OpenStax Tutor: #{tutor.uid} #{tutor.secret}\n"
+      )
+    end
+
+    it 'displays one application if APP_NAME is given' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'OpenStax biglearn'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:list'].invoke
+      end
+      expect(stdout).to eq(
+        "OpenStax Biglearn: #{biglearn.uid} #{biglearn.secret}\n"
+      )
+    end
+
+    it 'displays a warning message if app is not found' do
+      stub_const('ENV', ENV.to_hash.merge(
+        'APP_NAME' => 'not found'
+      ))
+      stdout, stderr = capture_output do
+        Rake::Task['accounts:oauth_apps:list'].invoke
+      end
+      expect(stdout).to eq("No applications found.\n")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,3 +68,20 @@ class ActiveRecord::Base
 end
 
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
+# For rspec < 3.0 which doesn't have the output matcher
+# See http://stackoverflow.com/questions/16507067/testing-stdout-output-in-rspec
+
+require 'stringio'
+
+def capture_output(&blk)
+  old_stdout = $stdout
+  old_stderr = $stderr
+  $stdout = fake_stdout = StringIO.new
+  $stderr = fake_stderr = StringIO.new
+  blk.call
+  [fake_stdout.string, fake_stderr.string]
+ensure
+  $stdout = old_stdout
+  $stderr = old_stderr
+end


### PR DESCRIPTION
Example usage:

Creating an application:

```
$ rake accounts:oauth_apps:create USERNAME=admin APP_NAME='Local' REDIRECT_URI='http://localhost:4000/callback,http://localhost:8000/' EMAIL_FROM_ADDRESS='local@example.org' EMAIL_SUBJECT_PREFIX='[local]' TRUSTED=true
Created oauth application "Local"
```

Updating an application:

```
$ rake accounts:oauth_apps:create APP_NAME='Local' EMAIL_FROM_ADDRESS='test@openstax.org'
Updated oauth application "Local"
```

Listing all applications:

```
$ rake accounts:oauth_apps:list
Application Name: 2500cf2c3bdabd4ba451bbf71bd8f52e9a9e9492b561ae01ba0c55431290b8d4 ed7037415caffa1fd489e2bfbd22df1704bac425d63f2140435165183ec197c8
Local: 026ec5d3c4302050045d9e9c735396d3924637bbbd1ba59ca9a4ee9715058d69 b085a0b7d8d3ef650001095680cd995e442433eacf1a12f67fff439381c1ba08
OpenStax CNX: 20a7840627af9a95 7c165fe056d7a2bb680002c78485900ddcbc203b3dacaa3589d3529f0ead7694
```

Displaying one application:

```
$ rake accounts:oauth_apps:list APP_NAME=local
Local: 026ec5d3c4302050045d9e9c735396d3924637bbbd1ba59ca9a4ee9715058d69 b085a0b7d8d3ef650001095680cd995e442433eacf1a12f67fff439381c1ba08
```

/cc @pumazi