### PR TITLE
Allow CNX users to sign up

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,6 @@ class SessionsController < ApplicationController
     # Hack to figure out if the user came from CNX to hide the login
     # In the future, use the client_id and some boolean flag in the client app
     referer = request.referer
-    session[:from_cnx] = (referer =~ /cnx\.org/) unless referer.blank?
 
     session[:client_id] = params[:client_id]
     @application = Doorkeeper::Application.where(uid: params[:client_id]).first

--- a/app/views/layouts/_application_top_nav.html.erb
+++ b/app/views/layouts/_application_top_nav.html.erb
@@ -12,10 +12,7 @@
       <% if signed_in? %>
         Welcome, <%= link_to current_user.username, main_app.profile_path %>&nbsp;&nbsp;&nbsp;<%= link_to 'Sign out', main_app.logout_path %>
       <% else %>
-        <% unless session[:from_cnx] %>
-          <%= link_to 'Sign up', main_app.signup_path %> or
-        <% end %>
-          <%= link_to "Sign in", main_app.login_path %>
+        <%= link_to 'Sign up', main_app.signup_path %> or <%= link_to "Sign in", main_app.login_path %>
       <% end %>
     </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,7 @@
 <%= page_heading("Sign in to your one OpenStax account!".html_safe) %>
 <div class="new-login">
 
-  <%= render 'sessions/login', hide_signup: session[:from_cnx] %>
+  <%= render 'sessions/login' %>
 
   <div id="login-explanation">
     <p>Use the buttons at the right to sign in using your Facebook, Twitter, or Google account.</p>

--- a/spec/features/hide_sign_up_from_cnx_users_spec.rb
+++ b/spec/features/hide_sign_up_from_cnx_users_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
-feature 'Hide sign up from CNX users', js: true do
-  scenario 'not from cnx' do
+feature 'Displays form elements', js: true do
+
+  scenario 'an anonymous user' do
     visit '/'
     expect(page).to have_content(/sign up/i)
 
@@ -12,15 +13,4 @@ feature 'Hide sign up from CNX users', js: true do
     expect(page).to have_content(/sign up/i)
   end
 
-  scenario 'from cnx' do
-    visit '/'
-    expect(page).to have_content(/sign up/i)
-
-    page.driver.add_header('Referer', 'http://cnx.org', permanent: false)
-    visit '/login'
-    expect(page).not_to have_content(/sign up/i)
-
-    visit '/'
-    expect(page).not_to have_content(/sign up/i)
-  end
 end


### PR DESCRIPTION
I left in the `:hide_signup` option on `sessions/_login` since it might be used elsewhere.