### PR TITLE
Don't break if get an anon user on verification sent

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,8 @@
 class StaticPagesController < ApplicationController
-  skip_before_filter :authenticate_user!, :registration,
+  skip_before_filter :authenticate_user!,
+                     only: [:api, :copyright, :home, :status]
+
+  skip_before_filter :registration,
                      only: [:api, :copyright, :home, :status, :verification_sent]
 
   fine_print_skip :general_terms_of_use, :privacy_policy,


### PR DESCRIPTION
In production someone must have signed out on one tab and then reloaded the verification sent page.  It then exploded.  This PR makes verification sent require a logged in user.