### PR TITLE
Handle any invalid characters from omniauth request

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ActiveRecord::Base
 
-  USERNAME_DISCARDED_CHAR_REGEX = /[^A-Za-z\d_]/
+  USERNAME_VALID_REGEX = /\A[A-Za-z\d_]+\z/
   USERNAME_MAX_LENGTH = 50
+  USERNAME_MIN_LENGTH = 3
   VALID_STATES = [
     'temp', # deprecated but still could exist for old accounts
     'new_social',
@@ -34,8 +35,8 @@ class User < ActiveRecord::Base
   before_validation :strip_names
 
   validates :username, presence: true,
-                       length: { minimum: 3, maximum: USERNAME_MAX_LENGTH },
-                       format: { with: /\A[A-Za-z\d_]+\z/,
+                       length: { minimum: USERNAME_MIN_LENGTH, maximum: USERNAME_MAX_LENGTH },
+                       format: { with: USERNAME_VALID_REGEX,
                                  message: "can only contain letters, numbers, and underscores." }
 
   validates :username, uniqueness: { case_sensitive: false },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,13 +58,14 @@ class User < ActiveRecord::Base
 
   before_save :add_unread_update
 
-  def username_is_unique?
-    return false if username.nil?
-    User.where('LOWER(username) = ?', username).none?
+  def self.username_is_valid?(username)
+    user = User.new(username: username)
+    user.valid?
+    user.errors[:username].none?
   end
 
-  def create_random_username(num_digits_in_suffix)
-    "user#{rand(10**num_digits_in_suffix).to_s.rjust(num_digits_in_suffix,'0')}"
+  def self.create_random_username(base:, num_digits_in_suffix:)
+    "#{base}#{rand(10**num_digits_in_suffix).to_s.rjust(num_digits_in_suffix,'0')}"
   end
 
   # Remove this method definition when we upgrade to Rails 4

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
 
-  USERNAME_DISCARDED_CHAR_REGEX = /[^A-Za-z\d_]/
+  USERNAME_VALID_REGEX = /\A[A-Za-z\d_]+\z/
+  USERNAME_MIN_LENGTH = 3
   USERNAME_MAX_LENGTH = 50
   VALID_STATES = [
     'temp', # deprecated but still could exist for old accounts
@@ -34,8 +35,8 @@ class User < ActiveRecord::Base
   before_validation :strip_names
 
   validates :username, presence: true,
-                       length: { minimum: 3, maximum: USERNAME_MAX_LENGTH },
-                       format: { with: /\A[A-Za-z\d_]+\z/,
+                       length: { minimum: USERNAME_MIN_LENGTH, maximum: USERNAME_MAX_LENGTH },
+                       format: { with: USERNAME_VALID_REGEX,
                                  message: "can only contain letters, numbers, and underscores." }
 
   validates :username, uniqueness: { case_sensitive: false },

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -30,36 +30,22 @@ class CreateUser
   end
 
   def generate_unique_valid_username(username)
-    return username if username_is_valid?(username) && username_is_unique?(username)
+    return username if username_is_valid?(username) && User.new(username: username).username_is_unique?
 
     username_max_attempts = 10
 
     username_max_attempts.times do
-      username = create_random_username(7)
-      return username if username_is_unique?(username)
+      username = User.new.create_random_username(7)
+      return username if User.new(username: username).username_is_unique?
     end
 
-    return create_random_username(12) # last-ditch effort
-
-    raise "could not create a unique username after 10 tries"
+    raise "could not create a unique username after #{username_max_attempts} tries"
   end
 
   def username_is_valid?(username)
-    return false if username.nil?
-
-    good_length = (username.length >= User::USERNAME_MIN_LENGTH) && (username.length <= User::USERNAME_MAX_LENGTH)
-    all_valid_chars = username.match(User::USERNAME_VALID_REGEX)
-
-    username_is_valid = good_length && all_valid_chars
-  end
-
-  def username_is_unique?(username)
-    return false if username.nil?
-    User.where('LOWER(username) = ?', username).none?
-  end
-
-  def create_random_username(num_digits_in_suffix)
-    "user#{rand(10**num_digits_in_suffix).to_s.rjust(num_digits_in_suffix,'0')}"
+    user = User.new(username: username)
+    user.valid?
+    user.errors[:username].none?
   end
 
   def guessed_first_name(full_name)

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -35,9 +35,11 @@ class CreateUser
     username_max_attempts = 10
 
     username_max_attempts.times do
-      username = create_random_username
+      username = create_random_username(7)
       return username if username_is_unique?(username)
     end
+
+    return create_random_username(12) # last-ditch effort
 
     raise "could not create a unique username after 10 tries"
   end
@@ -56,8 +58,8 @@ class CreateUser
     User.where('LOWER(username) = ?', username).none?
   end
 
-  def create_random_username
-    "user#{rand(1000000)}"
+  def create_random_username(num_digits_in_suffix)
+    "user#{rand(10**num_digits_in_suffix).to_s.rjust(num_digits_in_suffix,'0')}"
   end
 
   def guessed_first_name(full_name)

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -32,23 +32,14 @@ class CreateUser
   def generate_unique_valid_username(username)
     return username if username_is_valid?(username) && username_is_unique?(username)
 
+    username_max_attempts = 10
+    attempts_count = 0
     loop do
       username = create_random_username
-      break if username_is_unique?(username) || max_attempts_exceeded?
+      break if username_is_unique?(username) || (attempts_count += 1) > username_max_attempts
     end
 
     username
-  end
-
-  def max_attempts_exceeded?
-    @attempts_count ||= 0
-    @attempts_count += 1
-    did_exceed = @attempts_count > username_max_attempts
-    did_exceed
-  end
-
-  def username_max_attempts
-    10
   end
 
   def username_is_valid?(username)

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -33,13 +33,13 @@ class CreateUser
     return username if username_is_valid?(username) && username_is_unique?(username)
 
     username_max_attempts = 10
-    attempts_count = 0
-    loop do
+
+    username_max_attempts.times do
       username = create_random_username
-      break if username_is_unique?(username) || (attempts_count += 1) > username_max_attempts
+      return username if username_is_unique?(username)
     end
 
-    username
+    raise "could not create a unique username after 10 tries"
   end
 
   def username_is_valid?(username)

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -34,10 +34,21 @@ class CreateUser
 
     loop do
       username = create_random_username
-      break if username_is_unique?(username)
+      break if username_is_unique?(username) || max_attempts_exceeded?
     end
 
     username
+  end
+
+  def max_attempts_exceeded?
+    @attempts_count ||= 0
+    @attempts_count += 1
+    did_exceed = @attempts_count > username_max_attempts
+    did_exceed
+  end
+
+  def username_max_attempts
+    10
   end
 
   def username_is_valid?(username)

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -30,22 +30,16 @@ class CreateUser
   end
 
   def generate_unique_valid_username(username)
-    return username if username_is_valid?(username) && User.new(username: username).username_is_unique?
+    return username if User.username_is_valid?(username)
 
     username_max_attempts = 10
 
     username_max_attempts.times do
-      username = User.new.create_random_username(7)
-      return username if User.new(username: username).username_is_unique?
+      username = User.create_random_username(base: "user", num_digits_in_suffix: 7)
+      return username if User.username_is_valid?(username)
     end
 
     raise "could not create a unique username after #{username_max_attempts} tries"
-  end
-
-  def username_is_valid?(username)
-    user = User.new(username: username)
-    user.valid?
-    user.errors[:username].none?
   end
 
   def guessed_first_name(full_name)

--- a/spec/handlers/sessions_callback_spec.rb
+++ b/spec/handlers/sessions_callback_spec.rb
@@ -49,6 +49,18 @@ describe SessionsCallback do
             expect(linked_authentications.first.provider).to eq 'twitter'
             expect(linked_authentications.first.uid).to eq authentication.uid
           end
+
+          it "gracefully handles making a new social user with non-western characters in nickname" do
+            result = SessionsCallback.handle(
+              user_state: user_state,
+              request: MockOmniauthRequest.new(authentication.provider,
+                                               authentication.uid,
+                                               {nickname: "將"})
+            )
+
+            expect(result.errors).to be_empty
+            expect(User.last.username).to match(%r/\Auser\d+\z/)
+          end
         end
       end
 


### PR DESCRIPTION
This PR contains a valid change to how usernames should be handled.

Previously, invalid characters were stripped from the username and we attempted to use the filtered name. However, that code contained a bug when the filtered username turned out to be non-unique.

To correct for this, any time the given username is invalid in any way, a new, unique, and random username is created.

@jpslav 