### PR TITLE
New sign up page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ config/deploy_settings.yml
 
 # Ignore Cucumber and RSpec failure information
 cucumber_rerun.txt
-rspec.failures
+.rspec_last_failures
 
 Ignore Coveralls reports
 coverage/*

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,10 +9,10 @@
 @import "application_layout";
 @import "font-awesome";
 @import "bootstrap-social";
-@import "signin";
+@import "signinup";
 @import "profile";
 @import "social";
-@import "signup";
+@import "create_account";
 @import "misc";
 @import "application_js_hooks";
 

--- a/app/assets/stylesheets/create_account.scss
+++ b/app/assets/stylesheets/create_account.scss
@@ -1,4 +1,6 @@
-#sign-up {
+
+
+#create-account {
   .password-managed {
     margin-top: 25px;
     margin-bottom: 15px;
@@ -56,3 +58,5 @@
   }
 
 }
+
+

--- a/app/assets/stylesheets/signinup.scss
+++ b/app/assets/stylesheets/signinup.scss
@@ -1,4 +1,6 @@
-#signin {
+.btn-identity       { @include btn-social(#666666); }
+
+#signin, #signup {
 
   $social_button_width: 240px;
 
@@ -79,6 +81,28 @@
       margin-top: 8px;
     }
 
+  }
+
+  #social-signup-message {
+    margin-top:82px;
+
+    .the-message {
+      width: 280px;
+    }
+
+    @media(max-width: 767px) {
+      margin-top: 70px;
+
+      p {
+        @include button-form-group;
+        width: $social_button_width + 10px;
+        margin-bottom: 8px;
+
+        &.dont-want-to-remember {
+          display: none;
+        }
+      }
+    }
   }
 
   #cant-sign-in {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,8 @@
 
     <%= yield :head if content_for?(:head) %>
 
+    <script src="https://cdn.optimizely.com/js/1345615444.js"></script>
+
     <title><%= @page_title + ' - ' if !@page_title.nil? %><%= PAGE_TITLE_SUFFIX %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -51,7 +51,7 @@
         <div class='password-actions'>
           <button type="submit" class="btn btn-primary">Sign in</button>
 
-          <span class='sign-up'><%= link_to "Sign up", signup_password_path %></span>
+          <span class='sign-up'><%= link_to "Sign up", signup_path %></span>
         </div>
 
       <% end %>

--- a/app/views/signup/_new_account.html.erb
+++ b/app/views/signup/_new_account.html.erb
@@ -1,4 +1,4 @@
-<% @parent_col_id = "sign-up" %>
+<% @parent_col_id = "create-account" %>
 
 <% is_social_signup = signed_in? %>
 

--- a/app/views/signup/index.html.erb
+++ b/app/views/signup/index.html.erb
@@ -1,0 +1,54 @@
+<% @hide_session_info = true %>
+
+<% @parent_col_id = "signup" %>
+
+<%= page_heading "Sign up with OpenStax", sub_heading_text: "Access all OpenStax tools and resources" %>
+
+<div id="options" class="row">
+
+  <div id="social-login" class="col-sm-6">
+
+    <div class="button-form-group">
+      <%= link_to "/auth/facebook", class: 'btn btn-block btn-social btn-facebook', id: 'facebook-login-button' do %>
+        <span class="fa fa-facebook"></span> Sign up with Facebook
+      <% end %>
+      <%#= last_signin_mark('facebook') %>
+
+      <%= link_to "/auth/google_oauth2", class: 'btn btn-block btn-social btn-google', id: 'google-login-button' do %>
+        <span class="fa fa-google"></span> Sign up with Google
+      <% end %>
+      <%#= last_signin_mark('google_oauth2') %>
+
+      <%= link_to "/auth/twitter", class: 'btn btn-block btn-social btn-twitter', id: 'twitter-login-button' do %>
+        <span class="fa fa-twitter"></span> Sign up with Twitter
+      <% end %>
+
+      <%= link_to "/signup/password", class: 'btn btn-block btn-social btn-identity', id: 'identity-login-button' do %>
+        <span class="fa fa-key"></span> Sign up with a password
+      <% end %>
+      <%#= last_signin_mark('twitter') %>
+    </div>
+
+  </div>
+
+  <div id="social-signup-message" class="col-sm-6">
+
+
+    <div id="the-message">
+
+      <p class='dont-want-to-remember'><b>Don't want to remember a password?</b><br/>Sign up with Facebook, Google, or Twitter.</p>
+
+      <p class='already-have-account'><b>Already have an account?</b>&nbsp;&nbsp;<%= link_to "Sign in", signin_path %>.</p>
+    </div>
+
+  </div>
+</div>
+
+
+
+<div id="reminders" class="row" style="padding-top:30px">
+  <div class="col-xs-12">
+    <p><i>Don't worry.</i> OpenStax <b>won't post anything</b> to your social network without your permission.</p>
+    <p>If you're on a public computer, <b style="white-space:nowrap">be sure to sign out</b> when you're done!</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Accounts::Application.routes.draw do
   end
 
   namespace 'signup' do
+    get '/', action: :index
     get 'password'
     get 'social'
     post 'social'

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -28,6 +28,19 @@ feature 'User signs up as a local user', js: true do
     expect_sign_in_page
   end
 
+  scenario 'sign up chooser page' do
+    create_application
+    visit_authorize_uri
+
+    expect_sign_in_page
+    click_link 'Sign up'
+    expect(page).to have_content('Sign up with OpenStax')
+    expect(page).to have_content('Facebook')
+    expect(page).to have_content('Google')
+    expect(page).to have_content('Twitter')
+    expect(page).to have_content('a password')
+  end
+
   scenario 'with incorrect password confirmation', js: true do
     visit '/'
     click_password_sign_up

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
     mocks.yield_receiver_to_any_instance_implementation_blocks = true
   end
 
+  config.example_status_persistence_file_path = ".rspec_last_failures"
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -172,6 +172,7 @@ end
 
 def click_password_sign_up
   click_on 'Sign up'
+  click_on 'Sign up with a password'
 end
 
 def expect_sign_in_page


### PR DESCRIPTION
* Makes the "Sign up" link on the main sign in page go to a new page where the user chooses how to sign up.  All other pages remain the same, and this still uses "sign up" and "sign in".
* Adds optimizely
* Adds ability to run `rspec --only-failures`

Full width:

![image](https://cloud.githubusercontent.com/assets/1001691/14583408/dd921442-03d5-11e6-9813-42b286329d1c.png)

Responsive:

![image](https://cloud.githubusercontent.com/assets/1001691/14583423/4a4e3ec6-03d6-11e6-9b75-f85435860992.png)
