### PR TITLE
Better test coverage and bug fix in CreateUser routine

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,7 @@ class User < ActiveRecord::Base
   end
 
   def make_first_user_an_admin
-    return if Rails.env.production?
+    return if Rails.env.production? || Rails.env.test?
     self.is_administrator = true if User.count == 0
   end
 

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -17,7 +17,8 @@ class CreateUser
       username = generate_unique_valid_username(username)
     end
 
-    outputs[:user] = User.create do |user|
+    create_method = ensure_no_errors ? :create! : :create
+    outputs[:user] = User.send(create_method) do |user|
       user.username = username
       user.first_name = first_name.present? ? first_name : guessed_first_name(full_name)
       user.last_name = last_name.present? ? last_name : guessed_last_name(full_name)

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -1,7 +1,7 @@
 require 'openstax_rescue_from'
 
 OpenStax::RescueFrom.configure do |config|
-  config.raise_exceptions = Rails.application.config.consider_all_requests_local
+  config.raise_exceptions = Rails.env.development?
 
   config.app_name = 'Accounts'
   config.app_env = SECRET_SETTINGS[:environment_name]

--- a/spec/controllers/api/v1/application_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/application_groups_controller_spec.rb
@@ -179,7 +179,8 @@ describe Api::V1::ApplicationGroupsController, type: :controller, api: true, ver
     end
 
     it "should not let a user call it through an app" do
-      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
+      api_get :updates, user_2_token
+      expect(response).to have_http_status :forbidden
     end
 
   end
@@ -234,8 +235,10 @@ describe Api::V1::ApplicationGroupsController, type: :controller, api: true, ver
     end
 
     it "should not let a user call it through an app" do
-      expect{api_get :updates, user_2_token}.to raise_error(SecurityTransgression)
-      expect{api_put :updated, user_2_token}.to raise_error(SecurityTransgression)
+      api_get :updates, user_2_token
+      expect(response).to have_http_status :forbidden
+      api_put :updated, user_2_token
+      expect(response).to have_http_status :forbidden
     end
 
   end

--- a/spec/controllers/api/v1/contact_infos_controller_spec.rb
+++ b/spec/controllers/api/v1/contact_infos_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::ContactInfosController, type: :controller, api: true, version:
   describe "#resend_confirmation" do
     it "403s if the wrong user makes the request" do
       api_put :resend_confirmation, wrong_user_token, parameters: {id: contact_info.id}
-      expect(response).to have_http_status 403
+      expect(response).to have_http_status :forbidden
     end
 
     it "returns an `already_confirmed` error when confirmed" do
@@ -63,7 +63,7 @@ describe Api::V1::ContactInfosController, type: :controller, api: true, version:
 
     it "403s if the wrong user makes the request" do
       api_put :confirm_by_pin, wrong_user_token, parameters: {id: contact_info.id}
-      expect(response).to have_http_status 403
+      expect(response).to have_http_status :forbidden
     end
 
     it "204s if already confirmed" do

--- a/spec/controllers/api/v1/contact_infos_controller_spec.rb
+++ b/spec/controllers/api/v1/contact_infos_controller_spec.rb
@@ -21,9 +21,8 @@ describe Api::V1::ContactInfosController, type: :controller, api: true, version:
 
   describe "#resend_confirmation" do
     it "403s if the wrong user makes the request" do
-      expect{
-        api_put :resend_confirmation, wrong_user_token, parameters: {id: contact_info.id}
-      }.to raise_error(SecurityTransgression)
+      api_put :resend_confirmation, wrong_user_token, parameters: {id: contact_info.id}
+      expect(response).to have_http_status 403
     end
 
     it "returns an `already_confirmed` error when confirmed" do
@@ -63,9 +62,8 @@ describe Api::V1::ContactInfosController, type: :controller, api: true, version:
     end
 
     it "403s if the wrong user makes the request" do
-      expect{
-        api_put :confirm_by_pin, wrong_user_token, parameters: {id: contact_info.id}
-      }.to raise_error(SecurityTransgression)
+      api_put :confirm_by_pin, wrong_user_token, parameters: {id: contact_info.id}
+      expect(response).to have_http_status 403
     end
 
     it "204s if already confirmed" do

--- a/spec/controllers/api/v1/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/group_members_controller_spec.rb
@@ -29,17 +29,15 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
 
   context 'index' do
     it 'must not list group memberships without a token' do
-      expect{api_get :index, nil}.to(
-        raise_error(SecurityTransgression))
+      api_get :index, nil
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not list group memberships for an app without a user token' do
-      expect{api_get :index, untrusted_application_token}.to(
-        raise_error(SecurityTransgression))
+      api_get :index, untrusted_application_token
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must list all group memberships for human users' do
@@ -210,37 +208,33 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
 
   context 'create' do
     it 'must not create a group_member without a token' do
-      expect{api_post :create, nil, parameters: {group_id: group_3.id,
-                                                 user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, nil, parameters: {group_id: group_3.id,
+                                                 user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_member for an app without a user token' do
-      expect{api_post :create, untrusted_application_token,
+      api_post :create, untrusted_application_token,
                       parameters: {group_id: group_3.id,
-                                   user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                   user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_member for an unauthorized user' do
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                         user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                         user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
 
       group_3.add_member(user_1)
       controller.current_human_user.reload
 
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must create group_members for authorized users' do
@@ -298,42 +292,38 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
 
   context 'destroy' do
     it 'must not destroy a group_member without a token' do
-      expect{api_delete :destroy, nil,
+      api_delete :destroy, nil,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupMember.where(id: group_member_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_member for an app without a user token' do
-      expect{api_delete :destroy, untrusted_application_token,
+      api_delete :destroy, untrusted_application_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupMember.where(id: group_member_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_member for an unauthorized user' do
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupMember.where(id: group_member_1.id).first).not_to be_nil
 
       group_2.add_member(user_1)
 
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupMember.where(id: group_member_1.id).first).not_to be_nil
     end
 

--- a/spec/controllers/api/v1/group_nestings_controller_spec.rb
+++ b/spec/controllers/api/v1/group_nestings_controller_spec.rb
@@ -29,47 +29,42 @@ describe Api::V1::GroupNestingsController, type: :controller, api: true, version
 
   context 'create' do
     it 'must not create a group_nesting without a token' do
-      expect{api_post :create, nil, parameters: {group_id: group_3.id,
-                                                 member_group_id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, nil, parameters: {group_id: group_3.id,
+                                                 member_group_id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_nesting for an app without a user token' do
-      expect{api_post :create, untrusted_application_token,
+      api_post :create, untrusted_application_token,
                       parameters: {group_id: group_3.id,
-                                   member_group_id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+                                   member_group_id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_nesting for an unauthorized user' do
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          member_group_id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          member_group_id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
 
       group_3.add_owner(user_1)
       controller.current_human_user.reload
 
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          member_group_id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          member_group_id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
 
       GroupOwner.last.destroy
       group_1.add_owner(user_1)
       controller.current_human_user.reload
 
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          member_group_id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          member_group_id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must create group_nestings for authorized users' do
@@ -87,42 +82,38 @@ describe Api::V1::GroupNestingsController, type: :controller, api: true, version
 
   context 'destroy' do
     it 'must not destroy a group_nesting without a token' do
-      expect{api_delete :destroy, nil,
+      api_delete :destroy, nil,
                         parameters: {group_id: group_1.id,
-                                     member_group_id: group_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     member_group_id: group_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupNesting.where(id: group_nesting_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_nesting for an app without a user token' do
-      expect{api_delete :destroy, untrusted_application_token,
+      api_delete :destroy, untrusted_application_token,
                         parameters: {group_id: group_1.id,
-                                     member_group_id: group_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     member_group_id: group_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupNesting.where(id: group_nesting_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_nesting for an unauthorized user' do
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_1.id,
-                                     member_group_id: group_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     member_group_id: group_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupNesting.where(id: group_nesting_1.id).first).not_to be_nil
 
       group_2.add_member(user_1)
 
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_1.id,
-                                     member_group_id: group_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     member_group_id: group_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupNesting.where(id: group_nesting_1.id).first).not_to be_nil
     end
 

--- a/spec/controllers/api/v1/group_owners_controller_spec.rb
+++ b/spec/controllers/api/v1/group_owners_controller_spec.rb
@@ -29,17 +29,15 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
 
   context 'index' do
     it 'must not list group ownerships without a token' do
-      expect{api_get :index, nil}.to(
-        raise_error(SecurityTransgression))
+      api_get :index, nil
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not list group ownerships for an app without a user token' do
-      expect{api_get :index, untrusted_application_token}.to(
-        raise_error(SecurityTransgression))
+      api_get :index, untrusted_application_token
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must list all group ownerships for human users' do
@@ -182,37 +180,33 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
 
   context 'create' do
     it 'must not create a group_owner without a token' do
-      expect{api_post :create, nil, parameters: {group_id: group_3.id,
-                                                 user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, nil, parameters: {group_id: group_3.id,
+                                                 user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_owner for an app without a user token' do
-      expect{api_post :create, untrusted_application_token,
+      api_post :create, untrusted_application_token,
                       parameters: {group_id: group_3.id,
-                                   user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                   user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group_owner for an unauthorized user' do
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
 
       group_3.add_member(user_1)
       controller.current_human_user.reload
 
-      expect{api_post :create, user_1_token, parameters: {group_id: group_3.id,
-                                                          user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, user_1_token, parameters: {group_id: group_3.id,
+                                                          user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must create group_owners for authorized users' do
@@ -269,42 +263,38 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
 
   context 'destroy' do
     it 'must not destroy a group_owner without a token' do
-      expect{api_delete :destroy, nil,
+      api_delete :destroy, nil,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupOwner.where(id: group_owner_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_owner for an app without a user token' do
-      expect{api_delete :destroy, untrusted_application_token,
+      api_delete :destroy, untrusted_application_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupOwner.where(id: group_owner_1.id).first).not_to be_nil
     end
 
     it 'must not destroy a group_owner for an unauthorized user' do
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupOwner.where(id: group_owner_1.id).first).not_to be_nil
 
       group_2.add_member(user_1)
 
-      expect{api_delete :destroy, user_1_token,
+      api_delete :destroy, user_1_token,
                         parameters: {group_id: group_2.id,
-                                     user_id: user_2.id}}.to(
-        raise_error(SecurityTransgression))
+                                     user_id: user_2.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(GroupOwner.where(id: group_owner_1.id).first).not_to be_nil
     end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -251,24 +251,21 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
     end
 
     it 'must not show a private group without a token' do
-      expect{api_get :show, nil, parameters: {id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+    api_get :show, nil, parameters: {id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not show a private group to an app without a user token' do
-      expect{api_get :show, untrusted_application_token, parameters: {id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_get :show, untrusted_application_token, parameters: {id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not show a private group to an unauthorized user' do
-      expect{api_get :show, user_1_token, parameters: {id: group_1.id}}.to(
-        raise_error(SecurityTransgression))
+      api_get :show, user_1_token, parameters: {id: group_1.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must show private groups to authorized users' do
@@ -331,17 +328,15 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
 
   context 'create' do
     it 'must not create a group without a token' do
-      expect{api_post :create, nil}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, nil
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must not create a group for an app without a user token' do
-      expect{api_post :create, untrusted_application_token}.to(
-        raise_error(SecurityTransgression))
+      api_post :create, untrusted_application_token
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
     end
 
     it 'must create groups for users' do
@@ -367,54 +362,49 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
 
   context 'update' do
     it 'must not update a group without a token' do
-      expect{api_put :update, nil,
+      api_put :update, nil,
                      parameters: {id: group_3.id},
-                     raw_post_data: {name: 'MyGroup'}}.to(
-        raise_error(SecurityTransgression))
+                     raw_post_data: {name: 'MyGroup'}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(group_3.reload.name).to eq('Group 3')
     end
 
     it 'must not update a group for an app without a user token' do
-      expect{api_put :update, untrusted_application_token,
+      api_put :update, untrusted_application_token,
                      parameters: {id: group_3.id},
-                     raw_post_data: {name: 'MyGroup'}}.to(
-        raise_error(SecurityTransgression))
+                     raw_post_data: {name: 'MyGroup'}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(group_3.reload.name).to eq('Group 3')
     end
 
     it 'must not update a group for an unauthorized user' do
-      expect{api_put :update, user_1_token,
+      api_put :update, user_1_token,
                      parameters: {id: group_3.id},
-                     raw_post_data: {name: 'MyGroup'}}.to(
-        raise_error(SecurityTransgression))
+                     raw_post_data: {name: 'MyGroup'}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(group_3.reload.name).to eq('Group 3')
 
       group_3.add_member(user_1)
 
-      expect{api_put :update, user_1_token,
+      api_put :update, user_1_token,
                      parameters: {id: group_3.id},
-                     raw_post_data: {name: 'MyGroup'}}.to(
-        raise_error(SecurityTransgression))
+                     raw_post_data: {name: 'MyGroup'}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(group_3.reload.name).to eq('Group 3')
 
       FactoryGirl.create(:group_nesting, container_group: group_3,
                                          member_group: group_2)
       group_2.add_owner(user_1)
 
-      expect{api_put :update, user_1_token,
+      api_put :update, user_1_token,
                      parameters: {id: group_3.id},
-                     raw_post_data: {name: 'MyGroup'}}.to(
-        raise_error(SecurityTransgression))
+                     raw_post_data: {name: 'MyGroup'}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(group_3.reload.name).to eq('Group 3')
     end
 
@@ -432,48 +422,43 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
 
   context 'destroy' do
     it 'must not destroy a group without a token' do
-      expect{api_delete :destroy, nil,
-                        parameters: {id: group_3.id}}.to(
-        raise_error(SecurityTransgression))
+      api_delete :destroy, nil,
+                        parameters: {id: group_3.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(Group.where(id: group_3.id).first).not_to be_nil
     end
 
     it 'must not destroy a group for an app without a user token' do
-      expect{api_delete :destroy, untrusted_application_token,
-                        parameters: {id: group_3.id}}.to(
-        raise_error(SecurityTransgression))
+      api_delete :destroy, untrusted_application_token,
+                        parameters: {id: group_3.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(Group.where(id: group_3.id).first).not_to be_nil
     end
 
     it 'must not destroy a group for an unauthorized user' do
-      expect{api_delete :destroy, user_1_token,
-                        parameters: {id: group_3.id}}.to(
-        raise_error(SecurityTransgression))
+      api_delete :destroy, user_1_token,
+                        parameters: {id: group_3.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(Group.where(id: group_3.id).first).not_to be_nil
 
       group_3.add_member(user_1)
 
-      expect{api_delete :destroy, user_1_token,
-                        parameters: {id: group_3.id}}.to(
-        raise_error(SecurityTransgression))
+      api_delete :destroy, user_1_token,
+                        parameters: {id: group_3.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(Group.where(id: group_3.id).first).not_to be_nil
 
       FactoryGirl.create(:group_nesting, container_group: group_3, member_group: group_2)
       group_2.add_owner(user_1)
 
-      expect{api_delete :destroy, user_1_token,
-                        parameters: {id: group_3.id}}.to(
-        raise_error(SecurityTransgression))
+      api_delete :destroy, user_1_token,
+                        parameters: {id: group_3.id}
 
-      expect(response.body).to be_empty
+      expect(response).to have_http_status :forbidden
       expect(Group.where(id: group_3.id).first).not_to be_nil
     end
 

--- a/spec/controllers/api/v1/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/messages_controller_spec.rb
@@ -71,17 +71,14 @@ describe Api::V1::MessagesController, type: :controller, api: true, version: :v1
     it "does not allow users or untrusted applications to send messages" do
       Mail::TestMailer.deliveries.clear
 
-      expect{
-        api_post :create, user_1_untrusted_token, parameters: message_params
-      }.to raise_error(Lev::SecurityTransgression)
+      api_post :create, user_1_untrusted_token, parameters: message_params
+      expect(response).to have_http_status :forbidden
 
-      expect{
-        api_post :create, user_1_trusted_token, parameters: message_params
-      }.to raise_error(Lev::SecurityTransgression)
+      api_post :create, user_1_trusted_token, parameters: message_params
+      expect(response).to have_http_status :forbidden
 
-      expect{
-        api_post :create, untrusted_application_token, parameters: message_params
-      }.to raise_error(Lev::SecurityTransgression)
+      api_post :create, untrusted_application_token, parameters: message_params
+      expect(response).to have_http_status :forbidden
 
       # These exceptions are no longer "notified" out
       expect(Mail::TestMailer.deliveries.size).to eq(0)

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -109,7 +109,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
     end
 
     it "should not let an application get a User without a token" do
-      expect {api_get :show, trusted_application_token, parameters: {id: admin_user.id}}.to raise_error(SecurityTransgression)
+      api_get :show, trusted_application_token, parameters: {id: admin_user.id}
+      expect(response).to have_http_status :forbidden
     end
 
     it "should return a properly formatted JSON response for low-info user" do
@@ -195,7 +196,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
     end
 
     it "should not let an application update a User without a token" do
-      expect{api_put :update, trusted_application_token, parameters: {id: admin_user.id}}.to raise_error(SecurityTransgression)
+      api_put :update, trusted_application_token, parameters: {id: admin_user.id}
+      expect(response).to have_http_status :forbidden
     end
 
     it "should not let a user's contact info be modified through the users API" do
@@ -249,21 +251,19 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
 
     it "should not create a new user for anonymous" do
       user_count = User.count
-      expect{
-        api_post :find_or_create,
-                 nil,
-                 raw_post_data: {email: 'a-new-email@test.com'}
-      }.to raise_error(SecurityTransgression)
+      api_post :find_or_create,
+               nil,
+               raw_post_data: {email: 'a-new-email@test.com'}
+      expect(response).to have_http_status :forbidden
       expect(User.count).to eq user_count
     end
 
     it "should not create a new user for another user" do
       user_count = User.count
-      expect{
-        api_post :find_or_create,
-                 user_2_token,
-                 raw_post_data: {email: 'a-new-email@test.com'}
-      }.to raise_error(SecurityTransgression)
+      api_post :find_or_create,
+               user_2_token,
+               raw_post_data: {email: 'a-new-email@test.com'}
+       expect(response).to have_http_status :forbidden
       expect(User.count).to eq user_count
     end
 

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -92,8 +92,8 @@ module Oauth
 
     it "should not let a user get someone else's application" do
       controller.sign_in! user
-      expect{get :show, id: untrusted_application_admin.id}.to(
-        raise_error(SecurityTransgression))
+      get :show, id: untrusted_application_admin.id
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin get someone else's application" do
@@ -107,7 +107,8 @@ module Oauth
 
     it "should not let a user get new" do
       controller.sign_in! user
-      expect{ get :new }.to raise_error(SecurityTransgression)
+      get :new
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin get new" do
@@ -118,10 +119,11 @@ module Oauth
 
     it "should not let a user create an application" do
       controller.sign_in! user
-      expect{ post :create, :application => {
+      post :create, :application => {
                 name: 'Some app',
                 redirect_uri: 'http://www.example.com',
-                trusted: true} }.to raise_error(SecurityTransgression)
+                trusted: true}
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin create an application" do
@@ -146,8 +148,8 @@ module Oauth
 
     it "should not let a user edit someone else's application" do
       controller.sign_in! user
-      expect{get :edit, id: untrusted_application_admin.id}.to(
-        raise_error(SecurityTransgression))
+      get :edit, id: untrusted_application_admin.id
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin edit someone else's application" do
@@ -170,7 +172,8 @@ module Oauth
 
     it "should not let a user update someone else's application" do
       controller.sign_in! user
-      expect{post :update, id: untrusted_application_admin.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}}.to raise_error(SecurityTransgression)
+      post :update, id: untrusted_application_admin.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin update someone else's application" do
@@ -184,8 +187,8 @@ module Oauth
 
     it "should not let a user destroy an application" do
       controller.sign_in! user
-      expect{delete :destroy, id: untrusted_application_user.id}.to(
-        raise_error(SecurityTransgression))
+      delete :destroy, id: untrusted_application_user.id
+      expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin destroy an application" do

--- a/spec/controllers/remote_controller_spec.rb
+++ b/spec/controllers/remote_controller_spec.rb
@@ -8,8 +8,10 @@ describe RemoteController, type: :controller do
     render_views
 
     it 'throws when parent is not present or invalid' do
-      expect { get(:iframe) }.to raise_error(SecurityTransgression)
-      expect { get(:iframe, parent: 'foo') }.to raise_error(SecurityTransgression)
+      get(:iframe)
+      expect(response).to have_http_status :forbidden
+      get(:iframe, parent: 'foo')
+      expect(response).to have_http_status :forbidden
     end
 
     it 'loads and sets parent as context' do

--- a/spec/features/add_application_spec.rb
+++ b/spec/features/add_application_spec.rb
@@ -28,6 +28,6 @@ feature 'Add application to accounts', js: true do
     signin_as 'user'
 
     visit '/oauth/applications/new'
-    expect(page).to have_http_status 403
+    expect(page).to have_http_status :forbidden
   end
 end

--- a/spec/features/add_application_spec.rb
+++ b/spec/features/add_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Add application to accounts' do
+feature 'Add application to accounts', js: true do
   scenario 'without logging in' do
     visit '/oauth/applications'
     expect_sign_in_page
@@ -27,6 +27,7 @@ feature 'Add application to accounts' do
     visit '/signin'
     signin_as 'user'
 
-    expect{ visit '/oauth/applications/new' }.to raise_error(StandardError)
+    visit '/oauth/applications/new'
+    expect(page).to have_http_status 403
   end
 end

--- a/spec/features/add_application_spec.rb
+++ b/spec/features/add_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Add application to accounts', js: true do
+feature 'Add application to accounts' do
   scenario 'without logging in' do
     visit '/oauth/applications'
     expect_sign_in_page
@@ -26,15 +26,7 @@ feature 'Add application to accounts', js: true do
     create_user 'user'
     visit '/signin'
     signin_as 'user'
-    expect(page).to have_content('Welcome, user')
-    visit '/oauth/applications'
-    expect(page).to have_content('OAuth Applications')
-    create_new_application
-    expect(page).to have_content('Application created.')
-    expect(page).to have_content('Application: example')
-    expect(page).to have_content('Callback urls: https://localhost/')
-    expect(page.text).to match(/Application Id: [a-z0-9]+/)
-    expect(page.text).to match(/Secret: [a-z0-9]+/)
-    expect(page).to have_content('Trusted? No')
+
+    expect{ visit '/oauth/applications/new' }.to raise_error(StandardError)
   end
 end

--- a/spec/features/log_out_inactive_admins.rb
+++ b/spec/features/log_out_inactive_admins.rb
@@ -15,7 +15,7 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
   context "logged-in admin user" do
     before(:each) do
       create_admin_user
-      visit '/signin'
+      visit signin_path
       signin_as 'admin'
     end
 
@@ -76,7 +76,7 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
   context "logged-in non-admin user" do
     before(:each) do
       create_user 'user'
-      visit '/signin'
+      visit signin_path
       signin_as 'user'
     end
 
@@ -86,6 +86,21 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
       Timecop.travel(login_time + 26.minutes)
       visit non_admin_feature_url
       Timecop.travel(login_time + 31.minutes)
+      visit non_admin_feature_url
+
+      expect(page).to have_current_path(non_admin_feature_url)
+    end
+    scenario "cannot access admin features" do
+      visit admin_feature_url
+
+      expect(page).not_to have_current_path(admin_feature_url)
+    end
+    scenario "can access visitor pages" do
+      visit visitor_page_url
+
+      expect(page).to have_current_path(visitor_page_url)
+    end
+    scenario "can access non-admin (user required login) features when logged in" do
       visit non_admin_feature_url
 
       expect(page).to have_current_path(non_admin_feature_url)
@@ -104,9 +119,9 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
       expect(page).to have_current_path(signin_path)
     end
     scenario "can access visitor pages" do
-      visit "/copyright"
+      visit visitor_page_url
 
-      expect(page).to have_current_path("/copyright")
+      expect(page).to have_current_path(visitor_page_url)
     end
   end
 
@@ -116,5 +131,9 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
 
   def non_admin_feature_url
     "/profile"
+  end
+
+  def visitor_page_url
+    "/copyright"
   end
 end

--- a/spec/features/log_out_inactive_admins.rb
+++ b/spec/features/log_out_inactive_admins.rb
@@ -100,7 +100,7 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
 
       expect(page).to have_current_path(visitor_page_url)
     end
-    scenario "can access non-admin (user required login) features when logged in" do
+    scenario "can access user features" do
       visit non_admin_feature_url
 
       expect(page).to have_current_path(non_admin_feature_url)
@@ -113,7 +113,7 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
 
       expect(page).not_to have_current_path(admin_feature_url)
     end
-    scenario "cannot access non-admin* (required login) features" do
+    scenario "cannot access user features" do
       visit non_admin_feature_url
 
       expect(page).to have_current_path(signin_path)

--- a/spec/features/unknown_route_spec.rb
+++ b/spec/features/unknown_route_spec.rb
@@ -4,12 +4,12 @@ feature 'Unknown route used' do
 
   scenario 'when it is a JSON request' do
     visit '/lkajsdlkjdklfsjldkfjsl.json'
-    expect(page).to have_http_status 404
+    expect(page).to have_http_status :not_found
   end
 
   scenario 'when it is an HTML request' do
     visit '/lkajsdlkjdklfsjldkfjsl'
-    expect(page).to have_http_status 404
+    expect(page).to have_http_status :not_found
   end
 
 end

--- a/spec/features/unknown_route_spec.rb
+++ b/spec/features/unknown_route_spec.rb
@@ -3,15 +3,13 @@ require 'rails_helper'
 feature 'Unknown route used' do
 
   scenario 'when it is a JSON request' do
-    expect{
-      visit '/lkajsdlkjdklfsjldkfjsl.json'
-    }.to raise_error(ActionController::RoutingError)
+    visit '/lkajsdlkjdklfsjldkfjsl.json'
+    expect(page).to have_http_status 404
   end
 
   scenario 'when it is an HTML request' do
-    expect{
-      visit '/lkajsdlkjdklfsjldkfjsl'
-    }.to raise_error(ActionController::RoutingError)
+    visit '/lkajsdlkjdklfsjldkfjsl'
+    expect(page).to have_http_status 404
   end
 
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -5,7 +5,7 @@ feature 'User signs up as a local user', js: true do
     create_application
     visit_authorize_uri
 
-    expect_sign_in_page
+    expect(page.current_url).to include(signin_path)
     click_password_sign_up
     expect(page).to have_content('Create Account')
 
@@ -23,9 +23,9 @@ feature 'User signs up as a local user', js: true do
 
     visit '/'
     click_link 'Sign out'
-    expect_sign_in_page
+    expect(page.current_url).to include(signin_path)
     expect(page).not_to have_content('Welcome, testuser')
-    expect_sign_in_page
+    expect(page.current_url).to include(signin_path)
   end
 
   scenario 'sign up chooser page' do
@@ -224,7 +224,7 @@ feature 'User signs up as a local user', js: true do
     end
 
     visit '/signout'
-    expect_sign_in_page
+    expect(page).to have_current_path signin_path
   end
 
 end

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -3,68 +3,111 @@ require 'rails_helper'
 describe CreateUser do
 
   context "when all validations pass" do
-    it "creates a new user" do
-      expect{
-        CreateUser.call(username: "unclebob", title: "Mr.", first_name: "Robert", last_name: "Martin", state: "activated")
-      }.to change{User.count}.by 1
+    context "when ensure_no_errors is false" do
+      it "creates a new user" do
+        expect{
+          CreateUser.call(username: "unclebob", first_name: "Robert", last_name: "Martin", ensure_no_errors: false, state: "activated")
+        }.to change{User.count}.by 1
+      end
+    end
+
+    context "when ensure_no_errors is true" do
+      it "creates a new user" do
+        expect{
+          CreateUser.call(username: "unclebob", first_name: "Robert", last_name: "Martin", ensure_no_errors: true, state: "activated")
+        }.to change{User.count}.by 1
+      end
     end
   end
 
   context "when validations fail" do
-    context "when ensure_no_errors is false" do
-      it "returns errors on invalid input" do
-        outcome = nil
+    shared_examples "with invalid user state" do
+      it "raises an exception" do
         expect{
-          outcome = CreateUser.call(username: "unclebob", first_name: "Bob", last_name: "Martin", ensure_no_errors: false, state: 'bogus_state!')
-        }.to_not raise_error
-
-        expect(outcome.errors).to_not be_empty
+          CreateUser.call(username: "unclebob", first_name: "Robert", last_name: "Martin", ensure_no_errors: true, state: "bogus_state!")
+          }.to raise_error(StandardError)
       end
-
-      it "fails with an error when the username is taken" do
-        FactoryGirl.create(:user, username: "bubba")
-        outcome = nil
-        expect {
-          outcome = CreateUser.call(username: "bubba", ensure_no_errors: false, state: 'activated')
-        }.to change{User.count}.by 0
-        expect(outcome.errors.has_offending_input?(:username)).to be_truthy
-      end
-
     end
 
-    context "when ensure_no_errors is true" do
-      let(:invalid_input) {
-        last_name = "!@#$%^&*"
-        CreateUser.call(username: "unclebob", first_name: "Bob", last_name: last_name, ensure_no_errors: true, state: 'activated')
-      }
+    context "when ensure_no_errors is false" do
+      it_behaves_like "with invalid user state"
 
-      it "returns no errors" do
-        expect(invalid_input.errors).to be_empty
+      context "with invalid user information" do
+        it "returns errors" do
+          invalid_input = CreateUser.call(username: "!@#$%^&*", first_name: "!@#$%^&*", last_name: "!@#$%^&*", ensure_no_errors: false, state: 'activated')
+          expect(invalid_input.errors).to_not be_empty
+        end
+
+        it "does not raise an exception" do
+          expect{
+              CreateUser.call(username: "!@#$%^&*", first_name: "!@#$%^&*", last_name: "!@#$%^&*", ensure_no_errors: false, state: 'activated')
+            }.to_not raise_error
+        end
       end
 
-      it "can raise an exception" do
-        expect{
-          CreateUser.call(username: "unclebob", first_name: "Bob", last_name: "Martin", ensure_no_errors: true, state: 'bogus_state!')
-        }.to raise_error(StandardError)
-      end
-
-      context "username" do
-        it "succeeds when a username is already taken" do
+      context "when username is already taken" do
+        it "fails with an error" do
           FactoryGirl.create(:user, username: "bubba")
           outcome = nil
           expect {
-            outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
-          }.to change{User.count}.by 1
-          expect(outcome.errors).to be_empty
+            outcome = CreateUser.call(username: "bubba", ensure_no_errors: false, state: 'activated')
+          }.to change{User.count}.by 0
+          expect(outcome.errors.has_offending_input?(:username)).to be_truthy
+        end
+      end
+    end
+
+    context "when ensure_no_errors is true" do
+      it_behaves_like "with invalid user state"
+
+      context "with invalid user information" do
+        it "returns no errors" do
+          invalid_input = CreateUser.call(username: "!@#$%^&*", first_name: "!@#$%^&*", last_name: "!@#$%^&*", ensure_no_errors: true, state: 'activated')
+          expect(invalid_input.errors).to be_empty
         end
 
-        it "succeeds when the sanitized downcased username is already taken" do
-          FactoryGirl.create(:user, username: "Userone")
-          outcome = nil
-          expect {
-            outcome = CreateUser.call(username: "User One", ensure_no_errors: true, state: 'activated')
-          }.to change{User.count}.by 1
+        it "does not raise an exception" do
+          expect{
+            CreateUser.call(username: "!@#$%^&*", first_name: "!@#$%^&*", last_name: "!@#$%^&*", ensure_no_errors: true, state: 'activated')
+          }.to_not raise_error
+        end
+      end
+
+      context "when username is already taken" do
+        it "creates a new user" do
+          FactoryGirl.create(:user, username: "bubba")
+          expect { CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated') }.to change{ User.count }.by 1
+        end
+
+        it "assigns a unique username" do
+          FactoryGirl.create(:user, username: "bubba")
+          outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
+          expect(outcome.outputs.user.username).to_not eq "bubba"
+        end
+
+        it "returns no errors" do
+          FactoryGirl.create(:user, username: "bubba")
+          outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
           expect(outcome.errors).to be_empty
+        end
+      end
+
+      context "when sanitized downcased username is already taken" do
+        it "still creates a new user" do
+          FactoryGirl.create(:user, username: "Userone")
+          expect { CreateUser.call(username: "User One", ensure_no_errors: true, state: 'activated') }.to change{User.count}.by 1
+        end
+
+        it "assigns a unique username" do
+          FactoryGirl.create(:user, username: "bubba")
+          outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
+          expect(outcome.outputs.user.username).to_not eq "bubba"
+        end
+
+        it "returns no errors" do
+          FactoryGirl.create(:user, username: "Usertwo")
+          user_two = CreateUser.call(username: "User Two", ensure_no_errors: true, state: 'activated')
+          expect(user_two.errors).to be_empty
         end
       end
     end

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -2,37 +2,71 @@ require 'rails_helper'
 
 describe CreateUser do
 
-  context "when ensure_no_errors is false" do
-
-    it "fails with an error when the username is taken" do
-      FactoryGirl.create(:user, username: "bubba")
-      outcome = nil
-      expect {
-        outcome = CreateUser.call(username: "bubba", ensure_no_errors: false, state: 'activated')
-      }.to change{User.count}.by 0
-      expect(outcome.errors.has_offending_input?(:username)).to be_truthy
-    end
-
-  end
-
-  context "when ensure_no_errors is true" do
-    it "succeeds when a username is already taken" do
-      FactoryGirl.create(:user, username: "bubba")
-      outcome = nil
-      expect {
-        outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
+  context "when all validations pass" do
+    it "creates a new user" do
+      expect{
+        CreateUser.call(username: "unclebob", title: "Mr.", first_name: "Robert", last_name: "Martin", state: "activated")
       }.to change{User.count}.by 1
-      expect(outcome.errors).to be_empty
-    end
-
-    it "succeeds when the sanitized downcased username is already taken" do
-      FactoryGirl.create(:user, username: "Userone")
-      outcome = nil
-      expect {
-        outcome = CreateUser.call(username: "User One", ensure_no_errors: true, state: 'activated')
-      }.to change{User.count}.by 1
-      expect(outcome.errors).to be_empty
     end
   end
 
+  context "when validations fail" do
+    context "when ensure_no_errors is false" do
+      it "returns errors on invalid input" do
+        outcome = nil
+        expect{
+          outcome = CreateUser.call(username: "unclebob", first_name: "Bob", last_name: "Martin", ensure_no_errors: false, state: 'bogus_state!')
+        }.to_not raise_error
+
+        expect(outcome.errors).to_not be_empty
+      end
+
+      it "fails with an error when the username is taken" do
+        FactoryGirl.create(:user, username: "bubba")
+        outcome = nil
+        expect {
+          outcome = CreateUser.call(username: "bubba", ensure_no_errors: false, state: 'activated')
+        }.to change{User.count}.by 0
+        expect(outcome.errors.has_offending_input?(:username)).to be_truthy
+      end
+
+    end
+
+    context "when ensure_no_errors is true" do
+      let(:invalid_input) {
+        last_name = "!@#$%^&*"
+        CreateUser.call(username: "unclebob", first_name: "Bob", last_name: last_name, ensure_no_errors: true, state: 'activated')
+      }
+
+      it "returns no errors" do
+        expect(invalid_input.errors).to be_empty
+      end
+
+      it "can raise an exception" do
+        expect{
+          CreateUser.call(username: "unclebob", first_name: "Bob", last_name: "Martin", ensure_no_errors: true, state: 'bogus_state!')
+        }.to raise_error(StandardError)
+      end
+
+      context "username" do
+        it "succeeds when a username is already taken" do
+          FactoryGirl.create(:user, username: "bubba")
+          outcome = nil
+          expect {
+            outcome = CreateUser.call(username: "bubba", ensure_no_errors: true, state: 'activated')
+          }.to change{User.count}.by 1
+          expect(outcome.errors).to be_empty
+        end
+
+        it "succeeds when the sanitized downcased username is already taken" do
+          FactoryGirl.create(:user, username: "Userone")
+          outcome = nil
+          expect {
+            outcome = CreateUser.call(username: "User One", ensure_no_errors: true, state: 'activated')
+          }.to change{User.count}.by 1
+          expect(outcome.errors).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -141,6 +141,15 @@ def with_error_pages
   end
 end
 
+def with_show_exceptions_true
+  begin
+    Rails.application.config.action_dispatch.show_exceptions = true
+    yield if block_given?
+  ensure
+    Rails.application.config.action_dispatch.show_exceptions = false
+  end
+end
+
 def click_omniauth_link(provider, options={})
   options[:nickname] ||= 'jimbo'
   options[:uid] ||= '1337'

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -141,15 +141,6 @@ def with_error_pages
   end
 end
 
-def with_show_exceptions_true
-  begin
-    Rails.application.config.action_dispatch.show_exceptions = true
-    yield if block_given?
-  ensure
-    Rails.application.config.action_dispatch.show_exceptions = false
-  end
-end
-
 def click_omniauth_link(provider, options={})
   options[:nickname] ||= 'jimbo'
   options[:uid] ||= '1337'


### PR DESCRIPTION
**Comments for this PR's changes are in a different PR which, for some reason, blew up: https://github.com/openstax/accounts/pull/335**

This PR is an attempt make better specs and to make sure that routine CreateUser does what it's supposed to do.

Previously:
- CreateUser routine would still be able to return errors even when `ensure_no_errors` was `true`. 
- There was no test coverage to make sure that non-admins cannot access admin features.

Now:
- When `ensure_no_errors` is `true` in routine CreateUser, an exception is returned instead when validations fail and we cannot generate or determine a valid input (as we currently do for `username` and `first_name` and `last_name`.
- There is better test coverage in `spec/features/log_out_inactive_admins.rb`
- To do the fixes above, I was forced to change the settings for `rescue_from` which are in an initializer. Previous behavior was that it would raise exception when `Rails.application.config.consider_all_requests_local` was true. Now, it raises exception only in development environment `Rails.env.development?`