### PR TITLE
Login flow refinements and general refactoring

### DIFF
--- a/app/access_policies/user_access_policy.rb
+++ b/app/access_policies/user_access_policy.rb
@@ -9,7 +9,7 @@ class UserAccessPolicy
     when :search
       requestor.is_application? || requestor.is_activated?
     when :read, :update
-      requestor.is_human? && requestor.is_activated? && \
+      requestor.is_human? && \
       (requestor == user || requestor.is_administrator?) # Self or admin
     when :register
       requestor.is_human? && !requestor.is_activated? && \

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -50,4 +50,15 @@ form .nowrap label { white-space: nowrap; }
 input.finish-sign-up {
   float: right;
   clear: both;
+  margin-top: 6px;
+}
+
+.your-account {
+  tr.contact-info:first-child td {
+    border-top: none;
+  }
+
+  .add-email-address {
+    margin-top: 30px;
+  }
 }

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -46,3 +46,8 @@ table.std-list-1 {
 // adds top margin to the submit so that
 .horizontal-submit input { margin-top: 25px; }
 form .nowrap label { white-space: nowrap; }
+
+input.finish-sign-up {
+  float: right;
+  clear: both;
+}

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -1,10 +1,15 @@
 class ContactInfosController < ApplicationController
 
-  skip_before_filter :authenticate_user!, :registration, only: [:confirm, :confirm_unclaimed,
-                                                                :resend_confirmation]
+  skip_before_filter :authenticate_user!,
+                     only: [:confirm, :confirm_unclaimed, :resend_confirmation]
 
-  fine_print_skip :general_terms_of_use, :privacy_policy, only: [:confirm, :confirm_unclaimed,
-                                                                 :resend_confirmation]
+  skip_before_filter :registration,
+                     only: [:create, :destroy, :toggle_is_searchable, :confirm,
+                            :confirm_unclaimed, :resend_confirmation]
+
+  fine_print_skip :general_terms_of_use, :privacy_policy,
+                  only: [:create, :destroy, :toggle_is_searchable, :confirm,
+                         :confirm_unclaimed, :resend_confirmation]
 
   before_filter :get_contact_info, only: [:destroy, :toggle_is_searchable]
 

--- a/app/controllers/contact_infos_controller.rb
+++ b/app/controllers/contact_infos_controller.rb
@@ -43,24 +43,16 @@ class ContactInfosController < ApplicationController
   def resend_confirmation
     handle_with(ContactInfosResendConfirmation,
                 complete: lambda {
-                  path = :back
                   contact_info = @handler_result.outputs[:contact_info]
 
-                  if contact_info.verified
-                    msg = 'Your email address is already verified'
-                    user = contact_info.user
-                    path = user.registration_redirect_url \
-                      if user.is_temp? && user.registration_redirect_url
-                  else
-                    msg = "A verification message has been sent to \"#{
-                           contact_info.value}\""
-                  end
+                  msg = contact_info.verified ?
+                        'Your email address is already verified' :
+                        "A verification message has been sent to \"#{contact_info.value}\""
 
-                  redirect_to path,
+                  redirect_to :back,
                               notice: msg
                 })
   end
-
 
   def confirm_unclaimed
     handle_with(ConfirmUnclaimedAccount,

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -4,7 +4,7 @@ class RegistrationController < ApplicationController
   fine_print_skip :general_terms_of_use, :privacy_policy
 
   def complete
-    if !current_user.is_temp?
+    if current_user.is_activated?
       redirect_back
     elsif current_user.has_emails_but_none_verified?
       redirect_to registration_verification_pending_path

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -1,0 +1,40 @@
+class RegistrationController < ApplicationController
+
+  skip_before_filter :registration
+  fine_print_skip :general_terms_of_use, :privacy_policy
+
+  def complete
+    if !current_user.is_temp?
+      redirect_back
+    elsif current_user.has_emails_but_none_verified?
+      redirect_to registration_verification_pending_path
+    elsif request.put?
+      handle_with(UsersRegister,
+                  contracts_required: !contracts_not_required,
+                  success: lambda {
+                    redirect_back
+                  },
+                  failure: lambda {
+                    errors = @handler_result.errors.any?
+                    render :complete, status: errors ? 400 : 200
+                  })
+    end
+  end
+
+  def verification_pending
+    if !current_user.has_emails_but_none_verified?
+      flash.keep # "already verified" message
+      redirect_to registration_complete_path
+    end
+  end
+
+  def i_verified
+    if current_user.has_emails_but_none_verified?
+      redirect_to registration_verification_pending_path,
+                  alert: "We haven't seen that you clicked the verification link.  Please try again."
+    else
+      redirect_to registration_complete_path
+    end
+  end
+
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -55,7 +55,6 @@ class SessionsController < ApplicationController
       url = iframe_after_logout_url(parent: params[:parent])
     end
     session[ActionInterceptor.config.default_key] = nil
-    session[:registration_return_to] = nil
     session[:client_id] = nil
 
     sign_out!

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,10 +3,10 @@ class StaticPagesController < ApplicationController
                      only: [:api, :copyright, :home, :status]
 
   skip_before_filter :registration,
-                     only: [:api, :copyright, :home, :status, :verification_sent]
+                     only: [:api, :copyright, :home, :status]
 
   fine_print_skip :general_terms_of_use, :privacy_policy,
-                  only: [:api, :copyright, :home, :status, :verification_sent]
+                  only: [:api, :copyright, :home, :status]
 
   skip_protect_beta :only => [:status]
 
@@ -27,9 +27,6 @@ class StaticPagesController < ApplicationController
       store_url # needed for happy login flow, authenticate_user! does it too
       redirect_to login_path
     end
-  end
-
-  def verification_sent
   end
 
   # Used by AWS (and others) to make sure the site is still up.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,10 @@
 class UsersController < ApplicationController
 
-  skip_before_filter :registration, only: [:register, :ask_for_email]
+  skip_before_filter :registration,
+                     only: [:register, :ask_for_email, :edit, :update, :i_clicked_verification_link]
 
-  fine_print_skip :general_terms_of_use, :privacy_policy, only: [:register, :ask_for_email]
+  fine_print_skip :general_terms_of_use, :privacy_policy,
+                  only: [:register, :ask_for_email, :edit, :update, :i_clicked_verification_link]
 
   def edit
     OSU::AccessPolicy.require_action_allowed!(:update, current_user, current_user)
@@ -22,18 +24,29 @@ class UsersController < ApplicationController
   end
 
   def register
-    if request.put?
+    if !current_user.is_temp?
+      redirect_back
+    elsif has_emails_but_none_verified?
+      redirect_to verification_sent_path
+    elsif request.put?
       handle_with(UsersRegister,
                   contracts_required: !contracts_not_required,
                   success: lambda {
-                    redirect_back key: :registration_return_to
+                    redirect_back
                   },
                   failure: lambda {
                     errors = @handler_result.errors.any?
                     render :register, status: errors ? 400 : 200
                   })
+    end
+  end
+
+  def i_clicked_verification_link
+    if has_emails_but_none_verified?
+      redirect_to verification_sent_path,
+                  alert: "We haven't seen that you clicked the verification link.  Please try again."
     else
-      store_fallback key: :registration_return_to
+      redirect_to :register
     end
   end
 
@@ -59,6 +72,10 @@ class UsersController < ApplicationController
     up = up.slice(:title, :first_name, :last_name, :suffix)
     up[:full_name] = "#{up[:first_name]} #{up[:last_name]} #{up[:suffix]}"
     up
+  end
+
+  def has_emails_but_none_verified?
+    current_user.email_addresses.any? && current_user.email_addresses.none?(&:verified)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,10 @@
 class UsersController < ApplicationController
 
   skip_before_filter :registration,
-                     only: [:register, :ask_for_email, :edit, :update, :i_clicked_verification_link]
+                     only: [:ask_for_email, :edit, :update]
 
   fine_print_skip :general_terms_of_use, :privacy_policy,
-                  only: [:register, :ask_for_email, :edit, :update, :i_clicked_verification_link]
+                  only: [:ask_for_email, :edit, :update]
 
   def edit
     OSU::AccessPolicy.require_action_allowed!(:update, current_user, current_user)
@@ -23,40 +23,13 @@ class UsersController < ApplicationController
     end
   end
 
-  def register
-    if !current_user.is_temp?
-      redirect_back
-    elsif has_emails_but_none_verified?
-      redirect_to verification_sent_path
-    elsif request.put?
-      handle_with(UsersRegister,
-                  contracts_required: !contracts_not_required,
-                  success: lambda {
-                    redirect_back
-                  },
-                  failure: lambda {
-                    errors = @handler_result.errors.any?
-                    render :register, status: errors ? 400 : 200
-                  })
-    end
-  end
-
-  def i_clicked_verification_link
-    if has_emails_but_none_verified?
-      redirect_to verification_sent_path,
-                  alert: "We haven't seen that you clicked the verification link.  Please try again."
-    else
-      redirect_to :register
-    end
-  end
-
   def ask_for_email
     if request.put?
       handle_with(ContactInfosCreate,
                   success: lambda {
                     current_user.registration_redirect_url = stored_url
                     current_user.save
-                    redirect_to :verification_sent
+                    redirect_to registration_verification_pending_path
                   },
                   failure: lambda {
                     render :ask_for_email, status: 400
@@ -72,10 +45,6 @@ class UsersController < ApplicationController
     up = up.slice(:title, :first_name, :last_name, :suffix)
     up[:full_name] = "#{up[:first_name]} #{up[:last_name]} #{up[:suffix]}"
     up
-  end
-
-  def has_emails_but_none_verified?
-    current_user.email_addresses.any? && current_user.email_addresses.none?(&:verified)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,8 @@ class UsersController < ApplicationController
   end
 
   def ask_for_email
+    # FWIW, when this code is this resurrected, the registration_redirect_url
+    # may not be what we need.
     if request.put?
       handle_with(ContactInfosCreate,
                   success: lambda {

--- a/app/handlers/identities_register.rb
+++ b/app/handlers/identities_register.rb
@@ -16,7 +16,7 @@ class IdentitiesRegister
                translations: { inputs: {scope: :register} }
 
   uses_routine CreateIdentity,
-               translations: { inputs:  {scope: :register}, 
+               translations: { inputs:  {scope: :register},
                                outputs: {type: :verbatim}  }
 
   uses_routine AddEmailToUser,
@@ -33,8 +33,6 @@ class IdentitiesRegister
 
     if user.is_anonymous?
       run(CreateUser,
-          # first_name: register_params.first_name,
-          # last_name:  register_params.last_name,
           username:   register_params.username
       )
       user = outputs[[:create_user, :user]]
@@ -46,7 +44,7 @@ class IdentitiesRegister
       user.save
     end
 
-    run(CreateIdentity, 
+    run(CreateIdentity,
         password:              register_params.password,
         password_confirmation: register_params.password_confirmation,
         user_id:               user.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,6 +119,10 @@ class User < ActiveRecord::Base
     AddUnreadUpdateForUser.call(self).errors.none?
   end
 
+  def has_emails_but_none_verified?
+    email_addresses.any? && email_addresses.none?(&:verified)
+  end
+
   ##########################
   # Access Control Helpers #
   ##########################

--- a/app/views/contact_infos/_form.html.erb
+++ b/app/views/contact_infos/_form.html.erb
@@ -4,21 +4,21 @@
 %>
 
 <%= lev_form_for :contact_info, url: contact_infos_path,
-                                html: {class: 'form-horizontal'} do |f| %>
+                                html: {class: 'form-horizontal add-email-address'} do |f| %>
   <%= f.hidden_field :type, value: type %>
   <div class="row">
-    <span class="col-sm-9">
-      <%= f.label :value, humanized_name %>
+    <span class="col-sm-11">
+      <%= f.label :value, "Add an email address" %>
     </span>
   </div>
 
   <div class="row">
-    <span class="col-sm-9">
+    <span class="col-sm-11">
       <%= f.text_field :value %>
     </span>
 
-    <span class="col-sm-3">
-      <%= f.submit "Add #{humanized_name}",
+    <span class="col-sm-1">
+      <%= f.submit "Add",
                    class: 'standard' %>
     </span>
   </div>

--- a/app/views/contact_infos/_show.html.erb
+++ b/app/views/contact_infos/_show.html.erb
@@ -3,20 +3,24 @@
    humanized_name = contact_info.type.underscore.humanize
 %>
 
-<tr>
+<tr class='contact-info'>
   <td><%= contact_info.value %></td>
-  <td><%= contact_info.is_searchable ? 'Searchable' : 'Not searchable' %></td>
-  <td><%= button_to 'Toggle',
+  <td><%= contact_info.is_searchable ? 'Searchable' : 'Not Searchable' %> (<%= link_to 'Change',
                     toggle_is_searchable_contact_info_path(contact_info),
-                    method: :put, class: "standard" %></td>
-  <td><%= contact_info.verified ? 'Verified' : 'Unverified' %></td>
-  <td><%= button_to "Resend Verification",
-                    resend_confirmation_contact_info_path(contact_info),
-                    method: :put,
-                    class: "standard" unless contact_info.verified %></td>
-  <td><%= button_to "Delete",
+                    method: :put %>)</td>
+
+  <td>
+    <% if contact_info.verified %>
+      Verified
+    <% else %>
+      <%= link_to "Click to verify",
+                  resend_confirmation_contact_info_path(contact_info),
+                  method: :put %>
+    <% end %>
+  </td>
+
+  <td><%= link_to "Delete",
                     contact_info_path(contact_info),
                     method: :delete,
-                    confirm: "Are you sure you want to delete \"#{contact_info.value}?\"",
-                    class: "standard" %></td>
+                    confirm: "Are you sure you want to delete \"#{contact_info.value}?\"" %></td>
 </tr>

--- a/app/views/contact_infos/confirm_unclaimed.html.erb
+++ b/app/views/contact_infos/confirm_unclaimed.html.erb
@@ -9,7 +9,7 @@
   <% if @handler_result.outputs.can_log_in %>
     You can now <%= link_to("sign in", login_url) %> to your new account.
   <% else %>
-    Please <%= link_to('sign up',register_url) %> for a account using email <%= @handler_result.outputs.email_address %> address in order to complete the process.
+    Please <%= link_to('sign up',registration_complete_url) %> for a account using email <%= @handler_result.outputs.email_address %> address in order to complete the process.
   <% end %>
 </p>
 <% end %>

--- a/app/views/identities/_form.html.erb
+++ b/app/views/identities/_form.html.erb
@@ -2,28 +2,36 @@
    # identity
 %>
 
-<%= form_for identity, url: identity_path,
-             html: {class: 'form-horizontal'} do |f| %>
-<div class="row">
+<% if identity.user.is_activated? %>
 
-  <div class="col-sm-3">
-    <%= f.label :current_password, "Current Password" %>
-    <%= f.password_field :current_password %>
+  <%= form_for identity, url: identity_path,
+               html: {class: 'form-horizontal'} do |f| %>
+  <div class="row">
+
+    <div class="col-sm-3">
+      <%= f.label :current_password, "Current Password" %>
+      <%= f.password_field :current_password %>
+    </div>
+
+    <div class="col-sm-3">
+      <%= f.label :password, "New Password" %>
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="col-sm-3 nowrap">
+      <%= f.label :password_confirmation, "New Password Confirmation" %>
+      <%= f.password_field :password_confirmation %>
+    </div>
+
+    <div class="horizontal-submit col-sm-3">
+      <%= f.submit "Change Password", class: 'standard' %>
+    </div>
+
   </div>
+  <% end %>
 
-  <div class="col-sm-3">
-    <%= f.label :password, "New Password" %>
-    <%= f.password_field :password %>
+<% else %>
+  <div class="well">
+    These options will be available after you have clicked the button in the upper right to finish sign up.
   </div>
-
-  <div class="col-sm-3 nowrap">
-    <%= f.label :password_confirmation, "New Password Confirmation" %>
-    <%= f.password_field :password_confirmation %>
-  </div>
-
-  <div class="horizontal-submit col-sm-3">
-    <%= f.submit "Change Password", class: 'standard' %>
-  </div>
-
-</div>
 <% end %>

--- a/app/views/layouts/_application_top_nav.html.erb
+++ b/app/views/layouts/_application_top_nav.html.erb
@@ -12,7 +12,10 @@
       <% if signed_in? %>
         Welcome, <%= link_to current_user.username, main_app.profile_path %>&nbsp;&nbsp;&nbsp;<%= link_to 'Sign out', main_app.logout_path %>
       <% else %>
-        <%= link_to 'Sign up', main_app.signup_path %> or <%= link_to "Sign in", main_app.login_path %>
+        <% unless current_page?(main_app.signup_path) %>
+          <%= link_to 'Sign up', main_app.signup_path %> or
+        <% end %>
+          <%= link_to "Sign in", main_app.login_path %>
       <% end %>
     </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_include_tag  "application" %>
     <%= csrf_meta_tags %>
 
-    <title><%= @page_title + ' - ' if !@page_title.nil? %><%= SITE_NAME %></title>  
+    <title><%= @page_title + ' - ' if !@page_title.nil? %><%= SITE_NAME %></title>
 
   </head>
 

--- a/app/views/layouts/application_body_nav.html.erb
+++ b/app/views/layouts/application_body_nav.html.erb
@@ -1,4 +1,4 @@
-<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <% content_for :application_body do %>
@@ -6,6 +6,7 @@
   <div id="application-body-nav">
 
     <div id="application-body-nav-body">
+      <%= yield :above_page_heading %>
       <%= yield :page_heading %>
       <%= yield %>
     </div>

--- a/app/views/layouts/application_body_only.html.erb
+++ b/app/views/layouts/application_body_only.html.erb
@@ -1,4 +1,4 @@
-<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <% content_for :application_body do %>
@@ -6,6 +6,7 @@
   <div id="application-body-only">
 
     <div id="application-body-only-body">
+      <%= yield :above_page_heading %>
       <%= yield :page_heading %>
       <%= yield %>
     </div>

--- a/app/views/registration/complete.html.erb
+++ b/app/views/registration/complete.html.erb
@@ -2,7 +2,7 @@
 
 <p>* indicates required field.</p>
 
-<%= lev_form_for :register, url: register_path, method: :put, html: {id: 'profile-form'} do |f| %>
+<%= lev_form_for :register, url: registration_complete_path, method: :put, html: {id: 'profile-form'} do |f| %>
 
   <%= standard_field form: f, name: :username, type: :text_field, label: "Username *",
                      options: {value: current_user.username} %>

--- a/app/views/registration/verification_pending.html.erb
+++ b/app/views/registration/verification_pending.html.erb
@@ -5,9 +5,6 @@
   input[type='submit'] { margin: 10px 0 30px 40px; }
 </style>
 
-<%# flash.now[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
-    if params[:c] == "1" %>
-
 <% emails = current_user.email_addresses.collect(&:value) %>
 
 <ol>
@@ -19,7 +16,7 @@
 </ol>
 
 <%= button_to 'I clicked the link in the verification email',
-              i_clicked_verification_link_path,
+              registration_i_verified_path,
               method: :put, class: 'standard' %>
 
 <p style="margin: 80px 0 0 0; width: 90%">

--- a/app/views/sessions/ask_new_or_returning.html.erb
+++ b/app/views/sessions/ask_new_or_returning.html.erb
@@ -28,7 +28,7 @@ profile.</p>
     </div>
     <div class='well'>
     <%= link_to "Continue".html_safe,
-                register_path, class: 'standard' %>
+                registration_complete_path, class: 'standard' %>
     </div>
 
   </div>

--- a/app/views/sessions/ask_new_or_returning.html.erb
+++ b/app/views/sessions/ask_new_or_returning.html.erb
@@ -28,7 +28,7 @@ profile.</p>
     </div>
     <div class='well'>
     <%= link_to "Continue".html_safe,
-                stored_url, class: 'standard' %>
+                register_path, class: 'standard' %>
     </div>
 
   </div>

--- a/app/views/static_pages/verification_sent.html.erb
+++ b/app/views/static_pages/verification_sent.html.erb
@@ -5,22 +5,34 @@
   input[type='submit'] { margin: 10px 0 30px 40px; }
 </style>
 
-<% flash.now[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
-    if request.referrer == request.original_url %>
+<%# flash.now[:alert] = "We haven't seen that you clicked the verification link.  Please try again." \
+    if params[:c] == "1" %>
+
+<% emails = current_user.email_addresses.collect(&:value) %>
 
 <ol>
-  <li>Find the email we sent to <%= current_user.email_addresses.first.try(:value) %>.</li>
-  <li>Click the link in that email.</li>
+  <li>Find <%= emails.one? ? 'the email' : 'one of the emails' %>
+      we sent to
+      <%= emails.to_sentence(last_word_connector: ', or ', two_words_connector: ' or ') %>.</li>
+  <li>Click the link <%= emails.one? ? 'in that email' : 'in one of those emails' %>.</li>
   <li>Return here and click the button below.</li>
 </ol>
 
-<p><%= button_to 'I clicked the link in the verification email',
-                 stored_url,
-                 class: 'standard' %></p>
+<%= button_to 'I clicked the link in the verification email',
+              i_clicked_verification_link_path,
+              method: :put, class: 'standard' %>
 
-<p style="margin: 80px 0 0 0">
+<p style="margin: 80px 0 0 0; width: 90%">
   Can't find the email?  Try checking your junk or spam folder, or
-  <%= link_to 'click here to <b>resend</b> the verification email'.html_safe,
-               resend_confirmation_contact_info_path(current_user.email_addresses.first),
-               method: :put %>.
+  <% if emails.one? %>
+    <%= link_to 'click here to <b>resend</b> the verification email'.html_safe,
+                 resend_confirmation_contact_info_path(current_user.email_addresses.first),
+                 method: :put %>.
+  <% else %>
+    click
+    <%= current_user.email_addresses.collect{ |ea|
+          link_to(ea.value, resend_confirmation_contact_info_path(ea), method: :put)
+        }.to_sentence(last_word_connector: ', or ', two_words_connector: ' or ').html_safe %>
+    to resend those verification emails.
+  <% end %>
 </p>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,34 +2,42 @@
    # user
 %>
 
-<%= form_for user, url: profile_path, html: {class: 'form-horizontal profile-edit'} do |f| %>
-  <div class="row">
+<% if user.is_activated? %>
 
-    <div class="col-sm-1">
-      <%= f.label :title, "Title" %>
-      <%= f.text_field :title %>
+  <%= form_for user, url: profile_path, html: {class: 'form-horizontal profile-edit'} do |f| %>
+    <div class="row">
+
+      <div class="col-sm-1">
+        <%= f.label :title, "Title" %>
+        <%= f.text_field :title %>
+      </div>
+
+      <div class="col-sm-3">
+        <%= f.label :first_name, "First Name" %>
+        <%= f.text_field :first_name, value: user.first_name || \
+            user.guessed_first_name %>
+      </div>
+
+      <div class="col-sm-3">
+        <%= f.label :last_name, "Last Name" %>
+        <%= f.text_field :last_name, value: user.last_name || \
+            user.guessed_last_name %>
+      </div>
+
+      <div class="col-sm-2">
+        <%= f.label :suffix, 'Suffix' %>
+        <%= f.text_field :suffix, value: user.suffix %>
+      </div>
+
+      <div class="horizontal-submit col-sm-3">
+        <%= f.submit "Update Profile", class: 'standard' %>
+      </div>
+
     </div>
+  <% end %>
 
-    <div class="col-sm-3">
-      <%= f.label :first_name, "First Name" %>
-      <%= f.text_field :first_name, value: user.first_name || \
-          user.guessed_first_name %>
-    </div>
-
-    <div class="col-sm-3">
-      <%= f.label :last_name, "Last Name" %>
-      <%= f.text_field :last_name, value: user.last_name || \
-          user.guessed_last_name %>
-    </div>
-
-    <div class="col-sm-2">
-      <%= f.label :suffix, 'Suffix' %>
-      <%= f.text_field :suffix, value: user.suffix %>
-    </div>
-
-    <div class="horizontal-submit col-sm-3">
-      <%= f.submit "Update Profile", class: 'standard' %>
-    </div>
-
+<% else %>
+  <div class="well">
+    These options will be available after you have clicked the button in the upper right to finish sign up.
   </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -5,9 +5,8 @@
 <% default_tab = :name %>
 
 <% if !current_user.is_activated? %>
-  <%#= link_to 'Finish Sign Up', register_path, class: 'btn btn-primary' %>
   <% content_for :above_page_heading do %>
-    <%= button_to('Finish Sign Up!', register_path, method: :get, :class => "standard finish-sign-up") %>
+    <%= button_to('Finish Sign Up!', registration_complete_path, method: :get, :class => "standard finish-sign-up") %>
   <% end %>
   <% default_tab = :email %>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,10 +1,14 @@
 <%= page_heading("Your Account") %>
 
+<div class="your-account">
+
 <% default_tab = :name %>
 
 <% if !current_user.is_activated? %>
-  <%= link_to 'Finish Sign Up', register_path, class: 'btn btn-primary' %>
-  <%#= button_to('Finish Sign Up', register_path, :class => "standard finish-sign-up") %>
+  <%#= link_to 'Finish Sign Up', register_path, class: 'btn btn-primary' %>
+  <% content_for :above_page_heading do %>
+    <%= button_to('Finish Sign Up!', register_path, method: :get, :class => "standard finish-sign-up") %>
+  <% end %>
   <% default_tab = :email %>
 <% end %>
 
@@ -38,4 +42,6 @@
     <%= render partial: 'contact_infos/email_addresses', locals: {
                email_addresses: current_user.email_addresses } %>
   </div>
+</div>
+
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,8 +1,16 @@
 <%= page_heading("Your Account") %>
 
-<% @active_tab ||= params[:active_tab].try(:to_sym) || :name %>
+<% default_tab = :name %>
 
-<ul class="nav nav-tabs" role="tablist" style="margin-bottom: 30px">
+<% if !current_user.is_activated? %>
+  <%= link_to 'Finish Sign Up', register_path, class: 'btn btn-primary' %>
+  <%#= button_to('Finish Sign Up', register_path, :class => "standard finish-sign-up") %>
+  <% default_tab = :email %>
+<% end %>
+
+<% @active_tab ||= params[:active_tab].try(:to_sym) || default_tab %>
+
+<ul class="nav nav-tabs" role="tablist" style="margin-bottom: 30px; clear: both;">
   <li role="presentation" <% if @active_tab == :name %>class="active"<% end %>><a href="#name" aria-controls="name" role="tab" data-toggle="tab">Profile Settings</a></li>
 
   <% unless current_user.identity.nil? %>

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -39,15 +39,8 @@ ActionController::Base.class_exec do
 
   def registration
     return true if request.format != :html
-
     return unless current_user.is_temp?
-    store_url key: :registration_return_to
-    flash.keep
-    if current_user.email_addresses.empty? || current_user.email_addresses.any?(&:verified)
-      redirect_to register_path
-    else
-      redirect_to verification_sent_path
-    end
+    redirect_to register_path
   end
 
   def expired_password

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -40,7 +40,7 @@ ActionController::Base.class_exec do
   def registration
     return true if request.format != :html
     return unless current_user.is_temp?
-    redirect_to register_path
+    redirect_to registration_complete_path
   end
 
   def expired_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,11 +27,15 @@ Accounts::Application.routes.draw do
   scope controller: 'users' do
     get 'profile', action: :edit
     put 'profile', action: :update
-    get 'register'
-    put 'register'
     get 'ask_for_email'
     put 'ask_for_email'
-    put 'i_clicked_verification_link'
+  end
+
+  namespace 'registration' do
+    get 'complete'
+    put 'complete'
+    get 'verification_pending'
+    put 'i_verified'
   end
 
   resource :identity, only: :update
@@ -64,7 +68,6 @@ Accounts::Application.routes.draw do
   scope controller: 'static_pages' do
     get 'copyright'
     get 'status'
-    get 'verification_sent'
   end
 
   apipie

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Accounts::Application.routes.draw do
     put 'register'
     get 'ask_for_email'
     put 'ask_for_email'
+    put 'i_clicked_verification_link'
   end
 
   resource :identity, only: :update

--- a/lib/omniauth/strategies/custom_identity.rb
+++ b/lib/omniauth/strategies/custom_identity.rb
@@ -29,7 +29,7 @@ module OmniAuth
       option :name, "identity"
 
       def request_phase
-        SessionsController.action(:new).call(env)        
+        SessionsController.action(:new).call(env)
       end
 
       def callback_phase

--- a/spec/access_policies/user_access_policy_spec.rb
+++ b/spec/access_policies/user_access_policy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe UserAccessPolicy do
   end
 
   context 'read, update' do
-    it 'cannot be accessed by anonymous, temp users or apps' do
+    it 'cannot be accessed by anonymous users or apps' do
       expect(OSU::AccessPolicy.action_allowed?(:read, anon, anon)).to eq false
       expect(OSU::AccessPolicy.action_allowed?(:read, app, user)).to eq false
 

--- a/spec/access_policies/user_access_policy_spec.rb
+++ b/spec/access_policies/user_access_policy_spec.rb
@@ -24,20 +24,20 @@ RSpec.describe UserAccessPolicy do
   context 'read, update' do
     it 'cannot be accessed by anonymous, temp users or apps' do
       expect(OSU::AccessPolicy.action_allowed?(:read, anon, anon)).to eq false
-      expect(OSU::AccessPolicy.action_allowed?(:read, temp, temp)).to eq false
       expect(OSU::AccessPolicy.action_allowed?(:read, app, user)).to eq false
 
       expect(OSU::AccessPolicy.action_allowed?(:update, anon, anon)).to eq false
-      expect(OSU::AccessPolicy.action_allowed?(:update, temp, temp)).to eq false
       expect(OSU::AccessPolicy.action_allowed?(:update, app, user)).to eq false
     end
 
-    it 'can be accessed by non-temp users' do
+    it 'can be accessed by human users, temp or not' do
       expect(OSU::AccessPolicy.action_allowed?(:read, user, user)).to eq true
       expect(OSU::AccessPolicy.action_allowed?(:read, admin, admin)).to eq true
+      expect(OSU::AccessPolicy.action_allowed?(:read, temp, temp)).to eq true
 
       expect(OSU::AccessPolicy.action_allowed?(:update, user, user)).to eq true
       expect(OSU::AccessPolicy.action_allowed?(:update, admin, admin)).to eq true
+      expect(OSU::AccessPolicy.action_allowed?(:update, temp, temp)).to eq true
     end
 
     it 'cannot access other users unless admin' do

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe RegistrationController, type: :controller do
+
+  let!(:temp_user) { FactoryGirl.create :temp_user }
+
+  context 'GET complete' do
+    it 'renders the registration page' do
+      controller.sign_in! temp_user
+      get :complete
+      expect(response.status).to eq 200
+    end
+  end
+
+  context 'PUT complete' do
+    it 'registers the user' do
+      expect(temp_user.is_temp?).to eq true
+      contract_1 = FinePrint::Contract.first
+      contract_2 = FinePrint::Contract.last
+
+      controller.sign_in! temp_user
+      put :complete, register: {i_agree: true,
+                                 first_name: 'My',
+                                 last_name: 'Username',
+                                 username: "my_username",
+                                 contract_1_id: contract_1.id,
+                                 contract_2_id: contract_2.id}
+      expect(response.status).to eq 302
+      expect(temp_user.reload.is_temp?).to eq false
+      expect(temp_user.username).to eq "my_username"
+      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
+      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
+    end
+
+    it 'registers the user with all the details' do
+      expect(temp_user.is_temp?).to eq true
+      contract_1 = FinePrint::Contract.first
+      contract_2 = FinePrint::Contract.last
+
+      controller.sign_in! temp_user
+      put :complete, register: {i_agree: true,
+                                 title: 'Dr',
+                                 username: "my_username",
+                                 first_name: 'First',
+                                 last_name: 'Last',
+                                 suffix: 'Junior',
+                                 contract_1_id: contract_1.id,
+                                 contract_2_id: contract_2.id}
+      expect(response.status).to eq 302
+      expect(temp_user.reload.is_temp?).to eq false
+      expect(temp_user.username).to eq "my_username"
+      expect(temp_user.title).to eq 'Dr'
+      expect(temp_user.first_name).to eq 'First'
+      expect(temp_user.last_name).to eq 'Last'
+      expect(temp_user.suffix).to eq 'Junior'
+      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
+      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
+    end
+
+    it "claims an unclaimed account" do
+      user = FactoryGirl.create :user, state: 'unclaimed'
+      expect(user.state).to eq 'unclaimed'
+      controller.sign_in! user
+      contract_1 = FinePrint::Contract.first
+      contract_2 = FinePrint::Contract.last
+      put :complete, register: {i_agree: true,
+                                 first_name: 'My',
+                                 last_name: 'Username',
+                                 username: "my_username",
+                                 contract_1_id: contract_1.id,
+                                 contract_2_id: contract_2.id}
+      expect(user.reload.state).to eq 'activated'
+    end
+  end
+
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 RSpec.describe UsersController, type: :controller do
 
   let!(:user) { FactoryGirl.create :user, :terms_agreed }
-  let!(:temp_user) { FactoryGirl.create :temp_user }
 
   context 'GET edit' do
     it 'renders the edit profile page' do
@@ -34,75 +33,6 @@ RSpec.describe UsersController, type: :controller do
       expect(user.last_name).to eq 'NewLast'
       expect(user.suffix).to eq 'NewSuffix'
       expect(user.full_name).to eq 'NewFirst NewLast NewSuffix'
-    end
-  end
-
-  context 'GET register' do
-    it 'renders the registration page' do
-      controller.sign_in! temp_user
-      get 'register'
-      expect(response.status).to eq 200
-    end
-  end
-
-  context 'PUT register' do
-    it 'registers the user' do
-      expect(temp_user.is_temp?).to eq true
-      contract_1 = FinePrint::Contract.first
-      contract_2 = FinePrint::Contract.last
-
-      controller.sign_in! temp_user
-      put 'register', register: {i_agree: true,
-                                 first_name: 'My',
-                                 last_name: 'Username',
-                                 username: "my_username",
-                                 contract_1_id: contract_1.id,
-                                 contract_2_id: contract_2.id}
-      expect(response.status).to eq 302
-      expect(temp_user.reload.is_temp?).to eq false
-      expect(temp_user.username).to eq "my_username"
-      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
-      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
-    end
-
-    it 'registers the user with all the details' do
-      expect(temp_user.is_temp?).to eq true
-      contract_1 = FinePrint::Contract.first
-      contract_2 = FinePrint::Contract.last
-
-      controller.sign_in! temp_user
-      put 'register', register: {i_agree: true,
-                                 title: 'Dr',
-                                 username: "my_username",
-                                 first_name: 'First',
-                                 last_name: 'Last',
-                                 suffix: 'Junior',
-                                 contract_1_id: contract_1.id,
-                                 contract_2_id: contract_2.id}
-      expect(response.status).to eq 302
-      expect(temp_user.reload.is_temp?).to eq false
-      expect(temp_user.username).to eq "my_username"
-      expect(temp_user.title).to eq 'Dr'
-      expect(temp_user.first_name).to eq 'First'
-      expect(temp_user.last_name).to eq 'Last'
-      expect(temp_user.suffix).to eq 'Junior'
-      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
-      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
-    end
-
-    it "claims an unclaimed account" do
-      user = FactoryGirl.create :user, state: 'unclaimed'
-      expect(user.state).to eq 'unclaimed'
-      controller.sign_in! user
-      contract_1 = FinePrint::Contract.first
-      contract_2 = FinePrint::Contract.last
-      put 'register', register: {i_agree: true,
-                                 first_name: 'My',
-                                 last_name: 'Username',
-                                 username: "my_username",
-                                 contract_1_id: contract_1.id,
-                                 contract_2_id: contract_2.id}
-      expect(user.reload.state).to eq 'activated'
     end
   end
 

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -16,8 +16,8 @@ feature 'User manages emails' do
 
   context 'create' do
     scenario 'success', js: true do
-      fill_in 'Email address', with: 'user@mysite.com'
-      click_button 'Add Email address'
+      fill_in 'Add an email address', with: 'user@mysite.com'
+      click_button 'Add'
       expect(page).to have_content('Change Your Password')
       expect(page).to have_content(
         'A verification message has been sent to "user@mysite.com"')
@@ -25,28 +25,28 @@ feature 'User manages emails' do
     end
 
     scenario 'with empty value', js: true do
-      fill_in 'Email address', with: ''
-      click_button 'Add Email address'
+      fill_in 'Add an email address', with: ''
+      click_button 'Add'
       expect(page).to have_content("Value can't be blank")
     end
 
     scenario 'with invalid value', js: true do
-      fill_in 'Email address', with: 'user'
-      click_button 'Add Email address'
+      fill_in 'Add an email address', with: 'user'
+      click_button 'Add'
       expect(page).to have_content('Value is invalid')
     end
   end
 
   context 'destroy' do
     scenario 'success', js: true do
-      click_button 'Delete'
+      click_link 'Delete'
       expect(page).to have_content('Email address deleted')
     end
   end
 
   context 'resend_confirmation' do
     scenario 'success', js: true do
-      click_button 'Resend Verification'
+      click_link 'Click to verify'
       expect(page).to have_content('A verification message has been sent to "')
     end
   end


### PR DESCRIPTION
## General Refactoring

Reorganizes the registration actions into their own controller (removing them from the Users and StaticPages controllers).  Simplifies some of the redirection logic (more direct redirects, fewer action_interceptor-style redirects).

## Login Flow Refinements

Removes the sign up link from the header of the sign up page:

![image](https://cloud.githubusercontent.com/assets/1001691/11982654/f435229e-a961-11e5-8ca2-94735bd9367e.png)

Makes sure that the "We haven't seen that you clicked the verification link" message really only appears when the user clicks the button but hasn't clicked the link.  Previously it could show up in some unintended situations.

![image](https://cloud.githubusercontent.com/assets/1001691/11982674/1c8efcf6-a962-11e5-8ca5-0475b2ebf3bf.png)

Users can now click their username to access their profile *before* they've completed registration.  This will let them add other email addresses or delete the one they entered on the sign up screen (in case they mis-typed it)

When they click the username in this situation, they'll go to the profile page and directly to the email address tab.  There is a "Finish Sign Up!" button in the upper corner to return them to the registration process.

![image](https://cloud.githubusercontent.com/assets/1001691/11982708/55a11178-a962-11e5-945f-b1dd41ce5430.png)

If they click the other tabs they see a message saying they need to complete sign up before they can see the forms:

![image](https://cloud.githubusercontent.com/assets/1001691/11982712/68bcc87e-a962-11e5-9f17-16476f43b721.png)

Cleans up the "Manage Email Addresses" tab of the profile page:

![image](https://cloud.githubusercontent.com/assets/1001691/11982641/d608abb0-a961-11e5-93c2-8442582c70ce.png)


