### PR TITLE
Alternate: Fixed the 500 error on double register

### DIFF
--- a/app/handlers/identities_register.rb
+++ b/app/handlers/identities_register.rb
@@ -32,7 +32,7 @@ class IdentitiesRegister
     user = caller
 
     if user.identity
-      outputs[:identity] = user.identity
+      outputs[:identity] = user.identity # let the sign up flow continue
       fatal_error(code: :already_has_identity)
     end
 

--- a/app/handlers/identities_register.rb
+++ b/app/handlers/identities_register.rb
@@ -24,12 +24,17 @@ class IdentitiesRegister
 
   protected
 
-  def authorized?;
-    caller.is_anonymous? || caller.authentications.none?{|auth| auth.provider == 'identity'}
+  def authorized?
+    true
   end
 
   def handle
     user = caller
+
+    if user.identity
+      outputs[:identity] = user.identity
+      fatal_error(code: :already_has_identity)
+    end
 
     if user.is_anonymous?
       run(CreateUser,

--- a/app/views/sessions/ask_new_or_returning.html.erb
+++ b/app/views/sessions/ask_new_or_returning.html.erb
@@ -1,5 +1,12 @@
 <% authentications = current_user.authentications %>
 
+<% if request.env['errors'].any?{|error| error.code == :already_has_identity} %>
+  <% flash[:alert] = "It looks like you submitted the form on the last page twice.  We are " \
+                     "still using the values from your first submission.  If you want to " \
+                     "change your email address or password, you can do so on the account " \
+                     "profile page after registration is complete."  %>
+<% end %>
+
 <%= page_heading 'Merge Logins'  %>
 
 <% if false %>

--- a/app/views/sessions/ask_new_or_returning.html.erb
+++ b/app/views/sessions/ask_new_or_returning.html.erb
@@ -1,6 +1,6 @@
 <% authentications = current_user.authentications %>
 
-<% if request.env['errors'].any?{|error| error.code == :already_has_identity} %>
+<% if (request.env['errors'] || []).any?{|error| error.code == :already_has_identity} %>
   <% flash[:alert] = "It looks like you submitted the form on the last page twice.  We are " \
                      "still using the values from your first submission.  If you want to " \
                      "change your email address or password, you can do so on the account " \

--- a/lib/omniauth/strategies/custom_identity.rb
+++ b/lib/omniauth/strategies/custom_identity.rb
@@ -58,9 +58,12 @@ module OmniAuth
         @handler_result = IdentitiesRegister.handle(params: request,
                                                     caller: current_user)
 
-        if @handler_result.errors.empty?
+        error_codes = @handler_result.errors.map(&:code)
+
+        if error_codes.empty? || error_codes == [:already_has_identity]
           @identity = @handler_result.outputs[:identity]
           env['PATH_INFO'] = callback_path
+          env['errors'] = @handler_result.errors
           callback_phase
         else
           env['errors'] = @handler_result.errors

--- a/spec/handlers/identities_register_spec.rb
+++ b/spec/handlers/identities_register_spec.rb
@@ -3,15 +3,16 @@ require 'spec_helper'
 describe IdentitiesRegister do
 
   context "when user info ok but passwords don't match" do
-    let (:identities_register_call) { -> { 
+    let (:identities_register_call) { -> {
       IdentitiesRegister.handle(
         params: {
-          register: { 
-            username: 'joebob', 
-            first_name: 'joe', 
-            last_name: 'bob', 
-            password: 'pass', 
-            password_confirmation: 'word'
+          register: {
+            username: 'joebob',
+            first_name: 'joe',
+            last_name: 'bob',
+            password: 'pass',
+            password_confirmation: 'word',
+            email: 'joebob@example.com'
           }
         },
         caller: AnonymousUser.instance,
@@ -28,7 +29,61 @@ describe IdentitiesRegister do
 
     it "has errors for [:register, :password]" do
       outcome = identities_register_call.call
-      expect(outcome.errors.has_offending_input?([:register, :password]))
+      expect(outcome.errors).to have_offending_input(:register)
+      expect(outcome.errors).to have_offending_input(:password)
+    end
+  end
+
+  context "when the user already has a password" do
+    before(:each) do
+      expect(IdentitiesRegister.handle(
+        params: {
+          register: {
+            username: 'joebob',
+            first_name: 'joe',
+            last_name: 'bob',
+            password: 'password',
+            password_confirmation: 'password',
+            email: 'joebob@example.com'
+          }
+        },
+        caller: AnonymousUser.instance
+      ).errors).to be_empty
+    end
+
+    it "has errors for [:register, :username] if not logged in" do
+      outcome = IdentitiesRegister.handle(
+        params: {
+          register: {
+            username: 'joebob',
+            first_name: 'joe',
+            last_name: 'bob',
+            password: 'password',
+            password_confirmation: 'password',
+            email: 'joebob@example.com'
+          }
+        },
+        caller: AnonymousUser.instance
+      )
+      expect(outcome.errors).to have_offending_input(:register)
+      expect(outcome.errors).to have_offending_input(:username)
+    end
+
+    it "has errors for [:register, :user_id] if logged in" do
+      outcome = IdentitiesRegister.handle(
+        params: {
+          register: {
+            username: 'joebob',
+            first_name: 'joe',
+            last_name: 'bob',
+            password: 'password',
+            password_confirmation: 'password',
+            email: 'joebob@example.com'
+          }
+        },
+        caller: User.find_by_username('joebob')
+      )
+      expect(outcome.errors.map(&:code)).to eq [:already_has_identity]
     end
   end
 


### PR DESCRIPTION
@Dantemss instead of writing some comments on https://github.com/openstax/accounts/pull/263 I decided to put it in a PR.  Instead of letting the error bubble up from a lower-level routine, I'd prefer to be more explicit in `IdentitiesRegister` that only one identity is allowed (and `fatal_error` out immediately if that's not the case).  This approach also changes the flow to continue to the "merge logins" page with an error flash.