### PR TITLE
Email verification by PIN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'quiet_assets'
 
 gem 'openstax_utilities'
 gem 'openstax_api'
-gem 'lev', '~> 2.0.6'
+gem 'lev', '~> 2.2.0'
 
 gem 'jquery-rails'
 
@@ -72,6 +72,7 @@ group :development, :test do
   gem 'capybara-email'
   gem 'poltergeist'
   gem 'coveralls', require: false
+  gem 'shoulda-matchers', require: false
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    active_attr (0.8.5)
-      activemodel (>= 3.0.2, < 5.0)
-      activesupport (>= 3.0.2, < 5.0)
+    active_attr (0.9.0)
+      activemodel (>= 3.0.2, < 5.1)
+      activesupport (>= 3.0.2, < 5.1)
     activemodel (3.2.22)
       activesupport (= 3.2.22)
       builder (~> 3.0.0)
@@ -47,7 +47,7 @@ GEM
     bootstrap-sass (3.1.1.0)
       sass (~> 3.2)
     builder (3.0.4)
-    byebug (8.2.2)
+    byebug (8.2.5)
     capybara (2.6.2)
       addressable
       mime-types (>= 1.16)
@@ -132,7 +132,7 @@ GEM
     jwt (1.2.0)
     keyword_search (1.5.0)
     kgio (2.9.2)
-    lev (2.0.6)
+    lev (2.2.1)
       actionpack (>= 3.0)
       active_attr
       activemodel (>= 3.0)
@@ -151,7 +151,7 @@ GEM
     maruku (0.7.1)
     mime-types (1.25.1)
     mini_portile2 (2.0.0)
-    multi_json (1.11.2)
+    multi_json (1.11.3)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     netrc (0.8.0)
@@ -292,6 +292,8 @@ GEM
     schema_plus (1.7.1)
       activerecord (>= 3.2)
       valuable
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -332,7 +334,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.46)
+    tzinfo (0.3.49)
     uber (0.0.15)
     uglifier (2.1.2)
       execjs (>= 0.3.0)
@@ -371,7 +373,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   keyword_search (~> 1.5.0)
-  lev (~> 2.0.6)
+  lev (~> 2.2.0)
   lograge
   maruku
   omniauth
@@ -393,6 +395,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   sass-rails (~> 3.2.6)
   schema_plus (~> 1.7.1)
+  shoulda-matchers
   smarter_csv
   squeel
   test-unit

--- a/app/access_policies/contact_info_access_policy.rb
+++ b/app/access_policies/contact_info_access_policy.rb
@@ -7,8 +7,10 @@ class ContactInfoAccessPolicy
       !requestor.is_application? && \
       !requestor.is_anonymous? && \
       requestor == contact_info.user
-    when :confirm
+    when :confirm # TODO change to confirm_by_code
       true
+    when :confirm_by_pin
+      requestor.is_human? && requestor == contact_info.user
     else
       false
     end

--- a/app/access_policies/contact_info_access_policy.rb
+++ b/app/access_policies/contact_info_access_policy.rb
@@ -7,8 +7,6 @@ class ContactInfoAccessPolicy
       !requestor.is_application? && \
       !requestor.is_anonymous? && \
       requestor == contact_info.user
-    when :confirm # TODO change to confirm_by_code
-      true
     when :confirm_by_pin
       requestor.is_human? && requestor == contact_info.user
     else

--- a/app/controllers/api/v1/contact_infos_controller.rb
+++ b/app/controllers/api/v1/contact_infos_controller.rb
@@ -1,0 +1,77 @@
+class Api::V1::ContactInfosController < Api::V1::ApiController
+
+  before_filter :get_contact_info, only: [:resend_confirmation, :confirm_by_pin]
+
+  resource_description do
+    api_versions "v1"
+    short_description "Represents a user's contact info (email)"
+    description <<-EOS
+    EOS
+  end
+
+  api :PUT, '/contact_infos/:id/resend_confirmation',
+            'Resends the message with instructions on how to confirm the contact info'
+  description <<-EOS
+    Does not require an input body.  Called by users (or code running on behalf of users).
+
+    This is always a "resend" because a confirmation message is always sent when a
+    contact info is added to an account.
+
+    Returns:
+    * 403 if the contact info is not owned by the current user
+    * 204 if the contact info is owned by the current user and is unconfirmed
+    * 422 if the contact info is owned by the current user but is already confirmed.
+      Includes an `already_confirmed` error message.
+  EOS
+  def resend_confirmation
+    OSU::AccessPolicy.require_action_allowed!(:resend_confirmation, current_api_user, @contact_info)
+    if @contact_info.confirmed?
+      render_api_errors(:already_confirmed)
+    else
+      SendContactInfoConfirmation.call(@contact_info)
+      head :no_content
+    end
+  end
+
+  api :PUT, '/contact_infos/:id/confirm_by_pin', 'Confirm a contact info using a PIN'
+  description <<-EOS
+    Confirm a contact info using a PIN.  Called by users (or code running on behalf of users).
+
+    Returns:
+    * 403 if the contact info is not owned by the current user
+    * 204 if:
+       1. the confirmation is successful (contact info is owned by current user,
+          is unconfirmed, pin confirmation is allowed, pin matches, and was able to
+          mark confirmed), OR
+       2. the contact info is owned by the user and is already confirmed
+    * 422 if the contact info is owned by the user and is unconfirmed but:
+       1. pin confirmation is no longer allowed (out of attempts). Includes a
+          `no_pin_confirmation_attempts_remaining` error message, OR
+       2. the pin is not correct. Includes a `pin_not_correct` error message.
+
+    #{json_schema(Api::V1::ConfirmByPinRepresenter, include: :writeable)}
+  EOS
+  def confirm_by_pin
+    OSU::AccessPolicy.require_action_allowed!(:confirm_by_pin, current_api_user, @contact_info)
+
+    if @contact_info.confirmed?
+      head :no_content
+    else
+      payload = consume!(Hashie::Mash.new, represent_with: Api::V1::ConfirmByPinRepresenter)
+      outputs = ConfirmByPin.call(contact_info: @contact_info, pin: payload.pin)
+
+      if outputs.errors.none?
+        head :no_content
+      else
+        render_api_errors(outputs.errors)
+      end
+    end
+  end
+
+  protected
+
+  def get_contact_info
+    @contact_info = ContactInfo.find(params[:id])
+  end
+
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -98,7 +98,9 @@ class Api::V1::UsersController < Api::V1::ApiController
   def show
     OSU::AccessPolicy.require_action_allowed!(:read, current_api_user,
                                               current_human_user)
-    respond_with current_human_user
+    respond_with current_human_user,
+                 represent_with: Api::V1::UserRepresenter,
+                 render_contact_infos: true
   end
 
   ###############################################################

--- a/app/handlers/contact_infos_confirm.rb
+++ b/app/handlers/contact_infos_confirm.rb
@@ -2,7 +2,9 @@ class ContactInfosConfirm
 
   lev_handler
 
-  uses_routine ConfirmContactInfo
+  uses_routine ConfirmByCode,
+               translations: { outputs: { type: :verbatim },
+                               inputs: { type: :verbatim } }
 
   protected
 
@@ -11,14 +13,7 @@ class ContactInfosConfirm
   end
 
   def handle
-    fatal_error(code: :no_contact_info_for_code,
-                message: 'Unable to verify email address') if params[:code].nil?
-    contact_info = ContactInfo.where(confirmation_code: params[:code]).first
-    fatal_error(code: :no_contact_info_for_code,
-                message: 'Unable to verify email address') if contact_info.nil?
-    outputs[:contact_info] = contact_info
-
-    run(ConfirmContactInfo, contact_info)
+    run(ConfirmByCode, params[:code])
   end
 
 end

--- a/app/handlers/contact_infos_confirm.rb
+++ b/app/handlers/contact_infos_confirm.rb
@@ -2,8 +2,7 @@ class ContactInfosConfirm
 
   lev_handler
 
-  uses_routine MarkContactInfoVerified
-  uses_routine MergeUnclaimedUsers
+  uses_routine ConfirmContactInfo
 
   protected
 
@@ -18,8 +17,8 @@ class ContactInfosConfirm
     fatal_error(code: :no_contact_info_for_code,
                 message: 'Unable to verify email address') if contact_info.nil?
     outputs[:contact_info] = contact_info
-    run(MergeUnclaimedUsers, contact_info)
-    run(MarkContactInfoVerified, contact_info)
+
+    run(ConfirmContactInfo, contact_info)
   end
 
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -2,7 +2,10 @@ class ConfirmationMailer < SiteMailer
 
   def instructions(email_address)
     @email_address = email_address
+    @show_pin = ConfirmByPin.sequential_failure_for(@email_address).attempts_remaining?
+
     mail to: "\"#{email_address.user.full_name}\" <#{email_address.value}>",
-         subject: "Please verify this email address"
+         subject: @show_pin ? "Verify your email address using code #{@email_address.confirmation_pin}" :
+                              "Verify your email address"
   end
 end

--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -26,6 +26,9 @@ class ContactInfo < ActiveRecord::Base
 
   before_save :add_unread_update
 
+  def confirmed;  verified;  end
+  def confirmed?; verified?; end
+
   def to_subclass
     return self unless valid?
     becomes(type.constantize)

--- a/app/models/sequential_failure.rb
+++ b/app/models/sequential_failure.rb
@@ -1,0 +1,30 @@
+class SequentialFailure < ActiveRecord::Base
+  enum kind: [:confirm_by_pin]
+
+  validates :reference, presence: true,
+                        uniqueness: {scope: :kind}
+  validates :length, presence: true
+
+  attr_accessible :kind, :reference, :length
+
+  attr_accessor :num_failures_allowed
+
+  def reset!
+    self.length = 0
+    self.save!
+  end
+
+  def increment!
+    self.length += 1
+    self.save!
+  end
+
+  def attempts_remaining?
+    attempts_remaining > 0
+  end
+
+  def attempts_remaining
+    raise StandardError, "`num_failures_allowed` must be set" if num_failures_allowed.nil?
+    [0, num_failures_allowed - length].max
+  end
+end

--- a/app/representers/api/v1/confirm_by_pin_representer.rb
+++ b/app/representers/api/v1/confirm_by_pin_representer.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class ConfirmByPinRepresenter < Roar::Decorator
+    include Roar::Representer::JSON
+
+    property :pin,
+             type: String,
+             readable: false,
+             writeable: true,
+             schema_info: {
+                required: true,
+                description: 'The confirmation pin'
+             }
+
+  end
+end

--- a/app/representers/api/v1/contact_info_representer.rb
+++ b/app/representers/api/v1/contact_info_representer.rb
@@ -1,0 +1,44 @@
+module Api::V1
+  class ContactInfoRepresenter < Roar::Decorator
+    include Roar::Representer::JSON
+
+    property :id,
+             type: Integer,
+             readable: true,
+             writeable: false,
+             schema_info: {
+               required: true
+             }
+
+    property :type,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: {
+               required: true,
+               description: "Currently can only be 'EmailAddress'"
+             }
+
+    property :value,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: {
+               required: true,
+               description: "E.g. the actual email address string"
+             }
+
+    property :verified,
+             as: :is_verified,
+             readable: true,
+             writeable: false
+
+    property :num_pin_verification_attempts_remaining,
+             type: Integer,
+             readable: true,
+             writeable: false,
+             if: ->(*) { !verified },
+             getter: ->(*) { ConfirmByPin.sequential_failure_for(self).attempts_remaining }
+
+  end
+end

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -35,5 +35,9 @@ module Api::V1
              readable: true,
              writeable: true
 
+    collection :contact_infos,
+               if: ->(args) { args[:render_contact_infos] },
+               decorator: ContactInfoRepresenter
+
   end
 end

--- a/app/routines/add_email_to_user.rb
+++ b/app/routines/add_email_to_user.rb
@@ -29,5 +29,7 @@ class AddEmailToUser
 
     # The confirmation info won't be sent if already verified
     run(SendContactInfoConfirmation, email_address)
+
+    outputs.email = email_address
   end
 end

--- a/app/routines/confirm_by_code.rb
+++ b/app/routines/confirm_by_code.rb
@@ -1,0 +1,30 @@
+class ConfirmByCode
+  lev_routine
+
+  uses_routine ConfirmContactInfo
+
+  protected
+
+  def exec(code)
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') if code.nil?
+
+    contact_info = ContactInfo.where(confirmation_code: code).first
+
+    fatal_error(code: :no_contact_info_for_code,
+                message: 'Unable to verify email address') if contact_info.nil?
+
+    run(ConfirmContactInfo, contact_info)
+
+    # Now that this contact info confirmed by code, re-allow pin confirmation in the future
+    ConfirmByPin.sequential_failure_for(contact_info).reset!
+
+    outputs[:contact_info] = contact_info
+  end
+
+end
+
+
+
+
+

--- a/app/routines/confirm_by_pin.rb
+++ b/app/routines/confirm_by_pin.rb
@@ -1,0 +1,41 @@
+class ConfirmByPin
+  lev_routine
+
+  uses_routine ConfirmContactInfo
+
+  MAX_PIN_FAILURES = 5
+
+  def self.sequential_failure_for(contact_info)
+    SequentialFailure.confirm_by_pin
+                     .find_or_initialize_by_reference(contact_info.value).tap do |sf|
+      sf.num_failures_allowed = MAX_PIN_FAILURES
+    end
+  end
+
+  protected
+
+  def exec(contact_info:, pin:)
+    return if contact_info.confirmed?
+
+    sequential_failure = self.class.sequential_failure_for(contact_info)
+
+    if !sequential_failure.attempts_remaining?
+      fatal_error(code: :no_pin_confirmation_attempts_remaining)
+    else
+      if contact_info.confirmation_pin == pin
+        after_transaction do
+          sequential_failure.reset!
+        end
+
+        run(ConfirmContactInfo, contact_info)
+      else
+        after_transaction do
+          sequential_failure.increment!
+        end
+
+        fatal_error(code: :pin_not_correct)
+      end
+    end
+  end
+
+end

--- a/app/routines/confirm_by_pin.rb
+++ b/app/routines/confirm_by_pin.rb
@@ -23,11 +23,8 @@ class ConfirmByPin
       fatal_error(code: :no_pin_confirmation_attempts_remaining)
     else
       if contact_info.confirmation_pin == pin
-        after_transaction do
-          sequential_failure.reset!
-        end
-
         run(ConfirmContactInfo, contact_info)
+        sequential_failure.reset!
       else
         after_transaction do
           sequential_failure.increment!

--- a/app/routines/confirm_contact_info.rb
+++ b/app/routines/confirm_contact_info.rb
@@ -9,9 +9,6 @@ class ConfirmContactInfo
   def exec(contact_info)
     run(MergeUnclaimedUsers, contact_info)
     run(MarkContactInfoVerified, contact_info)
-
-    # Now that this contact info confirmed, re-allow pin confirmation in the future
-    ConfirmByPin.sequential_failure_for(contact_info).reset!
   end
 
 end

--- a/app/routines/confirm_contact_info.rb
+++ b/app/routines/confirm_contact_info.rb
@@ -1,0 +1,14 @@
+class ConfirmContactInfo
+  lev_routine
+
+  uses_routine MarkContactInfoVerified
+  uses_routine MergeUnclaimedUsers
+
+  protected
+
+  def exec(contact_info)
+    run(MergeUnclaimedUsers, contact_info)
+    run(MarkContactInfoVerified, contact_info)
+  end
+
+end

--- a/app/routines/confirm_contact_info.rb
+++ b/app/routines/confirm_contact_info.rb
@@ -9,6 +9,9 @@ class ConfirmContactInfo
   def exec(contact_info)
     run(MergeUnclaimedUsers, contact_info)
     run(MarkContactInfoVerified, contact_info)
+
+    # Now that this contact info confirmed, re-allow pin confirmation in the future
+    ConfirmByPin.sequential_failure_for(contact_info).reset!
   end
 
 end

--- a/app/routines/send_contact_info_confirmation.rb
+++ b/app/routines/send_contact_info_confirmation.rb
@@ -8,6 +8,7 @@ class SendContactInfoConfirmation
     return if contact_info.verified
 
     contact_info.confirmation_code = SecureRandom.hex(32)
+    contact_info.confirmation_pin = SecureRandom.random_number(1000000).to_s.rjust(6,"0")
 
     case contact_info.type
     when 'EmailAddress'

--- a/app/views/confirmation_mailer/instructions.html.erb
+++ b/app/views/confirmation_mailer/instructions.html.erb
@@ -1,6 +1,17 @@
 <p>Hi <%= @email_address.user.casual_name %>,</p>
 
-<p>Someone just added '<%= @email_address.value %>' to an OpenStax account.  If this was you, please follow the link below to verify that you own this account.</p>
+<p>Someone is trying to add '<%= @email_address.value %>' to an OpenStax account.  If this wasn't you, please disregard this message.</p>
+
+<% if @show_pin %>
+  <p>Enter your 6-digit verification code in the prompt on the OpenStax site you are using to verify your email address:</p>
+
+  <p>Your code: <b><%= @email_address.confirmation_pin %></b></p>
+
+  <p>If you have any trouble using this code, you can also click the link below to verify:</p>
+<% else %>
+  <p>Click on the link below to verify your email address:</p>
+<% end %>
+
 
 <p><%= confirm_url(code: @email_address.confirmation_code) %></p>
 

--- a/app/views/confirmation_mailer/instructions.html.erb
+++ b/app/views/confirmation_mailer/instructions.html.erb
@@ -3,7 +3,7 @@
 <p>Someone is trying to add '<%= @email_address.value %>' to an OpenStax account.  If this wasn't you, please disregard this message.</p>
 
 <% if @show_pin %>
-  <p>Enter your 6-digit verification code in the prompt on the OpenStax site you are using to verify your email address:</p>
+  <p>Enter your 6-digit code in the verification code field in your browser to verify your email address:</p>
 
   <p>Your code: <b><%= @email_address.confirmation_pin %></b></p>
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,7 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
+require 'active_record_enum'
 require 'markdown_wrapper'
 require 'settings'
 require 'sign_in_state'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,13 @@ Accounts::Application.routes.draw do
     resources :group_members, only: [:index], path: 'memberships'
     resources :group_owners, only: [:index], path: 'ownerships'
 
+    resources :contact_infos, only: [] do
+      member do
+        put 'resend_confirmation'
+        put 'confirm_by_pin'
+      end
+    end
+
     if !Rails.env.production?
       get 'raise_exception/:type', to: 'dev#raise_exception'
     end

--- a/db/migrate/20160427052420_create_sequential_failures.rb
+++ b/db/migrate/20160427052420_create_sequential_failures.rb
@@ -1,0 +1,13 @@
+class CreateSequentialFailures < ActiveRecord::Migration
+  def change
+    create_table :sequential_failures do |t|
+      t.integer :kind, null: false
+      t.string :reference, null: false
+      t.integer :length, default: 0
+
+      t.timestamps
+    end
+
+    add_index :sequential_failures, [:kind, :reference], unique: true
+  end
+end

--- a/db/migrate/20160427052709_add_confirmation_pin_to_contact_infos.rb
+++ b/db/migrate/20160427052709_add_confirmation_pin_to_contact_infos.rb
@@ -1,0 +1,6 @@
+class AddConfirmationPinToContactInfos < ActiveRecord::Migration
+  def change
+    add_column :contact_infos, :confirmation_pin, :string
+    add_index :contact_infos, :confirmation_pin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160319003444) do
+ActiveRecord::Schema.define(:version => 20160427052709) do
 
   create_table "application_groups", :force => true do |t|
     t.integer  "application_id",                :null => false
@@ -57,7 +57,9 @@ ActiveRecord::Schema.define(:version => 20160319003444) do
     t.datetime "updated_at",                              :null => false
     t.datetime "confirmation_sent_at"
     t.boolean  "is_searchable",        :default => false
+    t.string   "confirmation_pin"
     t.index ["confirmation_code"], :name => "index_contact_infos_on_confirmation_code", :unique => true
+    t.index ["confirmation_pin"], :name => "index_contact_infos_on_confirmation_pin"
     t.index ["user_id"], :name => "index_contact_infos_on_user_id"
     t.index ["value", "user_id", "type"], :name => "index_contact_infos_on_value_user_id_type", :unique => true
   end
@@ -230,6 +232,15 @@ ActiveRecord::Schema.define(:version => 20160319003444) do
     t.datetime "updated_at",  :null => false
     t.index ["code"], :name => "index_password_reset_codes_on_code", :unique => true
     t.index ["identity_id"], :name => "index_password_reset_codes_on_identity_id", :unique => true
+  end
+
+  create_table "sequential_failures", :force => true do |t|
+    t.integer  "kind",                      :null => false
+    t.string   "reference",                 :null => false
+    t.integer  "length",     :default => 0
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
+    t.index ["kind", "reference"], :name => "index_sequential_failures_on_kind_and_reference", :unique => true
   end
 
   create_table "users", :force => true do |t|

--- a/lib/active_record_enum.rb
+++ b/lib/active_record_enum.rb
@@ -1,0 +1,235 @@
+# Copied from https://github.com/rails/rails/blob/e3ceb28e66ca6e869f8f9778dc42672f48001a90/activerecord/lib/active_record/enum.rb
+# until we upgrade to Rails 4.1+
+
+# Changed from `/object/` to `/hash/`
+require 'active_support/core_ext/hash/deep_dup'
+
+module ActiveRecord
+  # Declare an enum attribute where the values map to integers in the database,
+  # but can be queried by name. Example:
+  #
+  #   class Conversation < ActiveRecord::Base
+  #     enum status: [ :active, :archived ]
+  #   end
+  #
+  #   # conversation.update! status: 0
+  #   conversation.active!
+  #   conversation.active? # => true
+  #   conversation.status  # => "active"
+  #
+  #   # conversation.update! status: 1
+  #   conversation.archived!
+  #   conversation.archived? # => true
+  #   conversation.status    # => "archived"
+  #
+  #   # conversation.status = 1
+  #   conversation.status = "archived"
+  #
+  #   conversation.status = nil
+  #   conversation.status.nil? # => true
+  #   conversation.status      # => nil
+  #
+  # Scopes based on the allowed values of the enum field will be provided
+  # as well. With the above example:
+  #
+  #   Conversation.active
+  #   Conversation.archived
+  #
+  # You can set the default value from the database declaration, like:
+  #
+  #   create_table :conversations do |t|
+  #     t.column :status, :integer, default: 0
+  #   end
+  #
+  # Good practice is to let the first declared status be the default.
+  #
+  # Finally, it's also possible to explicitly map the relation between attribute and
+  # database integer with a +Hash+:
+  #
+  #   class Conversation < ActiveRecord::Base
+  #     enum status: { active: 0, archived: 1 }
+  #   end
+  #
+  # Note that when an +Array+ is used, the implicit mapping from the values to database
+  # integers is derived from the order the values appear in the array. In the example,
+  # <tt>:active</tt> is mapped to +0+ as it's the first element, and <tt>:archived</tt>
+  # is mapped to +1+. In general, the +i+-th element is mapped to <tt>i-1</tt> in the
+  # database.
+  #
+  # Therefore, once a value is added to the enum array, its position in the array must
+  # be maintained, and new values should only be added to the end of the array. To
+  # remove unused values, the explicit +Hash+ syntax should be used.
+  #
+  # In rare circumstances you might need to access the mapping directly.
+  # The mappings are exposed through a class method with the pluralized attribute
+  # name:
+  #
+  #   Conversation.statuses # => { "active" => 0, "archived" => 1 }
+  #
+  # Use that class method when you need to know the ordinal value of an enum:
+  #
+  #   Conversation.where("status <> ?", Conversation.statuses[:archived])
+  #
+  # Where conditions on an enum attribute must use the ordinal value of an enum.
+  module Enum
+    def self.extended(base) # :nodoc:
+      base.class_attribute(:defined_enums, instance_writer: false)
+      base.defined_enums = {}
+    end
+
+    def inherited(base) # :nodoc:
+      base.defined_enums = defined_enums.deep_dup
+      super
+    end
+
+    ##########################################
+    #
+    # Added in from https://github.com/rails/rails/blob/52ce6ece8c8f74064bb64e0a0b1ddd83092718e1/activerecord/lib/active_record/attribute_methods.rb
+    #
+
+    BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
+
+    # A class method is 'dangerous' if it is already (re)defined by Active Record, but
+    # not by any ancestors. (So 'puts' is not dangerous but 'new' is.)
+    def dangerous_class_method?(method_name)
+      BLACKLISTED_CLASS_METHODS.include?(method_name.to_s) || class_method_defined_within?(method_name, Base)
+    end
+
+    def class_method_defined_within?(name, klass, superklass = klass.superclass) # :nodoc:
+      if klass.respond_to?(name, true)
+        if superklass.respond_to?(name, true)
+          klass.method(name).owner != superklass.method(name).owner
+        else
+          true
+        end
+      else
+        false
+      end
+    end
+
+    #
+    ###########################################
+
+    def enum(definitions)
+      klass = self
+      definitions.each do |name, values|
+        # statuses = { }
+        enum_values = ActiveSupport::HashWithIndifferentAccess.new
+        name        = name.to_sym
+
+        # def self.statuses statuses end
+        detect_enum_conflict!(name, name.to_s.pluralize, true)
+        klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
+
+        _enum_methods_module.module_eval do
+          # def status=(value) self[:status] = statuses[value] end
+          klass.send(:detect_enum_conflict!, name, "#{name}=")
+          define_method("#{name}=") { |value|
+            if enum_values.has_key?(value) || value.blank?
+              self[name] = enum_values[value]
+            elsif enum_values.has_value?(value)
+              # Assigning a value directly is not a end-user feature, hence it's not documented.
+              # This is used internally to make building objects from the generated scopes work
+              # as expected, i.e. +Conversation.archived.build.archived?+ should be true.
+              self[name] = value
+            else
+              raise ArgumentError, "'#{value}' is not a valid #{name}"
+            end
+          }
+
+          # def status() statuses.key self[:status] end
+          klass.send(:detect_enum_conflict!, name, name)
+          define_method(name) { enum_values.key self[name] }
+
+          # def status_before_type_cast() statuses.key self[:status] end
+          klass.send(:detect_enum_conflict!, name, "#{name}_before_type_cast")
+          define_method("#{name}_before_type_cast") { enum_values.key self[name] }
+
+          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+          pairs.each do |value, i|
+            enum_values[value] = i
+
+            # def active?() status == 0 end
+            klass.send(:detect_enum_conflict!, name, "#{value}?")
+            define_method("#{value}?") { self[name] == i }
+
+            # def active!() update! status: :active end
+            klass.send(:detect_enum_conflict!, name, "#{value}!")
+            define_method("#{value}!") { update! name => value }
+
+            # scope :active, -> { where status: 0 }
+            klass.send(:detect_enum_conflict!, name, value, true)
+            klass.scope value, -> { klass.where name => i }
+          end
+        end
+        defined_enums[name.to_s] = enum_values
+      end
+    end
+
+    private
+      def _enum_methods_module
+        @_enum_methods_module ||= begin
+          mod = Module.new do
+            private
+              def save_changed_attribute(attr_name, old)
+                if (mapping = self.class.defined_enums[attr_name.to_s])
+                  value = _read_attribute(attr_name)
+                  if attribute_changed?(attr_name)
+                    if mapping[old] == value
+                      clear_attribute_changes([attr_name])
+                    end
+                  else
+                    if old != value
+                      set_attribute_was(attr_name, mapping.key(old))
+                    end
+                  end
+                else
+                  super
+                end
+              end
+          end
+          include mod
+          mod
+        end
+      end
+
+      ENUM_CONFLICT_MESSAGE = \
+        "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
+        "this will generate a %{type} method \"%{method}\", which is already defined " \
+        "by %{source}."
+
+      def detect_enum_conflict!(enum_name, method_name, klass_method = false)
+        if klass_method && dangerous_class_method?(method_name)
+          raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+            enum: enum_name,
+            klass: self.name,
+            type: 'class',
+            method: method_name,
+            source: 'Active Record'
+          }
+        elsif !klass_method && dangerous_attribute_method?(method_name)
+          raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+            enum: enum_name,
+            klass: self.name,
+            type: 'instance',
+            method: method_name,
+            source: 'Active Record'
+          }
+        elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
+          raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+            enum: enum_name,
+            klass: self.name,
+            type: 'instance',
+            method: method_name,
+            source: 'another enum'
+          }
+        end
+      end
+  end
+end
+
+module ActiveRecord
+  class Base
+    extend ActiveRecord::Enum
+  end
+end

--- a/spec/access_policies/contact_info_access_policy_spec.rb
+++ b/spec/access_policies/contact_info_access_policy_spec.rb
@@ -35,19 +35,4 @@ RSpec.describe ContactInfoAccessPolicy do
     end
   end
 
-  context 'confirm' do
-    it 'can be accessed by anyone' do
-      expect(OSU::AccessPolicy.action_allowed?(:confirm, anon,
-                                               contact_info)).to eq true
-      expect(OSU::AccessPolicy.action_allowed?(:confirm, app,
-                                               contact_info)).to eq true
-      expect(OSU::AccessPolicy.action_allowed?(:confirm, temp,
-                                               contact_info)).to eq true
-      expect(OSU::AccessPolicy.action_allowed?(:confirm, user,
-                                               contact_info)).to eq true
-      expect(OSU::AccessPolicy.action_allowed?(:confirm, admin,
-                                               contact_info)).to eq true
-    end
-  end
-
 end

--- a/spec/controllers/api/v1/contact_infos_controller_spec.rb
+++ b/spec/controllers/api/v1/contact_infos_controller_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe Api::V1::ContactInfosController, type: :controller, api: true, version: :v1 do
+
+  let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
+
+  let!(:right_user) { FactoryGirl.create :user }
+  let!(:wrong_user) { FactoryGirl.create :user }
+
+  let!(:right_user_token)    { FactoryGirl.create :doorkeeper_access_token,
+                                                  application: untrusted_application,
+                                                  resource_owner_id: right_user.id }
+  let!(:wrong_user_token)    { FactoryGirl.create :doorkeeper_access_token,
+                                                  application: untrusted_application,
+                                                  resource_owner_id: wrong_user.id }
+
+  let!(:contact_info) {
+    AddEmailToUser.call("bob@example.com", right_user)
+    right_user.contact_infos.first
+  }
+
+  describe "#resend_confirmation" do
+    it "403s if the wrong user makes the request" do
+      expect{
+        api_put :resend_confirmation, wrong_user_token, parameters: {id: contact_info.id}
+      }.to raise_error(SecurityTransgression)
+    end
+
+    it "returns an `already_confirmed` error when confirmed" do
+      ConfirmContactInfo.call(contact_info)
+      api_put :resend_confirmation, right_user_token, parameters: {id: contact_info.id}
+      expect(response).to have_api_error_status(422)
+      expect(response).to have_api_error_code('already_confirmed')
+    end
+
+    it "sends the confirmation if all good" do
+      expect(SendContactInfoConfirmation).to receive(:call).with(contact_info)
+      api_put :resend_confirmation, right_user_token, parameters: {id: contact_info.id}
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  describe "#confirm_by_pin" do
+    it "204s if the pin matches and all stars align" do
+      api_put :confirm_by_pin, right_user_token, parameters: {id: contact_info.id},
+                                                 raw_post_data: {pin: contact_info.confirmation_pin}.to_json
+      expect(contact_info.reload).to be_confirmed
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "403s if the wrong user makes the request" do
+      expect{
+        api_put :confirm_by_pin, wrong_user_token, parameters: {id: contact_info.id}
+      }.to raise_error(SecurityTransgression)
+    end
+
+    it "204s if already confirmed" do
+      ConfirmContactInfo.call(contact_info)
+      api_put :confirm_by_pin, right_user_token, parameters: {id: contact_info.id}
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "422s if incorrect pin" do
+      api_put :confirm_by_pin, right_user_token, parameters: {id: contact_info.id},
+                                                 raw_post_data: {pin: 'blah'}.to_json
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_api_error_status(422)
+      expect(response).to have_api_error_code('pin_not_correct')
+    end
+
+    it "422s if no more pin attempts" do
+      ConfirmByPin::MAX_PIN_FAILURES.times { ConfirmByPin.call(contact_info: contact_info, pin: "whatever") }
+
+      api_put :confirm_by_pin, right_user_token, parameters: {id: contact_info.id},
+                                                 raw_post_data: {pin: 'blah'}.to_json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_api_error_status(422)
+      expect(response).to have_api_error_code('no_pin_confirmation_attempts_remaining')
+    end
+  end
+
+end

--- a/spec/factories/sequential_failures.rb
+++ b/spec/factories/sequential_failures.rb
@@ -1,0 +1,9 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :sequential_failure do
+    type 1
+    reference "MyString"
+    length 1
+  end
+end

--- a/spec/handlers/contact_infos_confirm_spec.rb
+++ b/spec/handlers/contact_infos_confirm_spec.rb
@@ -7,17 +7,17 @@ describe ContactInfosConfirm do
     FactoryGirl.create :email_address
     params = {}
     allow_any_instance_of(ContactInfosConfirm).to receive(:params).and_return(params)
-    expect_any_instance_of(ContactInfosConfirm).not_to receive(:run)
     result = ContactInfosConfirm.handle
     expect(result.errors).to be_present
+    expect(email).not_to be_verified
   end
 
   it 'returns error if confirmation code cannot be found' do
     params = { code: 'random' }
     allow_any_instance_of(ContactInfosConfirm).to receive(:params).and_return(params)
-    expect_any_instance_of(ContactInfosConfirm).not_to receive(:run)
     result = ContactInfosConfirm.handle
     expect(result.errors).to be_present
+    expect(email).not_to be_confirmed
   end
 
   it 'marks email address as verified if confirmation code matches' do

--- a/spec/models/sequential_failure_spec.rb
+++ b/spec/models/sequential_failure_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SequentialFailure, :type => :model do
+  it { is_expected.to validate_presence_of(:length) }
+  it { is_expected.to validate_presence_of(:reference) }
+  subject { SequentialFailure.confirm_by_pin.new }
+  it { is_expected.to validate_uniqueness_of(:reference).scoped_to(:kind) }
+
+  it "resets" do
+    sf = SequentialFailure.confirm_by_pin.create!(reference: 'blah', length: 3)
+    sf.reset!
+    expect(sf.reload.length).to eq 0
+  end
+
+  it "increments" do
+    sf = SequentialFailure.confirm_by_pin.create!(reference: 'blah', length: 3)
+    sf.increment!
+    expect(sf.reload.length).to eq 4
+  end
+
+  it "returns attempts remaining" do
+    sf = SequentialFailure.confirm_by_pin.create!(reference: 'blah', length: 3)
+    sf.num_failures_allowed = 4
+    expect(sf.attempts_remaining).to eq 1
+  end
+
+  it "returns attempts_remaining?" do
+    sf = SequentialFailure.confirm_by_pin.create!(reference: 'blah', length: 3)
+    sf.num_failures_allowed = 4
+    expect(sf.attempts_remaining?).to be_truthy
+    sf.num_failures_allowed = 3
+    expect(sf.attempts_remaining?).to be_falsy
+  end
+
+end

--- a/spec/routines/confirm_by_pin_spec.rb
+++ b/spec/routines/confirm_by_pin_spec.rb
@@ -72,7 +72,7 @@ describe ConfirmByPin do
         described_class.call(contact_info: other_contact_info, pin: other_contact_info.confirmation_pin)
       ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
 
-      ConfirmContactInfo.call(contact_info)
+      ConfirmByCode.call(contact_info.confirmation_code)
 
       described_class.call(contact_info: other_contact_info, pin: other_contact_info.confirmation_pin)
       expect(other_contact_info.reload).to be_confirmed

--- a/spec/routines/confirm_by_pin_spec.rb
+++ b/spec/routines/confirm_by_pin_spec.rb
@@ -59,8 +59,23 @@ describe ConfirmByPin do
       ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
     end
 
-    xit 'can succeed after contact info value confirmed by code' do
+    it 'can succeed after other contact info with same value is confirmed (would be by code)' do
+      other_user = FactoryGirl.create(:user)
+      AddEmailToUser.call("bob@example.com", other_user)
+      other_contact_info = other_user.contact_infos.first
 
+      expect(
+        described_class.call(contact_info: contact_info, pin: contact_info.confirmation_pin)
+      ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
+
+      expect(
+        described_class.call(contact_info: other_contact_info, pin: other_contact_info.confirmation_pin)
+      ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
+
+      ConfirmContactInfo.call(contact_info)
+
+      described_class.call(contact_info: other_contact_info, pin: other_contact_info.confirmation_pin)
+      expect(other_contact_info.reload).to be_confirmed
     end
   end
 

--- a/spec/routines/confirm_by_pin_spec.rb
+++ b/spec/routines/confirm_by_pin_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe ConfirmByPin do
+  let!(:user) { FactoryGirl.create :user }
+
+  let!(:contact_info) {
+    AddEmailToUser.call("bob@example.com", user)
+    user.contact_infos.first
+  }
+
+  context 'when the pin is correct' do
+    it 'confirms on the first try' do
+      expect(contact_info).not_to be_confirmed
+      described_class.call(contact_info: contact_info, pin: contact_info.confirmation_pin)
+      expect(contact_info).to be_confirmed
+    end
+
+    it 'confirms after a bad try' do
+      described_class.call(contact_info: contact_info, pin: "blah")
+      expect(contact_info).not_to be_confirmed
+      described_class.call(contact_info: contact_info, pin: contact_info.confirmation_pin)
+      expect(contact_info).to be_confirmed
+    end
+  end
+
+  it 'eventually runs out of available attempts' do
+    ConfirmByPin::MAX_PIN_FAILURES.times {
+      expect(
+        described_class.call(contact_info: contact_info, pin: "whatever")
+      ).to have_routine_error(:pin_not_correct)
+    }
+
+    expect(
+      described_class.call(contact_info: contact_info, pin: "whatever")
+    ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
+  end
+
+  context 'when number of attempts exhausted' do
+    before(:each) {
+      SequentialFailure.create!(
+        kind: :confirm_by_pin,
+        reference: "bob@example.com",
+        length: ConfirmByPin::MAX_PIN_FAILURES
+      )
+    }
+
+    it 'fails' do
+      expect(
+        described_class.call(contact_info: contact_info, pin: "whatever")
+      ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
+    end
+
+    it 'fails even if multiple contact_infos are used' do
+      contact_info.destroy
+      contact_info = FactoryGirl.create :email_address, value: "bob@example.com"
+
+      expect(
+        described_class.call(contact_info: contact_info, pin: "whatever")
+      ).to have_routine_error(:no_pin_confirmation_attempts_remaining)
+    end
+
+    xit 'can succeed after contact info value confirmed by code' do
+
+    end
+  end
+
+
+end

--- a/spec/routines/send_contact_info_confirmation_spec.rb
+++ b/spec/routines/send_contact_info_confirmation_spec.rb
@@ -27,6 +27,7 @@ describe SendContactInfoConfirmation do
       refetched_email = EmailAddress.find(email.id)
       expect(refetched_email.confirmation_sent_at.utc).to eq(now.utc)
       expect(refetched_email.confirmation_code).not_to be_blank
+      expect(refetched_email.confirmation_pin).not_to be_blank
     end
   end
 


### PR DESCRIPTION
Provides new APIs for getting contact info and confirming (verifying) contact infos.

* Contact info information provided in `GET /api/user` (see API docs)
* `PUT /api/contact_infos/:id/resend_confirmation` (see API docs)
* `PUT /api/contact_infos/:id/confirm` (see API docs)

## Misc
* Updates `lev` to `2.2.1` to get support for `after_transaction` blocks.
* Monkey patched in ActiveRecord enum support from Rails 4.2 :-)
* Added a `to have_routine_error_code` and `to have_routine_error_status` rspec helpers.
* Added should-matchers