### PR TITLE
Bug fix in oauth apps controller spec - use https

### DIFF
--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -27,7 +27,7 @@ module Oauth
                                                     :applications, :create])
         render :show
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 
@@ -49,7 +49,7 @@ module Oauth
                                                     :applications, :update])
         redirect_to action: :index
       else
-        render :edit
+        render :edit, status: :unprocessable_entity
       end
     end
 

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -39,7 +39,7 @@ module Oauth
       expect(assigns :application).to be_nil
 
       post :create, :application => {name: 'Some app',
-                                     redirect_uri: 'http://www.example.com',
+                                     redirect_uri: 'https://www.example.com',
                                      trusted: true}
       expect(response.code).to eq('302')
       expect(assigns :application).to be_nil
@@ -48,7 +48,7 @@ module Oauth
       expect(response.code).to eq('302')
       expect(assigns :application).to be_nil
 
-      post :update, id: untrusted_application_user2.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}
+      put :update, id: untrusted_application_user2.id, application: {name: 'Some other name', redirect_uri: 'https://www.example.net', trusted: true}
       expect(response.code).to eq('302')
       expect(assigns :application).to be_nil
 
@@ -121,7 +121,7 @@ module Oauth
       controller.sign_in! user
       post :create, :application => {
                 name: 'Some app',
-                redirect_uri: 'http://www.example.com',
+                redirect_uri: 'https://www.example.com',
                 trusted: true}
       expect(response).to have_http_status :forbidden
     end
@@ -163,25 +163,25 @@ module Oauth
 
     it "should let a user update his own untrusted application" do
       controller.sign_in! user
-      post :update, id: untrusted_application_user.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}
-      expect(response.code).to eq('200')
+      put :update, id: untrusted_application_user.id, application: {name: 'Some other name', redirect_uri: 'https://www.example.net', trusted: true}
+      expect(response).to redirect_to(oauth_applications_path)
       expect(assigns(:application).name).to eq('Some other name')
-      expect(assigns(:application).redirect_uri).to eq('http://www.example.net')
+      expect(assigns(:application).redirect_uri).to eq('https://www.example.net')
       expect(assigns(:application).trusted).to eq(false)
     end
 
     it "should not let a user update someone else's application" do
       controller.sign_in! user
-      post :update, id: untrusted_application_admin.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}
+      put :update, id: untrusted_application_admin.id, application: {name: 'Some other name', redirect_uri: 'https://www.example.net', trusted: true}
       expect(response).to have_http_status :forbidden
     end
 
     it "should let an admin update someone else's application" do
       controller.sign_in! admin
-      post :update, id: untrusted_application_user.id, application: {name: 'Some other name', redirect_uri: 'http://www.example.net', trusted: true}
-      expect(response.code).to eq('200')
+      put :update, id: untrusted_application_user.id, application: {name: 'Some other name', redirect_uri: 'https://www.example.net', trusted: true}
+      expect(response).to redirect_to(oauth_applications_path)
       expect(assigns(:application).name).to eq('Some other name')
-      expect(assigns(:application).redirect_uri).to eq('http://www.example.net')
+      expect(assigns(:application).redirect_uri).to eq('https://www.example.net')
       expect(assigns(:application).trusted).to eq(true)
     end
 


### PR DESCRIPTION
The specs for `oauth/applications_controller.rb` were **not** using https for the `redirect_uri`s. Thus, it was not expecting the appropriate `expect`ations!

It's possible that these specs were created before doorkeeper 2.2.0 or just before PR https://github.com/doorkeeper-gem/doorkeeper/pull/489/files, and that specific change was never accounted for.