### PR TITLE
Re-enable sessions callback specs

### DIFF
--- a/app/routines/transfer_authentications.rb
+++ b/app/routines/transfer_authentications.rb
@@ -1,14 +1,19 @@
-
 class TransferAuthentications
 
   lev_routine
+
+  uses_routine DestroyUser
 
   protected
 
   def exec(authentications, target_user)
     authentications = [authentications] if !(authentications.is_a? Array)
     authentications.each do |authentication|
+      authentication_user = authentication.user
       authentication.update_attribute(:user_id, target_user.id)
+      run(DestroyUser, authentication_user) \
+        if authentication_user && !authentication_user.is_activated? && \
+           authentication_user.reload.authentications.empty?
     end
   end
 

--- a/spec/controllers/registration_controller_spec.rb
+++ b/spec/controllers/registration_controller_spec.rb
@@ -6,59 +6,7 @@ RSpec.describe 'RegistrationController', type: :controller do
 
   # TODO find a new home for relevant pieces of below
 
-  xcontext 'GET complete' do
-    it 'renders the registration page' do
-      controller.sign_in! temp_user
-      get :complete
-      expect(response.status).to eq 200
-    end
-  end
-
   xcontext 'PUT complete' do
-    it 'registers the user' do
-      expect(temp_user.is_temp?).to eq true
-      contract_1 = FinePrint::Contract.first
-      contract_2 = FinePrint::Contract.last
-
-      controller.sign_in! temp_user
-      put :complete, register: {i_agree: true,
-                                 first_name: 'My',
-                                 last_name: 'Username',
-                                 username: "my_username",
-                                 contract_1_id: contract_1.id,
-                                 contract_2_id: contract_2.id}
-      expect(response.status).to eq 302
-      expect(temp_user.reload.is_temp?).to eq false
-      expect(temp_user.username).to eq "my_username"
-      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
-      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
-    end
-
-    it 'registers the user with all the details' do
-      expect(temp_user.is_temp?).to eq true
-      contract_1 = FinePrint::Contract.first
-      contract_2 = FinePrint::Contract.last
-
-      controller.sign_in! temp_user
-      put :complete, register: {i_agree: true,
-                                 title: 'Dr',
-                                 username: "my_username",
-                                 first_name: 'First',
-                                 last_name: 'Last',
-                                 suffix: 'Junior',
-                                 contract_1_id: contract_1.id,
-                                 contract_2_id: contract_2.id}
-      expect(response.status).to eq 302
-      expect(temp_user.reload.is_temp?).to eq false
-      expect(temp_user.username).to eq "my_username"
-      expect(temp_user.title).to eq 'Dr'
-      expect(temp_user.first_name).to eq 'First'
-      expect(temp_user.last_name).to eq 'Last'
-      expect(temp_user.suffix).to eq 'Junior'
-      expect(FinePrint.signed_contract?(temp_user, contract_1)).to eq true
-      expect(FinePrint.signed_contract?(temp_user, contract_2)).to eq true
-    end
-
     it "claims an unclaimed account" do
       user = FactoryGirl.create :user, state: 'unclaimed'
       expect(user.state).to eq 'unclaimed'

--- a/spec/routines/transfer_authentications_spec.rb
+++ b/spec/routines/transfer_authentications_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe TransferAuthentications do
+  let(:target_user) { FactoryGirl.create :temp_user, username: 'target_user' }
+  let(:other_user) { FactoryGirl.create :temp_user, username: 'other_user'}
+  let(:authentication) { FactoryGirl.create :authentication, user: other_user, provider: 'google' }
+  let(:authentication2) { FactoryGirl.create :authentication, user: nil, provider: 'facebook' }
+
+  it 'transfers an authentication to the target user' do
+    TransferAuthentications.call(authentication, target_user)
+    expect(authentication.reload.user).to eq(target_user)
+  end
+
+  it 'transfers a list of authentications to the target user' do
+    TransferAuthentications.call([authentication, authentication2], target_user)
+    expect(authentication.reload.user).to eq(target_user)
+    expect(authentication2.reload.user).to eq(target_user)
+  end
+
+  it 'deletes users that have no authentications' do
+    TransferAuthentications.call(authentication, target_user)
+    expect(User.exists?(other_user.id)).to be_falsey
+  end
+end


### PR DESCRIPTION
- Only return authentication_taken if the user linked to the authentication is activated
- If authentication is linked to the current user and the user is
      already signed in, there's nothing to do
- If the user linked to the authentication is not activated, transfer
      the authentication to the signed in user and delete the other user
