### PR TITLE
Fix issue #318 NoMethodError from routine add_email_to_user

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,7 +1,7 @@
 
 class SignupController < ApplicationController
 
-  skip_before_filter :authenticate_user!, only: [:password]
+  skip_before_filter :authenticate_user!, only: [:index, :password]
   skip_before_filter :finish_sign_up
 
   fine_print_skip :general_terms_of_use, :privacy_policy

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,7 +1,7 @@
 
 class SignupController < ApplicationController
 
-  skip_before_filter :authenticate_user!
+  skip_before_filter :authenticate_user!, only: [:password]
   skip_before_filter :finish_sign_up
 
   fine_print_skip :general_terms_of_use, :privacy_policy

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe SignupController, type: :controller do
+  let(:params) do
+    {
+      signup: {
+        i_agree: true,
+        username: 'sheep',
+        title: 'Miss',
+        first_name: 'Little',
+        last_name: 'Sheep',
+        email_address: 'sheep@example.org',
+        contract_1_id: FinePrint::Contract.first.id,
+        contract_2_id: FinePrint::Contract.last.id }
+    }
+  end
+
+  let(:user) { FactoryGirl.create :temp_user }
+  let!(:authentication) { FactoryGirl.create :authentication, user: user }
+
+  context "POST social" do
+    it "creates a new user with a social network and redirects on success" do
+      controller.sign_in! user
+      post :social, params
+
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects to login page if user is not logged in" do
+      post :social, params
+
+      expect(response).to redirect_to signin_path
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes issue #318 where routine `add_email_to_user` would return NoMethodError for empty array because signup#social controller would try to run routine without passing it a current user with email_addresses.

I added a before_filter on signup controller, social action, that forces it to have a current user. I also created specs for it, and created the specs file in the first place, as none existed.