### PR TITLE
Log out Admins after 30 minutes of inactivity

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def log_out_inactive_admins
-      if current_user.is_administrator?
+      if current_user.is_administrator? && is_real_production_site?
         if session[:last_admin_activity].to_time <= 30.minutes.ago
           sign_out!
           authenticate_admin!

--- a/lib/sign_in_state.rb
+++ b/lib/sign_in_state.rb
@@ -26,6 +26,7 @@ module SignInState
       session[:user_id] = @current_user.id
       cookies.signed[:secure_user_id] = { secure: true,
                                           value: "secure#{@current_user.id}" }
+      session[:last_admin_activity] = DateTime.now.to_s if @current_user.is_administrator?
     end
 
     @current_user

--- a/lib/sign_in_state.rb
+++ b/lib/sign_in_state.rb
@@ -26,7 +26,7 @@ module SignInState
       session[:user_id] = @current_user.id
       cookies.signed[:secure_user_id] = { secure: true,
                                           value: "secure#{@current_user.id}" }
-      session[:last_admin_activity] = DateTime.now.to_s if @current_user.is_administrator?
+      session[:last_admin_activity] = DateTime.now.to_s if @current_user.is_administrator? && is_real_production_site?
     end
 
     @current_user
@@ -52,6 +52,10 @@ module SignInState
       store_url
       redirect_to main_app.signin_path(params.slice(:client_id))
     end
+  end
+
+  def is_real_production_site?
+    request.host == 'accounts.openstax.org'
   end
 
   # Doorkeeper controllers define authenticate_admin!, so we need another name

--- a/spec/controllers/admin/contact_infos_controller_spec.rb
+++ b/spec/controllers/admin/contact_infos_controller_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Admin::ContactInfosController, type: :controller do
   let!(:user) { FactoryGirl.create :user_with_emails }
+  let(:admin) { FactoryGirl.create :user, :admin, :terms_agreed }
+
+  before(:each) do
+    controller.sign_in! admin
+  end
 
   it 'marks contact info as verified' do
     email = user.email_addresses.first

--- a/spec/controllers/admin/security_logs_controller_spec.rb
+++ b/spec/controllers/admin/security_logs_controller_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 describe Admin::SecurityLogsController, type: :controller do
   let(:no_results) { OpenStruct.new(outputs: OpenStruct.new(items: SecurityLog.where('1=0'))) }
+  let(:admin) { FactoryGirl.create :user, :admin, :terms_agreed }
+
+  before(:each) do
+    controller.sign_in! admin
+  end
 
   context 'GET #show' do
     it 'passes an empty hash to Admin::SearchSecurityLog if there is no search query' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe Admin::UsersController, type: :controller do
   let!(:user) { FactoryGirl.create :user }
   let!(:identity) { FactoryGirl.create :identity, user: user }
+  let(:admin) { FactoryGirl.create :user, :admin, :terms_agreed }
+
+  before(:each) do
+    controller.sign_in! admin
+  end
 
   describe 'PUT #update' do
     it 'updates a user' do

--- a/spec/features/log_out_inactive_admins.rb
+++ b/spec/features/log_out_inactive_admins.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
+  let!(:login_time) { DateTime.now }
+
+  before(:each) do
+    Timecop.freeze(login_time)
+  end
+
+  after(:each) do
+    Timecop.return
+  end
+
+  context "logged-in admin user" do
+    before(:each) do
+      create_admin_user
+      visit '/signin'
+      signin_as 'admin'
+    end
+
+    context "within 30mins from login" do
+      scenario 'user IS NOT redirected to login screen when admin feature is accessed' do
+        visit admin_feature_url
+        Timecop.travel(login_time + 29.minutes)
+        visit admin_feature_url
+
+        expect(page).to have_current_path(admin_feature_url)
+      end
+    end
+    context "that HAS NOT accessed any admin features in the past 30mins" do
+      scenario "user IS redirected to login screen when admin feature is accessed" do # Security feature!
+        visit admin_feature_url
+        expect(page).to have_current_path(admin_feature_url)
+        Timecop.travel(login_time + 5.minutes)
+        visit non_admin_feature_url
+        Timecop.travel(login_time + 31.minutes)
+        visit admin_feature_url
+
+        expect(page).to have_current_path(signin_path)
+      end
+    end
+    context "that HAS accessed any admin features in the past 30mins" do
+      scenario "user IS NOT redirected to login screen when admin feature is accessed" do
+        Timecop.travel(login_time + 5.minutes)
+        visit admin_feature_url
+        Timecop.travel(login_time + 26.minutes)
+        visit admin_feature_url
+
+        expect(page).to have_current_path(admin_feature_url)
+      end
+    end
+
+    context "after 30mins from login" do
+      scenario "user IS redirected to login screen when admin feature is accessed" do # Security feature!
+        Timecop.travel(login_time + 31.minutes)
+        visit admin_feature_url
+
+        expect(page).to have_current_path(signin_path)
+      end
+    end
+    context "when accessing only non-admin features" do
+      scenario "user IS NOT redirected to login" do
+        Timecop.travel(login_time + 5.minutes)
+        visit non_admin_feature_url
+        Timecop.travel(login_time + 26.minutes)
+        visit non_admin_feature_url
+        Timecop.travel(login_time + 31.minutes)
+        visit non_admin_feature_url
+
+        expect(page).to have_current_path(non_admin_feature_url)
+      end
+    end
+  end
+
+  context "logged-in non-admin user" do
+    before(:each) do
+      create_user 'user'
+      visit '/signin'
+      signin_as 'user'
+    end
+
+    scenario "user IS NOT redirected to login" do
+      Timecop.travel(login_time + 5.minutes)
+      visit non_admin_feature_url
+      Timecop.travel(login_time + 26.minutes)
+      visit non_admin_feature_url
+      Timecop.travel(login_time + 31.minutes)
+      visit non_admin_feature_url
+
+      expect(page).to have_current_path(non_admin_feature_url)
+    end
+  end
+
+  context "non-logged-in anonymous user" do
+    scenario "cannot access admin features" do
+      visit admin_feature_url
+
+      expect(page).not_to have_current_path(admin_feature_url)
+    end
+    scenario "cannot access non-admin* (required login) features" do
+      visit non_admin_feature_url
+
+      expect(page).to have_current_path(signin_path)
+    end
+    scenario "can access visitor pages" do
+      visit "/copyright"
+
+      expect(page).to have_current_path("/copyright")
+    end
+  end
+
+  def admin_feature_url
+    admin_security_log_path
+  end
+
+  def non_admin_feature_url
+    "/profile"
+  end
+end

--- a/spec/features/log_out_inactive_admins.rb
+++ b/spec/features/log_out_inactive_admins.rb
@@ -4,6 +4,7 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
   let!(:login_time) { DateTime.now }
 
   before(:each) do
+    allow_any_instance_of(ApplicationController).to receive(:is_real_production_site?).and_return(true)
     Timecop.freeze(login_time)
   end
 


### PR DESCRIPTION
If a user with administrator privileges steps away from their computer, a malicious user could take advantage of admin access to every feature. 

This feature is supposed to log admins out after **30 minutes of non-admin activity** for increased security. We don't want to annoy them when they are just using non-admin functionality.