### PR TITLE
Some rate limit improvements

### DIFF
--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -38,6 +38,7 @@ class IdentitiesController < ApplicationController
                   return if !request.post?
                   sign_in! @handler_result.outputs[:identity].user
                   security_log :password_reset
+                  security_log :sign_in_successful
                   redirect_back key: :password_return_to,
                                 notice: 'Your password has been reset successfully! You are now signed in.'
                 end,

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -139,7 +139,7 @@ class SessionsController < ApplicationController
       "The password you provided is incorrect."
     when 'too_many_login_attempts'
       "You have made too many login attempts recently. " \
-      "Please try again later or contact customer support for help."
+      "Please <a href=\"#{signin_help_url}\">reset your password</a> or try again later."
     else
       params[:message]
     end

--- a/spec/features/rate_limit_logins_spec.rb
+++ b/spec/features/rate_limit_logins_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 feature 'User gets blocked after multiple failed login attempts', js: true do
-  let(:max_attempts_per_user) { 3 }
-  let(:max_attempts_per_ip)   { 5 }
+  let(:max_attempts_per_user) { 2 }
+  let(:max_attempts_per_ip)   { max_attempts_per_user + 3 }
 
   background do
     stub_const 'OmniAuth::Strategies::CustomIdentity::MAX_LOGIN_ATTEMPTS_PER_USER',
@@ -11,129 +11,242 @@ feature 'User gets blocked after multiple failed login attempts', js: true do
                max_attempts_per_ip
   end
 
-  scenario 'with a known username' do
-    with_forgery_protection do
-      create_user 'user'
+  context 'with a known username' do
+    scenario 'getting the user unblocked after a password reset' do
+      with_forgery_protection do
+        create_user 'user'
 
-      max_attempts_per_user.times do
-        visit '/'
+        max_attempts_per_user.times do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user'
+          fill_in 'Password', with: SecureRandom.hex
+          click_button 'Sign in'
+          expect(page).to have_content('The password you provided is incorrect.')
+        end
+
+          visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: 'user'
         fill_in 'Password', with: SecureRandom.hex
         click_button 'Sign in'
-        expect(page).to have_content('The password you provided is incorrect.')
-      end
+        expect(page).to have_content('You have made too many login attempts recently.')
 
-        visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: 'user'
-      fill_in 'Password', with: SecureRandom.hex
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: 'user'
-      fill_in 'Password', with: 'password'
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
         visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: 'user'
         fill_in 'Password', with: 'password'
         click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        reset_code = generate_reset_code_for 'user'
+        visit "/reset_password?code=#{reset_code}"
+        expect(page).not_to have_content('Reset password link is invalid')
+        expect(page).to have_content('Confirm Password')
+        fill_in 'Password', with: '1234abcd'
+        fill_in 'Confirm Password', with: '1234abcd'
+        click_button 'Set Password'
+        expect(page).to have_content(
+          'Your password has been reset successfully! You are now signed in.'
+        )
+
+        click_link 'Sign out'
+
+        visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user'
+        fill_in 'Password', with: '1234abcd'
+        click_button 'Sign in'
         expect(page).to have_content('Welcome, user')
+      end
+    end
+
+    scenario 'getting the user unblocked after 1 hour' do
+      with_forgery_protection do
+        create_user 'user'
+
+        max_attempts_per_user.times do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user'
+          fill_in 'Password', with: SecureRandom.hex
+          click_button 'Sign in'
+          expect(page).to have_content('The password you provided is incorrect.')
+        end
+
+          visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user'
+        fill_in 'Password', with: SecureRandom.hex
+        click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user'
+        fill_in 'Password', with: 'password'
+        click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user'
+          fill_in 'Password', with: 'password'
+          click_button 'Sign in'
+          expect(page).to have_content('Welcome, user')
+        end
       end
     end
   end
 
-  scenario 'with a known verified email address' do
-    with_forgery_protection do
-      user = create_user 'user'
-      create_email_address_for user, 'user@example.com'
+  context 'with a known verified email address' do
+    scenario 'getting the user unblocked after a password reset' do
+      with_forgery_protection do
+        user = create_user 'user'
+        create_email_address_for user, 'user@example.com'
 
-      max_attempts_per_user.times do
+        max_attempts_per_user.times do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user@example.com'
+          fill_in 'Password', with: SecureRandom.hex
+          click_button 'Sign in'
+          expect(page).to have_content('The password you provided is incorrect.')
+        end
+
         visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: 'user@example.com'
         fill_in 'Password', with: SecureRandom.hex
         click_button 'Sign in'
-        expect(page).to have_content('The password you provided is incorrect.')
-      end
+        expect(page).to have_content('You have made too many login attempts recently.')
 
-      visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: 'user@example.com'
-      fill_in 'Password', with: SecureRandom.hex
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: 'user@example.com'
-      fill_in 'Password', with: 'password'
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
         visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: 'user@example.com'
         fill_in 'Password', with: 'password'
         click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        reset_code = generate_reset_code_for 'user'
+        visit "/reset_password?code=#{reset_code}"
+        expect(page).not_to have_content('Reset password link is invalid')
+        expect(page).to have_content('Confirm Password')
+        fill_in 'Password', with: '1234abcd'
+        fill_in 'Confirm Password', with: '1234abcd'
+        click_button 'Set Password'
+        expect(page).to have_content(
+          'Your password has been reset successfully! You are now signed in.'
+        )
+
+        click_link 'Sign out'
+
+        visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user@example.com'
+        fill_in 'Password', with: '1234abcd'
+        click_button 'Sign in'
         expect(page).to have_content('Welcome, user')
+      end
+    end
+
+    scenario 'getting the user unblocked after 1 hour' do
+      with_forgery_protection do
+        user = create_user 'user'
+        create_email_address_for user, 'user@example.com'
+
+        max_attempts_per_user.times do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user@example.com'
+          fill_in 'Password', with: SecureRandom.hex
+          click_button 'Sign in'
+          expect(page).to have_content('The password you provided is incorrect.')
+        end
+
+        visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user@example.com'
+        fill_in 'Password', with: SecureRandom.hex
+        click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        visit '/'
+        expect_sign_in_page
+
+        fill_in 'Username', with: 'user@example.com'
+        fill_in 'Password', with: 'password'
+        click_button 'Sign in'
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user@example.com'
+          fill_in 'Password', with: 'password'
+          click_button 'Sign in'
+          expect(page).to have_content('Welcome, user')
+        end
       end
     end
   end
 
-  scenario 'with random usernames' do
-    with_forgery_protection do
-      create_user 'user'
+  context 'with random usernames' do
+    scenario 'getting thier ip unblocked after 1 hour' do
+      with_forgery_protection do
+        create_user 'user'
 
-      max_attempts_per_ip.times do
+        max_attempts_per_ip.times do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: SecureRandom.hex
+          fill_in 'Password', with: SecureRandom.hex
+          click_button 'Sign in'
+          expect(page).to have_content('We have no account for the username or email you provided.')
+        end
+
         visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: SecureRandom.hex
         fill_in 'Password', with: SecureRandom.hex
         click_button 'Sign in'
-        expect(page).to have_content('We have no account for the username or email you provided.')
-      end
+        expect(page).to have_content('You have made too many login attempts recently.')
 
-      visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: SecureRandom.hex
-      fill_in 'Password', with: SecureRandom.hex
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      visit '/'
-      expect_sign_in_page
-
-      fill_in 'Username', with: 'user'
-      fill_in 'Password', with: 'password'
-      click_button 'Sign in'
-      expect(page).to have_content('You have made too many login attempts recently.')
-
-      Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
         visit '/'
         expect_sign_in_page
 
         fill_in 'Username', with: 'user'
         fill_in 'Password', with: 'password'
         click_button 'Sign in'
-        expect(page).to have_content('Welcome, user')
+        expect(page).to have_content('You have made too many login attempts recently.')
+
+        Timecop.freeze(Time.now + OmniAuth::Strategies::CustomIdentity::LOGIN_ATTEMPTS_PERIOD) do
+          visit '/'
+          expect_sign_in_page
+
+          fill_in 'Username', with: 'user'
+          fill_in 'Password', with: 'password'
+          click_button 'Sign in'
+          expect(page).to have_content('Welcome, user')
+        end
       end
     end
   end


### PR DESCRIPTION
- Reduce max failed login attempts per user to 10
- Reset per-user login attempts on successful login (e.g. password reset)
- Link to password reset page in the error message