### PR TITLE
Disable Click to verify button on click

### DIFF
--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -24,11 +24,15 @@ class Email
 
   sendVerification: (ev) ->
     ev.preventDefault()
+    ev.target.disabled = true
     $.ajax({type: "PUT", url: @url('resend_confirmation')})
       .success( (resp) =>
         OX.Alert.display(message: resp.message, type: 'success', parentEl: @$el)
       )
-      .error(OX.Alert.displayInsideElement(@$el))
+      .error( (e) =>
+        OX.Alert.display(_.extend(e, parentEl: @$el))
+        ev.target.disabled = false
+      )
 
   saveSearchable: (ev) ->
     @toggleSpinner(true)

--- a/app/assets/stylesheets/profile.css.scss
+++ b/app/assets/stylesheets/profile.css.scss
@@ -92,7 +92,18 @@
         margin-left: 6px;
       }
     }
-    .verify { margin-left: 20px; }
+    .verify {
+      margin-left: 20px;
+      form {
+        display: inline;
+        div { display: inline; }
+      }
+      input {
+        color: $link-color;
+        padding: 0;
+        font-size: 13px;
+      }
+    }
     &.new {
       .verify, .properties, .mod-holder { display: none; }
     }

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -35,7 +35,7 @@ module ProfileHelper
   end
 
   def email_entry(value:, id:, is_verified:, is_searchable:)
-    verify_link = is_verified ? '' : "<span class='verify'>(#{link_to('Click to verify', resend_confirmation_contact_info_path(id))})</span>"
+    verify_link = is_verified ? '' : "<span class='verify'>(#{button_to('Click to verify', resend_confirmation_contact_info_path(id), method: :put ) })</span>"
     (
       <<-SNIPPET
         <div class="email-entry controls-hidden" data-id="#{id}">

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -20,7 +20,7 @@ feature 'User manages emails', js: true do
         find('input').set('user@mysite.com')
         find('.glyphicon-ok').click
       }
-      expect(page).to have_content('Click to verify')
+      expect(page).to have_button('Click to verify')
       expect(page).to have_content('user@mysite.com')
     end
 
@@ -59,8 +59,9 @@ feature 'User manages emails', js: true do
 
   context 'resend_confirmation' do
     scenario 'success' do
-      click_link 'Click to verify'
+      click_button 'Click to verify'
       expect(page).to have_content('A verification message has been sent to "')
+      expect(page).to have_button('Click to verify', disabled: true)
     end
   end
 end


### PR DESCRIPTION
This PR helps prevent bots from clicking the `Click to verify` button (or in other words, following the URL) which sends emails to verify the logged in user's email address. The problem it presents otherwise is that the database will give the following error:
```
An ActiveRecord::StatementInvalid occurred in contact_infos#resend_confirmation:

  PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block
: SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
  activerecord (3.2.22) lib/active_record/connection_adapters/postgresql_adapter.rb:650:in async_exec
```