### PR TITLE
New flow fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -43,6 +43,8 @@ class SessionsController < ApplicationController
         when :returning_user, :new_password_user, :transferred_authentication
           set_last_signin_provider(@handler_result.outputs[:authentication].provider)
           redirect_to action: :returning_user
+        when :no_action
+          redirect_to action: :returning_user
         when :new_social_user
           redirect_to signup_social_path
         when :authentication_added

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -17,7 +17,7 @@
       <%= link_to "/auth/google_oauth2", class: 'btn btn-block btn-social btn-google', id: 'google-login-button' do %>
         <span class="fa fa-google"></span> Sign in with Google
       <% end %>
-      <%= last_signin_mark('google') %>
+      <%= last_signin_mark('google_oauth2') %>
 
       <%= link_to "/auth/twitter", class: 'btn btn-block btn-social btn-twitter', id: 'twitter-login-button' do %>
         <span class="fa fa-twitter"></span> Sign in with Twitter

--- a/app/views/signup/_new_account.html.erb
+++ b/app/views/signup/_new_account.html.erb
@@ -25,15 +25,18 @@
                          options: {value: user.username} %>
 
       <% if is_social_signup %>
-        <% provider = user.authentications.first.provider %>
+        <% authentication = user.authentications.first %>
+        <% provider = authentication.provider %>
+        <% icon_class = provider == 'google_oauth2' ? 'google' : provider %>
+
         <div class="password-managed">
           <div class="icon">
             <div class="fa-stack fa-lg">
               <i class="fa fa-square fa-stack-2x <%= provider %>-bkg"></i>
-              <i class="fa fa-<%= provider %> fa-stack-1x fa-inverse"></i>
+              <i class="fa fa-<%= icon_class %> fa-stack-1x fa-inverse"></i>
             </div>
           </div>
-          <div class="message">Password managed by <%= provider.capitalize %></div>
+          <div class="message">Password managed by <%= authentication.display_name %></div>
         </div>
       <% else %>
         <%= standard_field form: f, name: :password, type: :password_field, label: "Password *" %>


### PR DESCRIPTION
Made last sign in star show up for Google:

![image](https://cloud.githubusercontent.com/assets/1001691/14374978/2d61747a-fd11-11e5-936b-cde4ac7e9e37.png)

Fixed name and styling on "Password managed by" section of sign up for Google sign up:

![image](https://cloud.githubusercontent.com/assets/1001691/14374988/4357b532-fd11-11e5-9547-83f3ea2dd493.png)

Also fixed the IllegalState exception error we've seen.