### PR TITLE
Admin user search improvements

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class UsersController < BaseController
 
-    before_filter :get_user, only: [:edit, :update, :destroy, :become, :make_admin]
+    before_filter :get_user, only: [:edit, :update, :destroy, :become]
 
     def index
       security_log :users_searched_by_admin, search: params[:search]
@@ -41,16 +41,7 @@ module Admin
       redirect_to request.referrer
     end
 
-    def make_admin
-      if @user.update_attribute(:is_administrator, true)
-        security_log :admin_created, user_id: params[:id], username: @user.username
-        redirect_to request.referrer, notice: 'User successfully updated.'
-      else
-        redirect_to request.referrer, alert: 'Unable to update user.'
-      end
-    end
-
-  protected
+    protected
 
     def get_user
       @user = User.find(params[:id])

--- a/app/routines/admin/search_users.rb
+++ b/app/routines/admin/search_users.rb
@@ -33,7 +33,7 @@ module Admin
     protected
 
     def exec(query, options={})
-      options = options.merge(return_all: true)
+      options = options.merge(admin: true, return_all: true)
       run(:search_users, query, options)
 
       per_page = options[:per_page] || 20

--- a/app/routines/admin/search_users.rb
+++ b/app/routines/admin/search_users.rb
@@ -33,7 +33,7 @@ module Admin
     protected
 
     def exec(query, options={})
-      options = options.merge({:return_all => true})
+      options = options.merge(return_all: true)
       run(:search_users, query, options)
 
       per_page = options[:per_page] || 20

--- a/app/routines/search_application_users.rb
+++ b/app/routines/search_application_users.rb
@@ -1,5 +1,5 @@
 # Routine for searching for ApplicationUsers
-# 
+#
 # Caller provides a query and some options.  The query follows the rules of
 # https://github.com/bruce/keyword_search, e.g.:
 #
@@ -19,18 +19,17 @@
 # for this routine are arrays, not ActiveRecord relations
 
 class SearchApplicationUsers
-  
+
   lev_routine transaction: :no_transaction
 
-  uses_routine ::SearchUsers,
-               as: :search_users
+  uses_routine ::SearchUsers, as: :search_users
 
   protected
 
   def exec(application, query, options={})
     return if application.nil?
 
-    options = options.merge({:return_all => true})
+    options = options.merge(return_all: true)
     users = run(:search_users, query, options).outputs[:items]
 
     per_page = Integer(options[:per_page]) rescue 20

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -7,27 +7,18 @@
   contents = osu.action_list(
     records: users,
     list: {
-      headings: ['Username', 'First Name', 'Last Name', 'Is Admin?', 'Actions'],
-      widths: ['20%', '20%', '20%', '20%', '20%'],
+      headings: ['ID', 'Username', 'First Name', 'Last Name', 'Is Admin?', 'Actions'],
+      widths: ['10%', '20%', '20%', '20%', '10%', '20%'],
       data_procs:
         [
+          Proc.new { |user| user.id.to_s },
           Proc.new do |user|
             security_log_params = { query: "user:\"#{user.username}\"" }
             link_to user.username, admin_security_log_path(search: security_log_params)
           end,
           Proc.new { |user| user.first_name || '---' },
           Proc.new { |user| user.last_name || '---' },
-          Proc.new { |user|
-            if user.is_administrator
-              'Yes'
-            else
-              link_to 'Make them admin',
-                      make_admin_admin_user_path(user),
-                      method: :post,
-                      remote: true,
-                      class: 'make-admin'
-            end
-          },
+          Proc.new { |user| user.is_administrator ? 'Yes' : 'No' },
           Proc.new { |user|
             sign_in_link = link_to 'Sign in as',
                                    become_admin_user_path(user),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,6 @@ Accounts::Application.routes.draw do
 
     resources :users, only: [:index, :update, :edit] do
       post 'become', on: :member
-      post 'make_admin', on: :member
     end
 
     resource :security_log, only: [:show]

--- a/spec/routines/admin/search_security_log_spec.rb
+++ b/spec/routines/admin/search_security_log_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 describe Admin::SearchSecurityLog, type: :routine do
 
   let!(:user)            { FactoryGirl.create :user, first_name: 'Test', last_name: 'User' }
-  let!(:app)             { FactoryGirl.create :doorkeeper_application }
+  let!(:app)             { FactoryGirl.create :doorkeeper_application, name: 'Some Test App' }
 
   let!(:anon_sl)         { FactoryGirl.create :security_log, user: nil }
   let!(:user_sl)         { FactoryGirl.create :security_log, user: user }
   let!(:app_sl)          { FactoryGirl.create :security_log, user: nil, application: app }
   let!(:app_and_user_sl) { FactoryGirl.create :security_log, user: user, application: app }
 
-  let!(:another_app)     { FactoryGirl.create :doorkeeper_application }
+  let!(:another_app)     { FactoryGirl.create :doorkeeper_application, name: 'Another Test App' }
   let!(:ip_sl)           { FactoryGirl.create :security_log, application: another_app,
                                                              remote_ip: '192.168.0.1' }
   let!(:type_sl)         { FactoryGirl.create :security_log, application: another_app,

--- a/spec/routines/admin/search_users_spec.rb
+++ b/spec/routines/admin/search_users_spec.rb
@@ -22,12 +22,9 @@ module Admin
                                                 username: 'bigbear' }
 
     before(:each) do
-      MarkContactInfoVerified.call(user_1.contact_infos.email_addresses.order(:value).first)
-      MarkContactInfoVerified.call(user_4.contact_infos.email_addresses.order(:value).first)
       user_4.contact_infos.email_addresses.order(:value).first.update_attribute(
         :value, 'jstoly292929@hotmail.com'
       )
-      user_1.reload
     end
 
     it "should match based on username" do
@@ -35,9 +32,9 @@ module Admin
       expect(outcome).to eq [user_1]
     end
 
-    it "should ignore leading wildcards on username searches" do
-      outcome = SearchUsers.call('username:%rav').outputs.items.to_a
-      expect(outcome).to eq []
+    it "should prepend leading wildcards on username searches" do
+      outcome = SearchUsers.call('username:rav').outputs.items.to_a
+      expect(outcome).to eq [user_1]
     end
 
     it "should match based on one first name" do
@@ -50,16 +47,10 @@ module Admin
       expect(outcome).to eq [user_2]
     end
 
-    it "should match based on an exact email address" do
-      email = user_1.contact_infos.email_addresses.order(:value).first.value
-      outcome = SearchUsers.call("email:#{email}").outputs.items.to_a
-      expect(outcome).to eq [user_1]
-    end
-
-    it "should not match based on an incomplete email address" do
+    it "should match based on a partial email address" do
       email = user_1.contact_infos.email_addresses.order(:value).first.value.split('@').first
       outcome = SearchUsers.call("email:#{email}").outputs.items.to_a
-      expect(outcome).to eq []
+      expect(outcome).to eq [user_1]
     end
 
     it "should return all results if the query is empty" do
@@ -80,7 +71,7 @@ module Admin
     end
 
     it "shouldn't allow users to add their own wildcards" do
-      outcome = SearchUsers.call("username:'%ar'").outputs.items.to_a
+      outcome = SearchUsers.call("username:'e%r'").outputs.items.to_a
       expect(outcome).to eq []
     end
 

--- a/spec/routines/search_application_users_spec.rb
+++ b/spec/routines/search_application_users_spec.rb
@@ -137,8 +137,7 @@ describe SearchApplicationUsers do
 
     before(:each) do
       [bob_brown, bob_jones, tim_jones].each do |user|
-        FactoryGirl.create :application_user, application: application,
-                                              user: user
+        FactoryGirl.create :application_user, application: application, user: user
       end
     end
 


### PR DESCRIPTION
- Added ID to admin user search results
- Admins can search for partial emails and names containing the query in any position
- Removed Make user admin (can still do it in the Edit user page)
- Removed Make user admin API

Closes #320