### PR TITLE
Make verification alert only last for that page

### DIFF
--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -5,7 +5,7 @@
   input[type='submit'] { margin: 10px 0 30px 40px; }
 </style>
 
-<% flash[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
+<% flash.now[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
     if request.referrer == request.original_url %>
 
 <ol>


### PR DESCRIPTION
Without the `now` addition, the flash was persisting into the "Thank you for verifying your email address" page.