### PR TITLE
Allow resetting password without verified emails

### DIFF
--- a/app/handlers/identities_forgot_password.rb
+++ b/app/handlers/identities_forgot_password.rb
@@ -27,9 +27,9 @@ class IdentitiesForgotPassword
       fatal_error(code: 'Unable to reset password for this user',
                   offending_inputs: [:identity])
     end
-    email_addresses = user.contact_infos.email_addresses.verified
+    email_addresses = user.contact_infos.email_addresses
     if email_addresses.empty?
-      fatal_error(code: 'No verified email addresses found for this user',
+      fatal_error(code: 'No email addresses found for this user',
                   offending_inputs: [:email_address])
     end
     code = run(GeneratePasswordResetCode, user.identity).outputs[:code]

--- a/spec/features/forgot_password_spec.rb
+++ b/spec/features/forgot_password_spec.rb
@@ -35,7 +35,7 @@ feature 'User forgot password', js: true do
     @email.save
     fill_in 'Username', with: 'user1'
     click_button 'Submit'
-    expect(page.text).to include('No verified email addresses found for this user')
+    expect(page.text).to include('Password reset instructions sent to your email address!')
   end
 
   scenario 'user gets a password reset email' do


### PR DESCRIPTION
Per customer support, we want to let users who have not verified their password reset their password.  There's a danger we could spam some people here, but there isn't a security problem.