### PR TITLE
Account for edge case in logging out inactive admins feature

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -18,7 +18,11 @@ module Admin
 
     def log_out_inactive_admins
       if current_user.is_administrator? && is_real_production_site?
-        if session[:last_admin_activity].to_time <= 30.minutes.ago
+        if session[:last_admin_activity].nil?
+          # logged in as a normal user and then someone made normal user an admin
+          # otherwise, should never be nil for admins who log in as an admin
+          session[:last_admin_activity] = DateTime.now.to_s
+        elsif session[:last_admin_activity].to_time <= 30.minutes.ago
           sign_out!
           authenticate_admin!
         else

--- a/spec/features/log_out_inactive_admins.rb
+++ b/spec/features/log_out_inactive_admins.rb
@@ -125,6 +125,26 @@ feature 'Log out Admins after 30 minutes of non-admin activity', js: true do
     end
   end
 
+  context "non-admin user logs in" do
+    scenario "later someone makes him/her an admin" do
+      current_user = create_user 'user'
+      visit signin_path
+      signin_as 'user'
+      expect(current_user.is_administrator?).to eq false
+
+      Timecop.travel(login_time + 31.minutes)
+      visit non_admin_feature_url
+
+      current_user.is_administrator = true
+      current_user.save
+      expect(current_user.is_administrator?).to eq true
+
+      visit admin_feature_url
+
+      expect(page).to have_http_status :success
+    end
+  end
+
   def admin_feature_url
     admin_security_log_path
   end


### PR DESCRIPTION
If logged in as a `normal user` and then someone made `normal user` an `admin`, page would raise/return a 500 error.

Now, we check for `session[:last_admin_activity]` being `nil` (which *should* only occur in this edge case!) and if it is, set the `session[:last_admin_activity]`.