### PR TITLE
Quote full name in "to" header in emails

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -2,13 +2,13 @@ class ConfirmationMailer < SiteMailer
 
   def reminder(email_address)
     @email_address = email_address
-    mail to: "#{email_address.user.full_name} <#{email_address.value}>",
+    mail to: "\"#{email_address.user.full_name}\" <#{email_address.value}>",
          subject: "Reminder: please verify this email address"
   end
 
   def instructions(email_address)
     @email_address = email_address
-    mail to: "#{email_address.user.full_name} <#{email_address.value}>",
+    mail to: "\"#{email_address.user.full_name}\" <#{email_address.value}>",
          subject: "Please verify this email address"
   end
 end

--- a/app/mailers/reset_password_mailer.rb
+++ b/app/mailers/reset_password_mailer.rb
@@ -3,7 +3,7 @@ class ResetPasswordMailer < SiteMailer
   def reset_password(email_address, reset_password_code)
     @email_address = email_address
     @reset_password_code = reset_password_code
-    mail to: "#{email_address.user.full_name} <#{email_address.value}>",
+    mail to: "\"#{email_address.user.full_name}\" <#{email_address.value}>",
          subject: "Reset your password"
   end
 

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ConfirmationMailer do
-  let(:user) { FactoryGirl.create :user }
+  let(:user) { FactoryGirl.create :user, full_name: 'John Doe, Jr.' }
   let(:email) { FactoryGirl.create :email_address, value: 'to@example.org',
                                    user_id: user.id, confirmation_code: '1234' }
 
@@ -10,7 +10,7 @@ describe ConfirmationMailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq("[OpenStax] Reminder: please verify this email address")
-      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.header['to'].to_s).to eq('"John Doe, Jr." <to@example.org>')
       expect(mail.from).to eq(["noreply@openstax.org"])
     end
 
@@ -25,7 +25,7 @@ describe ConfirmationMailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq("[OpenStax] Please verify this email address")
-      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.header['to'].to_s).to eq('"John Doe, Jr." <to@example.org>')
       expect(mail.from).to eq(["noreply@openstax.org"])
     end
 

--- a/spec/mailers/reset_password_mailer_spec.rb
+++ b/spec/mailers/reset_password_mailer_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe ResetPasswordMailer do
   describe 'reset_password' do
     before :each do
-      @user = FactoryGirl.create :user, username: 'user1'
+      @user = FactoryGirl.create :user, username: 'user1', full_name: 'John Doe, Jr.'
       @email = FactoryGirl.create :email_address, user: @user
       @mail = ResetPasswordMailer.reset_password @email, '1234'
     end
 
     it 'renders the headers' do
       expect(@mail.subject).to eq('[OpenStax] Reset your password')
-      expect(@mail.to).to eq([@email.value])
+      expect(@mail.header['to'].to_s).to eq("\"John Doe, Jr.\" <#{@email.value}>")
       expect(@mail.from).to eq(['noreply@openstax.org'])
     end
 


### PR DESCRIPTION
When user has a full name that includes certain characters like commas,
we need to quote it.

Fix `AWS::SES Response Error: InvalidParameterValue`

Close #253