### PR TITLE
Temporary fix for issue 308

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -84,6 +84,11 @@ class SessionsController < ApplicationController
           redirect_to profile_path, alert: "That sign in option is already used by someone " \
                                            "else. If that someone is you, remove it from " \
                                            "your other account and try again."
+        when :same_provider
+          security_log :authentication_transfer_failed, authentication_id: authentication.id
+          redirect_to profile_path, alert: "You are logged in as #{current_user.name}. A different #{authentication.provider} account " \
+                                            "is already linked to your OpenStax account. Only one #{authentication.provider} account " \
+                                            "can be linked to your OpenStax account at a time."
         else
           Rails.logger.fatal "IllegalState: OAuth data: #{request.env['omniauth.auth']}"
           raise IllegalState, "SessionsCreate errors: #{@handler_result.errors.inspect

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -3,7 +3,7 @@ class Authentication < ActiveRecord::Base
 
   belongs_to :user, inverse_of: :authentications
 
-  validates :provider, presence: true
+  validates :provider, presence: true, uniqueness: { scope: :user_id }
   validates :uid, presence: true, uniqueness: { scope: :provider }
 
   before_destroy :check_not_last

--- a/app/routines/transfer_authentications.rb
+++ b/app/routines/transfer_authentications.rb
@@ -10,7 +10,9 @@ class TransferAuthentications
     authentications = [authentications] if !(authentications.is_a? Array)
     authentications.each do |authentication|
       authentication_user = authentication.user
-      authentication.update_attribute(:user_id, target_user.id)
+      authentication.update_attributes(user_id: target_user.id)
+      transfer_errors_from(authentication, {type: :verbatim}, true)
+
       run(DestroyUser, authentication_user) \
         if authentication_user && !authentication_user.is_activated? && \
            authentication_user.reload.authentications.empty?

--- a/db/migrate/20160906231547_add_index_on_uid_and_provider_in_authentications.rb
+++ b/db/migrate/20160906231547_add_index_on_uid_and_provider_in_authentications.rb
@@ -1,0 +1,8 @@
+class AddIndexOnUidAndProviderInAuthentications < ActiveRecord::Migration
+  def change
+    add_index :authentications,
+              [:uid, :provider],
+              name: 'index_authentications_on_uid_scoped',
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160509181733) do
+ActiveRecord::Schema.define(:version => 20160906231547) do
 
   create_table "application_groups", :force => true do |t|
     t.integer  "application_id",                :null => false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(:version => 20160509181733) do
     t.string   "uid"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.index ["uid", "provider"], :name => "index_authentications_on_uid_scoped", :unique => true
     t.index ["user_id", "provider"], :name => "index_authentications_on_user_id_scoped", :unique => true
   end
 

--- a/spec/handlers/sessions_create_spec.rb
+++ b/spec/handlers/sessions_create_spec.rb
@@ -356,6 +356,59 @@ describe SessionsCreate, type: :handler do
             end
           end
         end
+
+        context "linked to no one" do
+          context "but user already has already authenticated with the same provider before" do
+            context "new_social user" do
+              let!(:signed_in_user) { FactoryGirl.create(:new_social_user) }
+              let!(:authentication) { FactoryGirl.create(:authentication, user: signed_in_user) }
+
+              it "returns a status output instead of an exception or errors" do
+                handle_with_uid(111)
+
+                same_provider_different_uid = nil
+                expect{same_provider_different_uid = handle_with_uid(222)}.not_to raise_exception
+                expect(same_provider_different_uid.outputs[:status]).to eq :same_provider
+                expect(same_provider_different_uid.errors).to be_empty
+              end
+            end
+
+            context "temp user" do
+              let!(:signed_in_user) { FactoryGirl.create(:temp_user) }
+              let!(:authentication) { FactoryGirl.create(:authentication, user: signed_in_user) }
+
+              it "returns a status output instead of an exception or errors" do
+                handle_with_uid(111)
+
+                same_provider_different_uid = nil
+                expect{same_provider_different_uid = handle_with_uid(222)}.not_to raise_exception
+                expect(same_provider_different_uid.outputs[:status]).to eq :same_provider
+                expect(same_provider_different_uid.errors).to be_empty
+              end
+            end
+
+            context "non-temp user" do
+              let!(:signed_in_user) { FactoryGirl.create(:user) }
+              let!(:authentication) { FactoryGirl.create(:authentication, user: signed_in_user) }
+
+              it "returns a status output instead of an exception or errors" do
+                handle_with_uid(111)
+
+                same_provider_different_uid = nil
+                expect{same_provider_different_uid = handle_with_uid(222)}.not_to raise_exception
+                expect(same_provider_different_uid.outputs[:status]).to eq :same_provider
+                expect(same_provider_different_uid.errors).to be_empty
+              end
+            end
+          end
+
+          def handle_with_uid(uid)
+            described_class.handle(
+                              user_state: user_state,
+                              request: MockOmniauthRequest.new(authentication.provider, uid, {})
+                            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Referenced in [Trello](https://trello.com/c/pxA70dpY/79-accounts-explodes-if-you-try-to-add-the-same-oauth-provider-twice)

_Accounts seems to explode with a 500 when the same OAuth provider is added to a user's account twice. Error comes from uniqueness constraint in the database_