### PR TITLE
Fix #262: Handle non-utf-8 characters on an invalid url request

### DIFF
--- a/lib/json_and_string_parameter_filter.rb
+++ b/lib/json_and_string_parameter_filter.rb
@@ -40,15 +40,19 @@ class JsonAndStringParameterFilter
       # no need to do anything with param_value as it's nil
     elsif param_value.is_a?(String)
       if param_key =~ @string_regexp
-        param_value.gsub!(/^.*$/, '[FILTERED]')
+        utf8_encoded(param_value.gsub!(/^.*$/, '[FILTERED]'))
       else
         @value_filters.each do |value_filter|
-          param_value.gsub!(/^.*$/, '[FILTERED]') if value_filter.call(param_value)
+          utf8_encoded(param_value.gsub!(/^.*$/, '[FILTERED]')) if value_filter.call(utf8_encoded(param_value))
         end
       end
     elsif param_value.is_a?(Hash)
       filter_data_by_key(param_value, @string_regexp)
       filter_data_by_value(param_value, @value_filters)
     end
+  end
+
+  def utf8_encoded(input)
+    input.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
   end
 end

--- a/spec/features/unknown_route_spec.rb
+++ b/spec/features/unknown_route_spec.rb
@@ -12,4 +12,10 @@ feature 'Unknown route used' do
     expect(page).to have_http_status :not_found
   end
 
+  scenario "with non-utf-8 characters" do
+    visit "/%E2%EF%BF%BD%A6"
+
+    expect(page).to have_http_status :not_found
+  end
+
 end


### PR DESCRIPTION
This PR fixes bug https://github.com/openstax/accounts/issues/262 where are `routing_error ` occurs with message `"invalid byte sequence in UTF-8"`. 

Previously, file `config/initializers/filter_parameters.rb` did not handle non-utf8 characters. 

I just added method `utf8_encoded` that `encode`s strings into utf8 characters and used it where needed, in that same file.