### PR TITLE
Disallow spaces in email addresses

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,3 +1,5 @@
 class EmailAddress < ContactInfo
-  validates :value, format: { with: /\A[^@]+@[^@.]+\.[^@]+\z/ }
+  validates :value, format: {
+    with: /\A[^@ ]+@[^@. ]+\.[^@ ]+\z/,
+    message: "\"%{value}\" is not a valid email address" }
 end

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -33,7 +33,7 @@ feature 'User manages emails' do
     scenario 'with invalid value', js: true do
       fill_in 'Add an email address', with: 'user'
       click_button 'Add'
-      expect(page).to have_content('Value is invalid')
+      expect(page).to have_content('Value "user" is not a valid email address')
     end
   end
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -136,6 +136,22 @@ feature 'User signs up as a local user', js: true do
     expect(page).not_to have_content('Welcome, testuser')
   end
 
+  scenario 'with an invalid email address' do
+    visit '/'
+    expect(page).to have_content('Sign in to your one OpenStax account!')
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up')
+    expect(page).to have_content('register using your Facebook, Twitter, or Google account.')
+
+    fill_in 'Email Address', with: 'testuser@ex ample.org'
+    fill_in 'Username', with: 'testuser'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password Again', with: 'password'
+    click_button 'Continue'
+    expect(page).to have_content('Value "testuser@ex ample.org" is not a valid email address')
+    expect(page).not_to have_content('Welcome, testuser')
+  end
+
   scenario 'without any email addresses' do
     # this is a test for twitter users who have no email addresses
     create_application


### PR DESCRIPTION
To fix this error occured in identities#forgot_password:

```
data: {:error_id=>"074289",
   :class=>"AWS::SES::ResponseError",
   :message=>
    "InvalidParameterValue - Local address contains control or whitespace",
   :first_line_of_backtrace=>
    "/home/ostaccounts/src/accounts-a4650b5/vendor/bundle/ruby/1.9.1/gems/aws-ses-0.6.0/lib/aws/ses/base.rb:175:in `request'",
   :cause=>nil,
   :dns_name=>"unknown",
   :extras=>{}}
```