### PR TITLE
Pull faculty verification from Salesforce

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,14 @@ gem 'will_paginate'
 # Datetime parsing
 gem 'chronic'
 
+# Salesforce
+gem 'restforce'
+gem 'omniauth-salesforce'
+# Fork that supports Ruby >= 2.1
+gem 'active_force', github: 'openstax/active_force', ref: '9695896f5'
+
+gem 'redis-rails'
+
 # Protect attributes from mass-assignment in Active Record models
 # Bringing back the feature from Rails 3
 gem 'protected_attributes'
@@ -162,7 +170,7 @@ group :test do
 
   # CodeClimate integration
   gem "codeclimate-test-reporter", require: false
-
+  gem 'fakeredis'
   # Headless Capybara webkit driver
   gem 'capybara-webkit'
 

--- a/Gemfile
+++ b/Gemfile
@@ -109,8 +109,6 @@ gem 'omniauth-salesforce'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', github: 'openstax/active_force', ref: '9695896f5'
 
-gem 'redis-rails'
-
 gem 'awesome_print'
 
 gem 'whenever', require: false
@@ -172,7 +170,6 @@ group :test do
 
   # CodeClimate integration
   gem "codeclimate-test-reporter", require: false
-  gem 'fakeredis'
   gem 'db-query-matchers'
   # Headless Capybara webkit driver
   gem 'capybara-webkit'

--- a/Gemfile
+++ b/Gemfile
@@ -171,6 +171,7 @@ group :test do
   # CodeClimate integration
   gem "codeclimate-test-reporter", require: false
   gem 'fakeredis'
+  gem 'db-query-matchers'
   # Headless Capybara webkit driver
   gem 'capybara-webkit'
 

--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ gem 'omniauth-salesforce'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', github: 'openstax/active_force', ref: '9695896f5'
 
+# Allows 'ap' alternative to 'pp', used in a mailer
 gem 'awesome_print'
 
 gem 'whenever', require: false
@@ -130,9 +131,6 @@ group :development, :test do
 
   # Show failing parallel specs instantly
   gem 'rspec-instafail'
-
-  # Allows 'ap' alternative to 'pp'
-  gem 'awesome_print'
 
   # Thin development server
   gem 'thin'

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,8 @@ gem 'redis-rails'
 
 gem 'awesome_print'
 
+gem 'whenever', require: false
+
 gem 'protected_attributes'
 
 # Fast JSON parsing

--- a/Gemfile
+++ b/Gemfile
@@ -111,8 +111,8 @@ gem 'active_force', github: 'openstax/active_force', ref: '9695896f5'
 
 gem 'redis-rails'
 
-# Protect attributes from mass-assignment in Active Record models
-# Bringing back the feature from Rails 3
+gem 'awesome_print'
+
 gem 'protected_attributes'
 
 # Fast JSON parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/openstax/active_force.git
+  revision: 9695896f576ea850d6ca60fb7b8af9c0dd07e8ea
+  ref: 9695896f5
+  specs:
+    active_force (0.7.1)
+      active_attr (~> 0.8)
+      restforce (~> 2.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -142,6 +151,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
     ffi (1.9.14)
     fine_print (3.1.0)
       action_interceptor (>= 1.0)
@@ -228,6 +239,9 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-salesforce (1.0.5)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.0)
     omniauth-twitter (1.2.1)
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
@@ -304,6 +318,11 @@ GEM
       uber (~> 0.0.15)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    restforce (2.1.3)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.8.8)
+      hashie (>= 1.2.0, < 4.0)
+      json (>= 1.7.5, < 1.9.0)
     roar (1.0.3)
       representable (>= 2.0.1, <= 3.0.0)
     roar-rails (1.0.1)
@@ -431,6 +450,7 @@ PLATFORMS
 
 DEPENDENCIES
   action_interceptor (~> 1.1.0)
+  active_force!
   apipie-rails (~> 0.1.2)
   awesome_print
   aws-ses (~> 0.6.0)
@@ -465,6 +485,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   omniauth-identity
+  omniauth-salesforce
   omniauth-twitter
   openstax_api (~> 8.0.0)
   openstax_rescue_from (~> 1.6.0)
@@ -477,6 +498,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.7.1)
   representable (~> 3.0.0)
+  restforce
   rspec-instafail
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
@@ -491,8 +513,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   unicorn-worker-killer
-  whenever
   web-console (~> 2.0)
+  whenever
   will_paginate
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,6 +419,8 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     will_paginate (3.1.3)
     xml-simple (1.1.5)
     xpath (2.0.0)
@@ -489,6 +491,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   unicorn-worker-killer
+  whenever
   web-console (~> 2.0)
   will_paginate
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       addressable
     daemons (1.2.4)
     database_cleaner (1.5.3)
+    db-query-matchers (0.6.0)
     debug_inspector (0.0.2)
     declarative (0.0.8)
       uber (>= 0.0.15)
@@ -443,6 +444,7 @@ DEPENDENCIES
   coveralls
   daemons
   database_cleaner
+  db-query-matchers
   delayed_job_active_record
   doorkeeper (= 2.2.2)
   dotenv-rails

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,0 +1,4 @@
+//= require jquery
+//= require jquery_ujs
+//= require bootstrap
+//= require application/ui

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,13 @@
+@import "bootstrap";
+@import "common_colors";
+@import "admin_navbar";
+
+.underlined-spaced-row {
+  border-bottom: 1px solid gray;
+  padding-bottom: 20px;
+  margin-bottom: 20px
+}
+
+nav.navbar.production {
+  border-bottom: 2px solid red;
+}

--- a/app/assets/stylesheets/admin_navbar.scss
+++ b/app/assets/stylesheets/admin_navbar.scss
@@ -1,0 +1,8 @@
+.admin {
+  .navbar {
+    a {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+  }
+}

--- a/app/controllers/admin/console_controller.rb
+++ b/app/controllers/admin/console_controller.rb
@@ -1,0 +1,7 @@
+module Admin
+  class ConsoleController < BaseController
+    layout 'admin'
+
+    def index; end
+  end
+end

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -16,5 +16,13 @@ module Admin
       redirect_to admin_salesforce_path
     end
 
+    def update_users
+      UpdateUserSalesforceInfo.call
+
+      flash[:notice] = "The update completed."
+
+      redirect_to admin_salesforce_path
+    end
+
   end
 end

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -6,8 +6,7 @@ module Admin
     end
 
     def callback
-      user = SalesforceUser.save_from_omniauth!(env["omniauth.auth"])
-      SalesforceUser.all.reject{|uu| uu.id == user.id}.each(&:destroy)
+      SalesforceUser.save_from_omniauth!(env["omniauth.auth"])
       redirect_to admin_salesforce_path
     end
 

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -13,14 +13,13 @@ module Admin
 
     def destroy_user
       SalesforceUser.destroy_all
+      ActiveForce.clear_sfdc_client! # since user is now gone, any client invalid
       redirect_to admin_salesforce_path
     end
 
     def update_users
       UpdateUserSalesforceInfo.call
-
       flash[:notice] = "The update completed."
-
       redirect_to admin_salesforce_path
     end
 

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class SalesforceController < BaseController
+    def callback
+      user = SalesforceUser.save_from_omniauth!(env["omniauth.auth"])
+      SalesforceUser.all.reject{|uu| uu.id == user.id}.each(&:destroy)
+      redirect_to admin_salesforce_path
+    end
+
+    def destroy_user
+      SalesforceUser.destroy_all
+      redirect_to admin_salesforce_path
+    end
+
+    protected
+
+    def salesforce_path
+      admin_salesforce_path
+    end
+
+  end
+end

--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -1,5 +1,10 @@
 module Admin
   class SalesforceController < BaseController
+    layout 'admin'
+
+    def show
+    end
+
     def callback
       user = SalesforceUser.save_from_omniauth!(env["omniauth.auth"])
       SalesforceUser.all.reject{|uu| uu.id == user.id}.each(&:destroy)
@@ -9,12 +14,6 @@ module Admin
     def destroy_user
       SalesforceUser.destroy_all
       redirect_to admin_salesforce_path
-    end
-
-    protected
-
-    def salesforce_path
-      admin_salesforce_path
     end
 
   end

--- a/app/controllers/admin/security_logs_controller.rb
+++ b/app/controllers/admin/security_logs_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class SecurityLogsController < BaseController
+    layout 'admin'
 
     def show
       items = SearchSecurityLog.call(params[:search] || {}).outputs.items || SecurityLog.none

--- a/app/controllers/api/v1/application_users_controller.rb
+++ b/app/controllers/api/v1/application_users_controller.rb
@@ -88,7 +88,9 @@ class Api::V1::ApplicationUsersController < Api::V1::ApiController
     OSU::AccessPolicy.require_action_allowed!(:search, current_api_user, ApplicationUser)
     options = params.slice(:page, :per_page, :order_by)
     outputs = SearchApplicationUsers.call(current_application, params[:q], options).outputs
-    respond_with outputs, represent_with: Api::V1::UserSearchRepresenter, location: nil
+    respond_with outputs, represent_with: Api::V1::UserSearchRepresenter,
+                          render_salesforce_info: current_api_user.application.trusted?,
+                          location: nil
   end
 
   ###############################################################
@@ -170,7 +172,9 @@ class Api::V1::ApplicationUsersController < Api::V1::ApiController
     OSU::AccessPolicy.require_action_allowed!(:updates, current_api_user, ApplicationUser)
     outputs = GetUpdatedApplicationUsers.call(current_application).outputs
     respond_with outputs[:application_users],
-                 represent_with: Api::V1::ApplicationUsersRepresenter, location: nil
+                 represent_with: Api::V1::ApplicationUsersRepresenter,
+                 render_salesforce_info: true,
+                 location: nil
   end
 
   ###############################################################

--- a/app/controllers/api/v1/application_users_controller.rb
+++ b/app/controllers/api/v1/application_users_controller.rb
@@ -89,7 +89,9 @@ class Api::V1::ApplicationUsersController < Api::V1::ApiController
     options = params.slice(:page, :per_page, :order_by)
     outputs = SearchApplicationUsers.call(current_application, params[:q], options).outputs
     respond_with outputs, represent_with: Api::V1::UserSearchRepresenter,
-                          render_salesforce_info: current_api_user.application.trusted?,
+                          user_options: {
+                            render_salesforce_info: current_api_user.application.trusted?
+                          },
                           location: nil
   end
 
@@ -173,7 +175,7 @@ class Api::V1::ApplicationUsersController < Api::V1::ApiController
     outputs = GetUpdatedApplicationUsers.call(current_application).outputs
     respond_with outputs[:application_users],
                  represent_with: Api::V1::ApplicationUsersRepresenter,
-                 render_salesforce_info: true,
+                 user_options: { render_salesforce_info: true },
                  location: nil
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -100,7 +100,9 @@ class Api::V1::UsersController < Api::V1::ApiController
                                               current_human_user)
     respond_with current_human_user,
                  represent_with: Api::V1::UserRepresenter,
-                 user_options: { render_contact_infos: true }, location: nil
+                 user_options: { render_contact_infos: true, 
+                                 render_salesforce_info: true, }, 
+                 location: nil
   end
 
   ###############################################################

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -101,4 +101,8 @@ module ApplicationHelper
     end
   end
 
+  def is_real_production_site?
+    request.host == 'accounts.openstax.org'
+  end
+
 end

--- a/app/mailers/dev_mailer.rb
+++ b/app/mailers/dev_mailer.rb
@@ -1,6 +1,6 @@
 class DevMailer < SiteMailer
 
-  def pp(object:, to:, subject:)
+  def inspect_object(object:, to:, subject:)
     @object = object
     mail to: to,
          subject: subject

--- a/app/mailers/dev_mailer.rb
+++ b/app/mailers/dev_mailer.rb
@@ -1,0 +1,9 @@
+class DevMailer < SiteMailer
+
+  def pp(object:, to:, subject:)
+    @object = object
+    mail to: to,
+         subject: subject
+  end
+
+end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -1,5 +1,7 @@
 require 'singleton'
 
+class AnonymousUserIsImmutableError < StandardError; end
+
 class AnonymousUser
   include Singleton
 
@@ -86,6 +88,7 @@ class AnonymousUser
     end
 
     define_method "#{status}!" do
+      raise AnonymousUserIsImmutableError, "Cannot set faculty status on the AnonymousUser."
     end
   end
 
@@ -94,6 +97,7 @@ class AnonymousUser
   end
 
   def faculty_status=(status)
+    raise AnonymousUserIsImmutableError, "Cannot set faculty status on the AnonymousUser."
   end
 
 end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -80,4 +80,20 @@ class AnonymousUser
     full_name
   end
 
+  User.faculty_statuses.each do |status, value|
+    define_method "#{status}?" do
+      User::DEFAULT_FACULTY_STATUS.to_s == status
+    end
+
+    define_method "#{status}!" do
+    end
+  end
+
+  def faculty_status
+    User::DEFAULT_FACULTY_STATUS.to_s
+  end
+
+  def faculty_status=(status)
+  end
+
 end

--- a/app/models/salesforce_user.rb
+++ b/app/models/salesforce_user.rb
@@ -1,0 +1,17 @@
+class SalesforceUser < ActiveRecord::Base
+  validates :uid, presence: true
+  validates :oauth_token, presence: true
+  validates :refresh_token, presence: true
+  validates :instance_url, presence: true
+
+  def self.save_from_omniauth!(auth)
+    where(auth.slice(:uid).permit!).first_or_initialize.tap do |user|
+      user.uid = auth.uid
+      user.name = auth.info.name
+      user.oauth_token = auth.credentials.token
+      user.refresh_token = auth.credentials.refresh_token
+      user.instance_url = auth.credentials.instance_url
+      user.save!
+    end
+  end
+end

--- a/app/models/salesforce_user.rb
+++ b/app/models/salesforce_user.rb
@@ -4,6 +4,8 @@ class SalesforceUser < ActiveRecord::Base
   validates :refresh_token, presence: true
   validates :instance_url, presence: true
 
+  after_save :ensure_only_one_record
+
   def self.save_from_omniauth!(auth)
     where(auth.slice(:uid).permit!).first_or_initialize.tap do |user|
       user.uid = auth.uid
@@ -13,5 +15,9 @@ class SalesforceUser < ActiveRecord::Base
       user.instance_url = auth.credentials.instance_url
       user.save!
     end
+  end
+
+  def ensure_only_one_record
+    SalesforceUser.where{id != self.id}.destroy_all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,11 @@ class User < ActiveRecord::Base
 
   has_many :security_logs
 
+  enum faculty_status: [:no_faculty_info, :pending_faculty, :confirmed_faculty, :rejected_faculty]
+
+  after_initialize { self.faculty_status ||= 'no_faculty_info' }
+  validates :faculty_status, presence: true
+
   before_validation :strip_names
 
   validates :username, presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
 
   enum faculty_status: [:no_faculty_info, :pending_faculty, :confirmed_faculty, :rejected_faculty]
 
-  after_initialize { self.faculty_status ||= 'no_faculty_info' }
+  after_initialize { self.faculty_status ||= :no_faculty_info }
   validates :faculty_status, presence: true
 
   before_validation :strip_names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,8 @@ class User < ActiveRecord::Base
 
   enum faculty_status: [:no_faculty_info, :pending_faculty, :confirmed_faculty, :rejected_faculty]
 
-  after_initialize { self.faculty_status ||= :no_faculty_info }
+  DEFAULT_FACULTY_STATUS = :no_faculty_info
+  after_initialize { self.faculty_status ||= DEFAULT_FACULTY_STATUS }
   validates :faculty_status, presence: true
 
   before_validation :strip_names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,6 @@ class User < ActiveRecord::Base
   enum faculty_status: [:no_faculty_info, :pending_faculty, :confirmed_faculty, :rejected_faculty]
 
   DEFAULT_FACULTY_STATUS = :no_faculty_info
-  after_initialize { self.faculty_status ||= DEFAULT_FACULTY_STATUS }
   validates :faculty_status, presence: true
 
   before_validation :strip_names

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -40,10 +40,18 @@ module Api::V1
              readable: true,
              writeable: false
 
-    property :faculty_status,
+    property :salesforce_contact_id,
              type: String,
              readable: true,
              writeable: false
+
+    property :faculty_status,
+             type: String,
+             readable: true,
+             writeable: false,
+             schema_info: {
+                description: "One of #{User.faculty_statuses.keys.map{|st| "'#{st}'"}.join(', ')}"
+             }
 
     collection :contact_infos,
                if: ->(user_options:, **) { user_options.try(:fetch, :render_contact_infos, false) },

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -41,13 +41,13 @@ module Api::V1
              writeable: false
 
     property :salesforce_contact_id,
-             if: ->(args) { args[:render_salesforce_info] },
+             if: ->(user_options:, **) { user_options.try(:fetch, :render_salesforce_info, false) },
              type: String,
              readable: true,
              writeable: false
 
     property :faculty_status,
-             if: ->(args) { args[:render_salesforce_info] },
+             if: ->(user_options:, **) { user_options.try(:fetch, :render_salesforce_info, false) },
              type: String,
              readable: true,
              writeable: false,

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -41,11 +41,13 @@ module Api::V1
              writeable: false
 
     property :salesforce_contact_id,
+             if: ->(args) { args[:render_salesforce_info] },
              type: String,
              readable: true,
              writeable: false
 
     property :faculty_status,
+             if: ->(args) { args[:render_salesforce_info] },
              type: String,
              readable: true,
              writeable: false,

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -40,6 +40,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :faculty_status,
+             type: String,
+             readable: true,
+             writeable: false
+
     collection :contact_infos,
                if: ->(user_options:, **) { user_options.try(:fetch, :render_contact_infos, false) },
                decorator: ContactInfoRepresenter

--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -137,9 +137,11 @@ class UpdateUserSalesforceInfo
   def notify_errors
     return if @errors.empty?
     Rails.logger.warn("UpdateUserSalesforceInfo errors: " + @errors.inspect)
-    DevMailer.inspect_object(object: @errors,
-                             subject: "UpdateUserSalesforceInfo errors",
-                             to: SECRET_SETTINGS[:mail_recipients][:salesforce]).deliver
+    DevMailer.inspect_object(
+      object: @errors,
+      subject: "UpdateUserSalesforceInfo errors",
+      to: Rails.application.secrets[:mail_recipients]['salesforce']
+    ).deliver_later
   end
 
 end

--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -1,0 +1,131 @@
+class UpdateUserSalesforceInfo
+  USER_BLOCK_SIZE = 1000
+
+  def initialize
+    @errors = []
+  end
+
+  def self.call
+    new.call
+  end
+
+  def call
+    contacts_by_email = {}
+    contacts_by_id = {}
+
+    contacts.each do |contact|
+      contacts_by_email[contact.email] = contact
+      contacts_by_id[contact.id] = contact
+    end
+
+    # Go through all users that have already have a Salesforce ID and make sure
+    # their SF information is stil the same.
+
+    User.where("salesforce_contact_id IS NOT NULL")
+        .find_each do |user|
+
+      begin
+        contact = contacts_by_id[user.salesforce_contact_id]
+        cache_contact_data_in_user(contact, user)
+        user.save! if user.changed?
+      rescue StandardError => ee
+        error!(exception: ee, user: user)
+      end
+    end
+
+    # Go through all users that don't yet have a Salesforce ID and populate their
+    # salesforce info when they have verified emails that match SF data.
+
+    sf_emails = contacts_by_email.keys
+
+    User.eager_load(:contact_infos)
+        .where(salesforce_contact_id: nil)
+        .where(contact_infos: { value: sf_emails, verified: true })
+        .find_each do |user|
+
+      begin
+        # The query above really should be limiting us to only verified email addresses
+        # but in case there is some odd thing where a User has multiple addresses some
+        # of which are verified and some are not, and in case `user.contact_infos` gets
+        # those, add this extra `select(&:verified?)` call
+
+        contacts = user.contact_infos.select(&:verified?).map{|ci| contacts_by_email[ci.value]}
+
+        next if contacts.size == 0
+
+        if contacts.size > 1
+          error!(message: "More than one SF contact (#{contacts.map(&:id).join(', ')}) " \
+                          "for user #{user.id}")
+        else
+          cache_contact_data_in_user(contacts.first, user)
+          user.save!
+        end
+      rescue StandardError => ee
+        error!(exception: ee, user: user)
+      end
+    end
+
+    notify_errors
+  end
+
+  def cache_contact_data_in_user(contact, user)
+    if contact.nil?
+      user.salesforce_contact_id = nil
+      user.faculty_status = :no_faculty_info
+    else
+      user.salesforce_contact_id = contact.id
+
+      user.faculty_status = case contact.faculty_verified
+      when "Confirmed"
+        :confirmed_faculty
+      when "Pending"
+        :pending_faculty
+      when /Rejected/
+        :rejected_faculty
+      when nil
+        :no_faculty_info
+      else
+        raise "Unknown faculty_verified field: '#{contact.faculty_verified}'' on contact #{contact.id}"
+      end
+    end
+  end
+
+  def contacts
+    # The query below is not particularly fast, takes around a minute.  We could
+    # try to do something fancier, like only query contacts modified in the last day
+    # or keep track of when the SF data was last updated and use those timestamps
+    # to limit what data we pull from Salesforce (could have a global field in redis
+    # or could copy SF contact "LastModifiedAt" to a "sf_refreshed_at" field on each
+    # User record).
+    #
+    # Here's one example query as a starting point:
+    #   Salesforce::Contact.order("LastModifiedDate").where("LastModifiedDate >= #{1.day.ago.utc.iso8601}")
+
+    # TODO DEAL WITH EMAIL_ALT!! Not guaranteed to be unique unfortunately
+
+    @contacts ||= Salesforce::Contact.select(:id, :email, :faculty_verified).to_a
+  end
+
+  def error!(exception: nil, message: nil, user: nil)
+    error = {}
+
+    error[:message] = message || exception.try(:message)
+    error[:exception] = {
+      class: exception.class.name,
+      message: exception.message,
+      first_backtrace_line: exception.backtrace.try(:first)
+    } if exception.present?
+    error[:user] = user.try(:id)
+
+    @errors.push(error)
+  end
+
+  def notify_errors
+    return if @errors.empty?
+    Rails.logger.warn("UpdateUserSalesforceInfo errors: " + @errors.inspect)
+    DevMailer.pp(object: @errors,
+                 subject: "UpdateUserSalesforceInfo errors",
+                 to: SECRET_SETTINGS[:mail_recipients][:salesforce]).deliver
+  end
+
+end

--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -71,7 +71,7 @@ class UpdateUserSalesforceInfo
   def cache_contact_data_in_user(contact, user)
     if contact.nil?
       user.salesforce_contact_id = nil
-      user.faculty_status = :no_faculty_info
+      user.faculty_status = User::DEFAULT_FACULTY_STATUS
     else
       user.salesforce_contact_id = contact.id
 

--- a/app/views/admin/base/_console_dialog.html.erb
+++ b/app/views/admin/base/_console_dialog.html.erb
@@ -9,6 +9,7 @@
       <li class="active"><a href="#misc-tab" data-toggle="tab">Misc</a></li>
       <li><a href="#users-tab" data-toggle="tab">Users</a></li>
       <li><a href="#links-tab" data-toggle="tab">Links</a></li>
+      <li><a href="#salesforce-tab" data-toggle="tab">Salesforce</a></li>
       <% unless Rails.env.production? %>
         <li class="dev"><a href="#dev-tab" data-toggle="tab">Dev</a></li>
       <% end %>
@@ -32,13 +33,17 @@
         <%= render 'links' %>
       </div>
 
+      <div class="tab-pane" id="salesforce-tab">
+        <%= render 'salesforce' %>
+      </div>
+
       <% unless Rails.env.production? %>
         <div class="tab-pane" id="dev-tab">
           <%= render 'dev/base/index' %>
         </div>
       <% end %>
     </div>
-    
+
   </div>
 
 <% end %>

--- a/app/views/admin/base/_console_dialog.html.erb
+++ b/app/views/admin/base/_console_dialog.html.erb
@@ -9,11 +9,12 @@
       <li class="active"><a href="#misc-tab" data-toggle="tab">Misc</a></li>
       <li><a href="#users-tab" data-toggle="tab">Users</a></li>
       <li><a href="#links-tab" data-toggle="tab">Links</a></li>
-      <li><a href="#salesforce-tab" data-toggle="tab">Salesforce</a></li>
       <% unless Rails.env.production? %>
         <li class="dev"><a href="#dev-tab" data-toggle="tab">Dev</a></li>
       <% end %>
+      <li><a href="admin/console">Full Console >></a></li>
     </ul>
+
   </div>
 
   <div class="modal-body">
@@ -31,10 +32,6 @@
 
       <div class="tab-pane" id="links-tab">
         <%= render 'links' %>
-      </div>
-
-      <div class="tab-pane" id="salesforce-tab">
-        <%= render 'salesforce' %>
       </div>
 
       <% unless Rails.env.production? %>

--- a/app/views/admin/base/_console_dialog.html.erb
+++ b/app/views/admin/base/_console_dialog.html.erb
@@ -12,7 +12,7 @@
       <% unless Rails.env.production? %>
         <li class="dev"><a href="#dev-tab" data-toggle="tab">Dev</a></li>
       <% end %>
-      <li><a href="admin/console">Full Console >></a></li>
+      <li><a href="/admin/console">Full Console >></a></li>
     </ul>
 
   </div>

--- a/app/views/admin/base/_salesforce.html.erb
+++ b/app/views/admin/base/_salesforce.html.erb
@@ -1,0 +1,24 @@
+<h2> "Salesforce Integration" </h2>
+
+<h3>API User Setup</h3>
+
+<p>When Accounts makes calls to Salesforce's API, it must do so on behalf of a
+  specific Salesforce user.  At any one time, Accounts has information for either
+  zero or one such user.  Use the link below to set the current user that Accounts
+  acts as when calling the Salesforce API.</p>
+
+<% @user = SalesforceUser.first %>
+
+<div style="margin: 30px 0px">
+<p>
+<% if @user.present? %>
+  The current Salesforce user is <b><%= @user.name || "[Unknown Name]" %></b>.
+<% else %>
+  There <b>is no</b> Salesforce user currently set.
+<% end %>
+</p>
+</div>
+
+<%= link_to "Set Accounts's Salesforce User", "/auth/salesforce?redirect_uri=http://localhost:2999/auth/salesforce/callback", id: "sign_in", class: 'btn btn-primary' %>
+
+<%= link_to "Clear Salesforce User", destroy_user_admin_salesforce_path, class: 'btn btn-danger pull-right', method: :delete %>

--- a/app/views/admin/console/index.html.erb
+++ b/app/views/admin/console/index.html.erb
@@ -1,0 +1,3 @@
+<% @page_header = "Accounts Admin Console" %>
+
+Use the links in the header to access specific console pages.  Hit "Exit" to leave this console.

--- a/app/views/admin/salesforce/show.html.erb
+++ b/app/views/admin/salesforce/show.html.erb
@@ -22,3 +22,21 @@
 <%= link_to "Set Accounts's Salesforce User", "/auth/salesforce?redirect_uri=#{auth_salesforce_callback_url}", id: "sign_in", class: 'btn btn-primary' %>
 
 <%= link_to "Clear Salesforce User", destroy_user_admin_salesforce_path, class: 'btn btn-danger pull-right', method: :delete %>
+
+<hr/>
+
+<h3>Refresh Salesforce User Info</h3>
+
+<p>Use the button below to trigger a refresh the cache of information from Salesforce Contact records into Accounts User records.</p>
+
+<p>This operation...</p>
+<ol>
+  <li><b>takes a several minutes to complete</b>,</li>
+  <li>does not write anything to Salesforce, and</li>
+  <li>is called automatically <a href="https://github.com/openstax/accounts/blob/master/config/schedule.rb">the schedule shown here.</a></li>
+</ol>
+
+<%= form_tag(update_users_admin_salesforce_path, method: :put, style: 'margin: 30px 0') do %>
+  <%= submit_tag 'Refresh', class: 'btn btn-primary', disable_with: "Refreshing..." %>
+<% end %>
+

--- a/app/views/admin/salesforce/show.html.erb
+++ b/app/views/admin/salesforce/show.html.erb
@@ -1,4 +1,4 @@
-<h2> "Salesforce Integration" </h2>
+<% @page_header = "Salesforce Integration" %>
 
 <h3>API User Setup</h3>
 
@@ -19,6 +19,6 @@
 </p>
 </div>
 
-<%= link_to "Set Accounts's Salesforce User", "/auth/salesforce?redirect_uri=http://localhost:2999/auth/salesforce/callback", id: "sign_in", class: 'btn btn-primary' %>
+<%= link_to "Set Accounts's Salesforce User", "/auth/salesforce?redirect_uri=#{auth_salesforce_callback_url}", id: "sign_in", class: 'btn btn-primary' %>
 
 <%= link_to "Clear Salesforce User", destroy_user_admin_salesforce_path, class: 'btn btn-danger pull-right', method: :delete %>

--- a/app/views/admin/security_logs/show.html.erb
+++ b/app/views/admin/security_logs/show.html.erb
@@ -1,7 +1,7 @@
 <%# Copyright 2016 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<h4>Security Log</h4>
+<% @page_header = "Security Log" %>
 
 <%= lev_form_for :search,
                  url: admin_security_log_path,

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -22,6 +22,29 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :salesforce_contact %>
+    <div>
+      <% sf_id = @user.salesforce_contact_id %>
+      <% if sf_id.nil? %>
+        Not Set
+      <% else %>
+        <% sf_user = SalesforceUser.first %>
+
+        <% if sf_user.nil? %>
+          <%= sf_id %>
+        <% else %>
+          <%= link_to sf_id, sf_user.instance_url + "/" + sf_id, target: '_blank' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :faculty_status %>
+    <div><%= @user.faculty_status %></div>
+  </div>
+
+  <div class="form-group">
     <%= f.label :first_name %>
     <%= f.text_field :first_name, value: params[:user].nil? ? @user.first_name : params[:user][:first_name] %>
   </div>

--- a/app/views/dev_mailer/inspect_object.text.erb
+++ b/app/views/dev_mailer/inspect_object.text.erb
@@ -1,1 +1,2 @@
+<%# `ai` is AwesomePrint's "dump to ASCII string" method %>
 <%= @object.ai(plain:true, ruby19_syntax: true, indent: 2) %>

--- a/app/views/dev_mailer/pp.text.erb
+++ b/app/views/dev_mailer/pp.text.erb
@@ -1,1 +1,1 @@
-<%= @object.try(:pretty_inspect) %>
+<%= @object.ai(plain:true, ruby19_syntax: true, indent: 2) %>

--- a/app/views/dev_mailer/pp.text.erb
+++ b/app/views/dev_mailer/pp.text.erb
@@ -1,0 +1,1 @@
+<%= @object.try(:pretty_inspect) %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -71,7 +71,7 @@
         <h1><%= @page_header %></h1>
       </div>
 
-      <%#= render 'layouts/flash_messages' %>
+      <%= render 'layouts/attention' %>
 
       <%= yield %>
     </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+
+    <title>OpenStax Accounts : Administration</title>
+    <%= stylesheet_link_tag 'admin', media: 'all', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'admin', 'data-turbolinks-track' => true %>
+    <%= csrf_meta_tags %>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body class="admin">
+
+    <nav class="navbar navbar-default <%= 'production' if is_real_production_site? %>">
+      <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/admin/console">Accounts Admin Console</a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+
+            <li><%= link_to 'Security Log', admin_security_log_path %></li>
+            <li><%= link_to 'Salesforce', admin_salesforce_path %></li>
+
+<% if false %>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Menu Button<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><%= link_to 'Item 1', some_path %></li>
+                <li><%= link_to 'Item 2', some_path %></li>
+                <li><%= link_to 'Item 3', some_path %></li>
+              </ul>
+            </li>
+<% end %>
+
+          </ul>
+
+          <ul class="nav navbar-nav navbar-right">
+            <li><a href="/">Exit</a></li>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.username %> <span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><%= link_to 'Sign out!', signout_path %></li>
+              </ul>
+            </li>
+          </ul>
+        </div><!-- /.navbar-collapse -->
+      </div><!-- /.container-fluid -->
+    </nav>
+
+    <div class="container">
+      <div class="page-header">
+        <h1><%= @page_header %></h1>
+      </div>
+
+      <%#= render 'layouts/flash_messages' %>
+
+      <%= yield %>
+    </div>
+
+  </body>
+</html>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,6 +8,9 @@ require 'contracts_not_required'
 require 'require_recent_signin'
 require 'json_serialize'
 require 'omniauth/strategies/custom_identity'
+require 'salesforce/client'
+require 'salesforce/user_missing'
+require 'salesforce/contact'
 
 SITE_NAME = 'OpenStax Accounts'
 PAGE_TITLE_SUFFIX = SITE_NAME

--- a/config/initializers/active_force.rb
+++ b/config/initializers/active_force.rb
@@ -1,13 +1,5 @@
 module ActiveForce
 
-  mattr_accessor :cache_store
-  secrets = SECRET_SETTINGS[:redis]
-  self.cache_store = Redis::Store.new(
-    url: secrets['url'],
-    namespace: secrets['namespaces']['active_force'],
-    expires_in: 1.year
-  )
-
   class << self
 
     # Use a lazy setting of the client so that migrations etc are in place
@@ -18,6 +10,10 @@ module ActiveForce
         self.sfdc_client = Salesforce::Client.new
       end
       original_sfdc_client
+    end
+
+    def clear_sfdc_client!
+      self.sfdc_client = nil
     end
   end
 

--- a/config/initializers/active_force.rb
+++ b/config/initializers/active_force.rb
@@ -1,0 +1,31 @@
+module ActiveForce
+
+  mattr_accessor :cache_store
+  secrets = SECRET_SETTINGS[:redis]
+  self.cache_store = Redis::Store.new(
+    url: secrets['url'],
+    namespace: secrets['namespaces']['active_force'],
+    expires_in: 1.year
+  )
+
+  class << self
+
+    # Use a lazy setting of the client so that migrations etc are in place
+    # to allow the RealClient to be successfully instantiated.
+    alias_method :original_sfdc_client, :sfdc_client
+    def sfdc_client
+      if !original_sfdc_client.is_a?(Salesforce::Client)
+        self.sfdc_client = Salesforce::Client.new
+      end
+      original_sfdc_client
+    end
+  end
+
+  class SObject
+    # Save that precious SF API call count!
+    def save_if_changed
+      save if changed?
+    end
+  end
+
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -12,6 +12,9 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :twitter, secrets[:twitter_consumer_key], secrets[:twitter_consumer_secret]
   provider :google_oauth2, secrets[:google_client_id], secrets[:google_client_secret]
   provider :custom_identity
+
+  provider :salesforce, SECRET_SETTINGS[:salesforce]['consumer_key'],
+                        SECRET_SETTINGS[:salesforce]['consumer_secret']
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -13,8 +13,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, secrets[:google_client_id], secrets[:google_client_secret]
   provider :custom_identity
 
-  provider :salesforce, SECRET_SETTINGS[:salesforce]['consumer_key'],
-                        SECRET_SETTINGS[:salesforce]['consumer_secret']
+  provider :salesforce, secrets[:salesforce]['consumer_key'],
+                        secrets[:salesforce]['consumer_secret']
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
 
   namespace 'admin' do
     get '/', to: 'base#index'
+    get '/console', to: 'console#index'
 
     put 'cron',                         to: 'base#cron'
     get 'raise_exception/:type',        to: 'base#raise_exception', as: 'raise_exception'
@@ -152,8 +153,8 @@ Rails.application.routes.draw do
     post :verify_contact_info, path: '/contact_infos/:id/verify',
          controller: :contact_infos, action: :verify
 
-    resource :salesforce, only: [], controller: :salesforce do
-      delete :destroy_user
+    resource :salesforce, only: [:show], controller: :salesforce do
+      delete :destroy_user, on: :collection
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,10 @@ Rails.application.routes.draw do
          controller: :contact_infos, action: :verify
 
     resource :salesforce, only: [:show], controller: :salesforce do
-      delete :destroy_user, on: :collection
+      collection do
+        delete :destroy_user
+        put :update_users
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   # More often used routes should appear first
   root to: 'static_pages#home'
 
+  match '/auth/salesforce/callback', to: 'admin/salesforce#callback',
+                                     via: [:get, :post]
+
   scope controller: 'sessions' do
     get 'signin', action: :new
 
@@ -148,6 +151,10 @@ Rails.application.routes.draw do
 
     post :verify_contact_info, path: '/contact_infos/:id/verify',
          controller: :contact_infos, action: :verify
+
+    resource :salesforce, only: [], controller: :salesforce do
+      delete :destroy_user
+    end
   end
 
   namespace 'dev' do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,14 @@
+bundle_command = ENV['BUNDLE_COMMAND'] || 'bundle exec'
+
+set :bundle_command, bundle_command
+set :runner_command, "#{bundle_command} rails runner"
+
+# Server time is UTC; times below are interpreted that way.
+# Ideally we'd have a better way to specify times relative to Central
+# time, independent of the server time.  Maybe there's something here:
+#   * https://github.com/javan/whenever/issues/481
+#   * https://github.com/javan/whenever/pull/239
+
+every 1.hour, at: 45 do
+  runner "OpenStax::RescueFrom.this{ UpdateUserSalesforceInfo.call }"
+end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -42,6 +42,9 @@ development:
   google_client_id: my_google_client_id
   google_client_secret: my_google_client_secret
 
+  mail_recipients:
+    salesforce: 'recipients@example.org'
+
   # Valid urls for loading inside an iframe
   valid_iframe_origins:
     - http://localhost
@@ -50,6 +53,10 @@ development:
 
   # Set to true to disable the corner dev/admin console
   disable_corner_console: false
+
+  salesforce:
+    consumer_key: my_salesforce_key
+    consumer_secret: my_salesforce_secret
 
 test:
   # Used to encrypt and sign cookies
@@ -71,8 +78,15 @@ test:
     recipients: 'recipients@example.org'
     environment_name: TEST
 
+  mail_recipients:
+    salesforce: 'recipients@example.org'
+
   # Valid urls for loading inside an iframe
   valid_iframe_origins:
     - http://localhost
     - https://cnx.org
     - https://openstax.org
+
+  salesforce:
+    consumer_key: my_salesforce_key
+    consumer_secret: my_salesforce_secret

--- a/db/migrate/20160918213306_create_salesforce_users.rb
+++ b/db/migrate/20160918213306_create_salesforce_users.rb
@@ -1,0 +1,11 @@
+class CreateSalesforceUsers < ActiveRecord::Migration
+  def change
+    create_table :salesforce_users do |t|
+      t.string :name
+      t.string :uid, null: false
+      t.string :oauth_token, null: false
+      t.string :refresh_token, null: false
+      t.string :instance_url, null: false
+    end
+  end
+end

--- a/db/migrate/20160918213622_add_salesforce_info_to_users.rb
+++ b/db/migrate/20160918213622_add_salesforce_info_to_users.rb
@@ -1,0 +1,9 @@
+class AddSalesforceInfoToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :salesforce_contact_id, :string
+    add_column :users, :faculty_status, :integer, default: 0, null: false
+
+    add_index :users, :faculty_status
+    add_index :users, :salesforce_contact_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160918213622) do
+ActiveRecord::Schema.define(version: 20160918213622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,12 +202,12 @@ ActiveRecord::Schema.define(:version => 20160918213622) do
     t.datetime "updated_at"
   end
 
-  create_table "salesforce_users", :force => true do |t|
+  create_table "salesforce_users", force: :cascade do |t|
     t.string "name"
-    t.string "uid",           :null => false
-    t.string "oauth_token",   :null => false
-    t.string "refresh_token", :null => false
-    t.string "instance_url",  :null => false
+    t.string "uid",           :null=>false
+    t.string "oauth_token",   :null=>false
+    t.string "refresh_token", :null=>false
+    t.string "instance_url",  :null=>false
   end
 
   create_table "security_logs", force: :cascade do |t|
@@ -228,20 +228,18 @@ ActiveRecord::Schema.define(:version => 20160918213622) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "username",         :default=>"", :null=>false, :index=>{:name=>"index_users_on_username", :unique=>true}
+    t.string   "username",              :default=>"", :null=>false, :index=>{:name=>"index_users_on_username", :unique=>true}
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "is_administrator", :default=>false
-    t.string   "first_name",       :index=>{:name=>"index_users_on_first_name", :case_sensitive=>false}
-    t.string   "last_name",        :index=>{:name=>"index_users_on_last_name", :case_sensitive=>false}
+    t.boolean  "is_administrator",      :default=>false
+    t.string   "first_name",            :index=>{:name=>"index_users_on_first_name", :case_sensitive=>false}
+    t.string   "last_name",             :index=>{:name=>"index_users_on_last_name", :case_sensitive=>false}
     t.string   "title"
-    t.string   "uuid",             :index=>{:name=>"index_users_on_uuid", :unique=>true}
+    t.string   "uuid",                  :index=>{:name=>"index_users_on_uuid", :unique=>true}
     t.string   "suffix"
-    t.string   "state",            :default=>"temp", :null=>false
-    t.string   "salesforce_contact_id"
-    t.integer  "faculty_status",        :default => 0,      :null => false
-    t.index ["faculty_status"], :name => "index_users_on_faculty_status"
-    t.index ["salesforce_contact_id"], :name => "index_users_on_salesforce_contact_id"
+    t.string   "state",                 :default=>"temp", :null=>false
+    t.string   "salesforce_contact_id", :index=>{:name=>"index_users_on_salesforce_contact_id"}
+    t.integer  "faculty_status",        :default=>0, :null=>false, :index=>{:name=>"index_users_on_faculty_status"}
   end
   add_index "users", ["username"], :name=>"index_users_on_username_case_insensitive", :case_sensitive=>false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160906231547) do
+ActiveRecord::Schema.define(:version => 20160918213622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,6 +202,14 @@ ActiveRecord::Schema.define(version: 20160906231547) do
     t.datetime "updated_at"
   end
 
+  create_table "salesforce_users", :force => true do |t|
+    t.string "name"
+    t.string "uid",           :null => false
+    t.string "oauth_token",   :null => false
+    t.string "refresh_token", :null => false
+    t.string "instance_url",  :null => false
+  end
+
   create_table "security_logs", force: :cascade do |t|
     t.integer  "user_id",        :index=>{:name=>"index_security_logs_on_user_id_and_created_at", :with=>["created_at"]}
     t.integer  "application_id", :index=>{:name=>"index_security_logs_on_application_id_and_created_at", :with=>["created_at"]}
@@ -230,6 +238,10 @@ ActiveRecord::Schema.define(version: 20160906231547) do
     t.string   "uuid",             :index=>{:name=>"index_users_on_uuid", :unique=>true}
     t.string   "suffix"
     t.string   "state",            :default=>"temp", :null=>false
+    t.string   "salesforce_contact_id"
+    t.integer  "faculty_status",        :default => 0,      :null => false
+    t.index ["faculty_status"], :name => "index_users_on_faculty_status"
+    t.index ["salesforce_contact_id"], :name => "index_users_on_salesforce_contact_id"
   end
   add_index "users", ["username"], :name=>"index_users_on_username_case_insensitive", :case_sensitive=>false
 

--- a/lib/salesforce/client.rb
+++ b/lib/salesforce/client.rb
@@ -1,0 +1,20 @@
+module Salesforce
+  class Client < Restforce::Data::Client
+
+    def initialize
+      user = SalesforceUser.first
+      if user.nil?
+        Rails.logger.error { "The Salesforce client was requested but no user is available." }
+        raise Salesforce::UserMissing
+      end
+      secrets = SECRET_SETTINGS[:salesforce]
+      super(oauth_token: user.oauth_token,
+            refresh_token: user.refresh_token,
+            instance_url: user.instance_url,
+            client_id: secrets['consumer_key'],
+            client_secret: secrets['consumer_secret'],
+            api_version: '37.0')
+    end
+
+  end
+end

--- a/lib/salesforce/client.rb
+++ b/lib/salesforce/client.rb
@@ -7,7 +7,7 @@ module Salesforce
         Rails.logger.error { "The Salesforce client was requested but no user is available." }
         raise Salesforce::UserMissing
       end
-      secrets = SECRET_SETTINGS[:salesforce]
+      secrets = Rails.application.secrets[:salesforce]
       super(oauth_token: user.oauth_token,
             refresh_token: user.refresh_token,
             instance_url: user.instance_url,

--- a/lib/salesforce/contact.rb
+++ b/lib/salesforce/contact.rb
@@ -8,5 +8,7 @@ module Salesforce
     field :last_modified_at,        from: "LastModifiedDate"
 
     self.table_name = 'Contact'
+
+
   end
 end

--- a/lib/salesforce/contact.rb
+++ b/lib/salesforce/contact.rb
@@ -1,0 +1,12 @@
+module Salesforce
+  class Contact < ActiveForce::SObject
+    field :name,                    from: "Name"
+    field :email,                   from: "Email"
+    field :email_alt,               from: "Email_alt__c"
+    field :faculty_confirmed_date,  from: "Faculty_Confirmed_Date__c", as: :datetime
+    field :faculty_verified,        from: "Faculty_Verified__c"
+    field :last_modified_at,        from: "LastModifiedDate"
+
+    self.table_name = 'Contact'
+  end
+end

--- a/lib/salesforce/user_missing.rb
+++ b/lib/salesforce/user_missing.rb
@@ -1,0 +1,3 @@
+module Salesforce
+  class UserMissing < StandardError; end
+end

--- a/spec/controllers/api/v1/application_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/application_groups_controller_spec.rb
@@ -155,7 +155,8 @@ describe Api::V1::ApplicationGroupsController, type: :controller, api: true, ver
           is_public: false,
           owners: [
             {group_id: group_2.id,
-             user: {id: user_1.id, username: user_1.username, uuid: user_1.uuid}}
+             user: {id: user_1.id, username: user_1.username, uuid: user_1.uuid,
+                    faculty_status: user_1.faculty_status}}
           ],
           members: [],
           nestings: [],

--- a/spec/controllers/api/v1/application_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/application_groups_controller_spec.rb
@@ -155,8 +155,7 @@ describe Api::V1::ApplicationGroupsController, type: :controller, api: true, ver
           is_public: false,
           owners: [
             {group_id: group_2.id,
-             user: {id: user_1.id, username: user_1.username, uuid: user_1.uuid,
-                    faculty_status: user_1.faculty_status}}
+             user: {id: user_1.id, username: user_1.username, uuid: user_1.uuid}}
           ],
           members: [],
           nestings: [],

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -57,7 +57,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
           first_name: bob_brown.first_name,
           last_name: bob_brown.last_name,
           full_name: bob_brown.full_name,
-          uuid: bob_brown.uuid
+          uuid: bob_brown.uuid,
+          faculty_status: bob_brown.faculty_status
         }, unread_updates: 0
       }.to_json
       expect(response.body).to eq(expected_response)
@@ -97,7 +98,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
             first_name: user_2.first_name,
             last_name: user_2.last_name,
             full_name: user_2.full_name,
-            uuid: user_2.uuid
+            uuid: user_2.uuid,
+            faculty_status: user_2.faculty_status
           }
         ]
       }.to_json
@@ -173,7 +175,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
             first_name: user_2.first_name,
             last_name: user_2.last_name,
             full_name: user_2.full_name,
-            uuid: user_2.uuid
+            uuid: user_2.uuid,
+            faculty_status: user_2.faculty_status
           }
         ]
       }.to_json
@@ -216,7 +219,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
           first_name: user_2.first_name,
           last_name: user_2.last_name,
           full_name: user_2.full_name,
-          uuid: user_2.uuid
+          uuid: user_2.uuid,
+          faculty_status: user_2.faculty_status
         },
         unread_updates: 2
       }].to_json
@@ -242,7 +246,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
           first_name: user_2.first_name,
           last_name: user_2.last_name,
           full_name: user_2.full_name,
-          uuid: user_2.uuid
+          uuid: user_2.uuid,
+          faculty_status: user_2.faculty_status
         },
         unread_updates: 3
       }].to_json
@@ -262,7 +267,8 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
           first_name: user_2.first_name,
           last_name: user_2.last_name,
           full_name: user_2.full_name,
-          uuid: user_2.uuid
+          uuid: user_2.uuid,
+          faculty_status: user_2.faculty_status
         },
         unread_updates: 2
       }].to_json

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -57,8 +57,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
           first_name: bob_brown.first_name,
           last_name: bob_brown.last_name,
           full_name: bob_brown.full_name,
-          uuid: bob_brown.uuid,
-          faculty_status: bob_brown.faculty_status
+          uuid: bob_brown.uuid
         }, unread_updates: 0
       }.to_json
       expect(response.body).to eq(expected_response)
@@ -98,8 +97,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
             first_name: user_2.first_name,
             last_name: user_2.last_name,
             full_name: user_2.full_name,
-            uuid: user_2.uuid,
-            faculty_status: user_2.faculty_status
+            uuid: user_2.uuid
           }
         ]
       }.to_json

--- a/spec/controllers/api/v1/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/group_members_controller_spec.rb
@@ -360,8 +360,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
     {
       'id' => user.id,
       'username' => user.username,
-      'uuid' => user.uuid,
-      'faculty_status' => user.faculty_status
+      'uuid' => user.uuid
     }
   end
 

--- a/spec/controllers/api/v1/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/group_members_controller_spec.rb
@@ -64,7 +64,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
             'members' => [
               {
                 'group_id' => group_1.id,
-                'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+                'user' => user_hash(user_1)
               }
             ],
             'nestings' => [],
@@ -95,7 +95,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
           'members' => [
             {
               'group_id' => group_1.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'nestings' => [
@@ -136,7 +136,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
           'members' => [
             {
               'group_id' => group_1.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'nestings' => [
@@ -163,8 +163,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
             *group_2.group_members.map do |group_member|
               {
                 'group_id' => group_2.id,
-                'user' => { 'id' => group_member.user.id, 'username' => group_member.user.username,
-                            'uuid' => group_member.user.uuid }
+                'user' => user_hash(group_member.user)
               }
             end
           ),
@@ -205,7 +204,7 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
           'owners' => [],
           'members' => [
             { 'group_id' => group_3.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid } }
+              'user' => user_hash(user_1) }
           ],
           'nestings' => [],
           'supertree_group_ids' => [group_3.id],
@@ -261,13 +260,13 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
           'owners' => [
             {
               'group_id' => group_3.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'members' => [
             {
               'group_id' => group_3.id,
-              'user' => { 'id' => user_2.id, 'username' => user_2.username, 'uuid' => user_2.uuid }
+              'user' => user_hash(user_2)
             }
           ],
           'nestings' => [],
@@ -290,13 +289,13 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
           'is_public' => false,
           'owners' => [
             { 'group_id' => group_1.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'members' => [
             {
               'group_id' => group_1.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'nestings' => [],
@@ -355,6 +354,15 @@ describe Api::V1::GroupMembersController, type: :controller, api: true, version:
       expect(response.body).to be_blank
       expect(GroupMember.where(id: group_member_1.id).first).to be_nil
     end
+  end
+
+  def user_hash(user)
+    {
+      'id' => user.id,
+      'username' => user.username,
+      'uuid' => user.uuid,
+      'faculty_status' => user.faculty_status
+    }
   end
 
 end

--- a/spec/controllers/api/v1/group_owners_controller_spec.rb
+++ b/spec/controllers/api/v1/group_owners_controller_spec.rb
@@ -332,8 +332,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
     {
       'id' => user.id,
       'username' => user.username,
-      'uuid' => user.uuid,
-      'faculty_status' => user.faculty_status
+      'uuid' => user.uuid
     }
   end
 

--- a/spec/controllers/api/v1/group_owners_controller_spec.rb
+++ b/spec/controllers/api/v1/group_owners_controller_spec.rb
@@ -63,7 +63,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
             'owners' => [
               {
                 'group_id' => group_1.id,
-                'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+                'user' => user_hash(user_1)
               }
             ],
             'members' => [],
@@ -94,7 +94,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
           'owners' => [
             {
               'group_id' => group_1.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'members' => [],
@@ -134,8 +134,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
             *group_2.group_owners.map do |group_owner|
               {
                 'group_id' => group_2.id,
-                'user' => { 'id' => group_owner.user.id, 'username' => group_owner.user.username,
-                            'uuid' => group_owner.user.uuid }
+                'user' => user_hash(group_owner.user)
               }
             end
           ),
@@ -173,7 +172,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
           'owners' => [
             {
               'group_id' => group_3.id,
-              'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }
+              'user' => user_hash(user_1)
             }
           ],
           'members' => [],
@@ -232,7 +231,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
             *group_3.owners.map do |owner|
               {
                 'group_id' => group_3.id,
-                'user' => { 'id' => owner.id, 'username' => owner.username, 'uuid' => owner.uuid }
+                'user' => user_hash(owner)
               }
             end
           ),
@@ -262,7 +261,7 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
             *group_1.owners.map do |owner|
               {
                 'group_id' => group_1.id,
-                'user' => { 'id' => owner.id, 'username' => owner.username, 'uuid' => owner.uuid }
+                'user' => user_hash(owner)
               }
             end
           ),
@@ -327,6 +326,15 @@ describe Api::V1::GroupOwnersController, type: :controller, api: true, version: 
       expect(response.body).to be_blank
       expect(GroupOwner.where(id: group_owner_1.id).first).to be_nil
     end
+  end
+
+  def user_hash(user)
+    {
+      'id' => user.id,
+      'username' => user.username,
+      'uuid' => user.uuid,
+      'faculty_status' => user.faculty_status
+    }
   end
 
 end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -488,8 +488,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
     {
       'id' => user.id,
       'username' => user.username,
-      'uuid' => user.uuid,
-      'faculty_status' => user.faculty_status
+      'uuid' => user.uuid
     }
   end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -57,7 +57,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => false,
         'members' => [
           { 'group_id' => group_1.id,
-            'user' => { 'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid } }
+            'user' => user_hash(user_1) }
         ], 'owners' => [], 'nestings' => [],
         'supertree_group_ids' => [group_1.id],
         'subtree_group_ids' => [group_1.id],
@@ -135,7 +135,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => true,
         'members' => [
           {'group_id' => group_3.id,
-           'user' => {'id' => user_2.id, 'username' => user_2.username, 'uuid' => user_2.uuid }}
+           'user' => user_hash(user_2)}
         ], 'owners' => [], 'nestings' => [
           'container_group_id' => group_3.id,
           'member_group_id' => group_2.id
@@ -161,7 +161,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => false,
         'members' => [
           {'group_id' => group_2.id,
-           'user' => {'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }}
+           'user' => user_hash(user_1)}
         ], 'owners' => [], 'nestings' => [],
         'supertree_group_ids' => group_2.supertree_group_ids,
         'subtree_group_ids' => [group_2.id],
@@ -175,7 +175,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => true,
         'members' => [
           {'group_id' => group_3.id,
-           'user' => {'id' => user_2.id, 'username' => user_2.username, 'uuid' => user_2.uuid }}
+           'user' => user_hash(user_2)}
         ], 'owners' => [], 'nestings' => [
           'container_group_id' => group_3.id,
           'member_group_id' => group_2.id
@@ -206,7 +206,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => false,
         'members' => [
           {'group_id' => group_2.id,
-           'user' => {'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }}
+           'user' => user_hash(user_1)}
         ], 'owners' => [], 'nestings' => [],
         'supertree_group_ids' => [group_2.id],
         'subtree_group_ids' => [group_2.id],
@@ -220,7 +220,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => true,
         'members' => [
           {'group_id' => group_3.id,
-           'user' => {'id' => user_2.id, 'username' => user_2.username, 'uuid' => user_2.uuid }}
+           'user' => user_hash(user_2)}
         ], 'owners' => [], 'nestings' => [],
         'supertree_group_ids' => [group_3.id],
         'subtree_group_ids' => [group_3.id],
@@ -282,7 +282,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => false,
         'members' => [
           {'group_id' => group_1.id,
-           'user' => {'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }}
+           'user' => user_hash(user_1)}
         ],
         'owners' => [], 'nestings' => [],
         'supertree_group_ids' => [group_1.id],
@@ -308,7 +308,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'is_public' => false,
         'members' => [], 'owners' => [
           {'group_id' => group_1.id,
-           'user' => {'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }}
+           'user' => user_hash(user_1)}
         ], 'nestings' => [
           {
             'container_group_id' => group_1.id,
@@ -350,7 +350,7 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
         'members' => [],
         'owners' => [
           {'group_id' => Group.last.id,
-           'user' => {'id' => user_1.id, 'username' => user_1.username, 'uuid' => user_1.uuid }}
+           'user' => user_hash(user_1)}
         ], 'nestings' => [],
         'supertree_group_ids' => [Group.last.id],
         'subtree_group_ids' => [Group.last.id],
@@ -482,6 +482,15 @@ describe Api::V1::GroupsController, type: :controller, api: true, version: :v1 d
 
       expect(Group.where(id: group_3.id).first).to be_nil
     end
+  end
+
+  def user_hash(user)
+    {
+      'id' => user.id,
+      'username' => user.username,
+      'uuid' => user.uuid,
+      'faculty_status' => user.faculty_status
+    }
   end
 
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -59,7 +59,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
             first_name: user_2.first_name,
             last_name: user_2.last_name,
             full_name: user_2.full_name,
-            uuid: user_2.uuid
+            uuid: user_2.uuid,
+            faculty_status: user_2.faculty_status
           }
         ]
       }.to_json
@@ -104,6 +105,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
         id: user_1.id,
         username: user_1.username,
         uuid: user_1.uuid,
+        faculty_status: user_1.faculty_status,
         contact_infos: []
       }.to_json
 
@@ -122,6 +124,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
         id: user_1.id,
         username: user_1.username,
         uuid: user_1.uuid,
+        faculty_status: user_1.faculty_status,
         contact_infos: []
       }.to_json
 
@@ -137,6 +140,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
         first_name: user_2.first_name,
         last_name: user_2.last_name,
         full_name: user_2.full_name
+        faculty_status: user_1.faculty_status,
       )
     end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -5,7 +5,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
   let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
   let!(:trusted_application)     { FactoryGirl.create :doorkeeper_application, :trusted }
   let!(:user_1)          { FactoryGirl.create :user, :terms_agreed }
-  let!(:user_2)          { FactoryGirl.create :user_with_emails, :terms_agreed, first_name: 'Bob', last_name: 'Michaels' }
+  let!(:user_2)          { FactoryGirl.create :user_with_emails, :terms_agreed, first_name: 'Bob',
+                                              last_name: 'Michaels', salesforce_contact_id: "somesfid" }
   let!(:unclaimed_user)  { FactoryGirl.create :user_with_emails, state:'unclaimed' }
   let!(:admin_user)      { FactoryGirl.create :user, :terms_agreed, :admin }
 
@@ -60,6 +61,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
             last_name: user_2.last_name,
             full_name: user_2.full_name,
             uuid: user_2.uuid,
+            salesforce_contact_id: user_2.salesforce_contact_id,
             faculty_status: user_2.faculty_status
           }
         ]

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -60,9 +60,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
             first_name: user_2.first_name,
             last_name: user_2.last_name,
             full_name: user_2.full_name,
-            uuid: user_2.uuid,
-            salesforce_contact_id: user_2.salesforce_contact_id,
-            faculty_status: user_2.faculty_status
+            uuid: user_2.uuid
           }
         ]
       }.to_json
@@ -134,6 +132,9 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
     end
 
     it "should return a properly formatted JSON response for user with name" do
+      user_2.salesforce_contact_id = 'blah'
+      user_2.save
+
       api_get :show, user_2_token
 
       expect(response.body_as_hash).to include(
@@ -143,6 +144,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
         last_name: user_2.last_name,
         full_name: user_2.full_name
         faculty_status: user_1.faculty_status,
+        salesforce_contact_id: 'blah',
       )
     end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -142,7 +142,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
         username: user_2.username,
         first_name: user_2.first_name,
         last_name: user_2.last_name,
-        full_name: user_2.full_name
+        full_name: user_2.full_name,
         faculty_status: user_1.faculty_status,
         salesforce_contact_id: 'blah',
       )

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :user do
     username { SecureRandom.hex(3) }
     state 'activated' # otherwise the default from DB will be to 'temp'
+
     trait :admin do
       is_administrator true
     end

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -205,6 +205,7 @@ feature 'User logs in as a local user', js: true do
       fill_in (t :"sessions.new.username_or_email"), with: 'user@example.com'
       fill_in (t :"sessions.new.password"), with: 'password'
       click_button (t :"sessions.new.sign_in")
+
       expect(page.current_url).to match(app_callback_url)
     end
   end

--- a/spec/mailers/dev_mailer_spec.rb
+++ b/spec/mailers/dev_mailer_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 describe DevMailer, type: :mailer do
 
-  describe "pp" do
+  describe "#inspect" do
     it 'has basic header pretty prints object' do
-      mail = DevMailer.pp object: [{a: 2}, {b: "yo yo yo"}], to: "bob@example.com", subject: "Howdy"
+      mail = DevMailer.inspect_object object: [{a: 2}, {b: "yo yo yo"}],
+                                      to: "bob@example.com",
+                                      subject: "Howdy"
 
       expect(mail.header['to'].to_s).to eq('bob@example.com')
       expect(mail.from).to eq(["noreply@openstax.org"])
@@ -16,7 +18,7 @@ describe DevMailer, type: :mailer do
 
     it 'does not explode with nil object' do
       expect{
-        DevMailer.pp object: nil, to: "bob@example.com", subject: "Howdy"
+        DevMailer.inspect_object object: nil, to: "bob@example.com", subject: "Howdy"
       }.not_to raise_error
     end
   end

--- a/spec/mailers/dev_mailer_spec.rb
+++ b/spec/mailers/dev_mailer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe DevMailer, type: :mailer do
+
+  describe "pp" do
+    it 'has basic header pretty prints object' do
+      mail = DevMailer.pp object: [{a: 2}, {b: "yo yo yo"}], to: "bob@example.com", subject: "Howdy"
+
+      expect(mail.header['to'].to_s).to eq('bob@example.com')
+      expect(mail.from).to eq(["noreply@openstax.org"])
+      expect(mail.subject).to eq "[OpenStax] Howdy"
+      expect(mail.body.encoded).to eq(
+        "[\r\n  [0] {\r\n    :a => 2\r\n  },\r\n  [1] {\r\n    :b => \"yo yo yo\"\r\n  }\r\n]\r\n"
+      )
+    end
+
+    it 'does not explode with nil object' do
+      expect{
+        DevMailer.pp object: nil, to: "bob@example.com", subject: "Howdy"
+      }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/models/anonymous_user_spec.rb
+++ b/spec/models/anonymous_user_spec.rb
@@ -10,12 +10,12 @@ describe AnonymousUser do
     expect(au.confirmed_faculty?).to be_falsy
 
     expect(au.faculty_status).to eq "no_faculty_info"
-    expect{au.faculty_status="blah"}.not_to raise_error
+    expect{au.faculty_status="blah"}.to raise_error(AnonymousUserIsImmutableError)
 
-    expect{au.no_faculty_info!}.not_to raise_error
-    expect{au.pending_faculty!}.not_to raise_error
-    expect{au.rejected_faculty!}.not_to raise_error
-    expect{au.confirmed_faculty!}.not_to raise_error
+    expect{au.no_faculty_info!}.to raise_error(AnonymousUserIsImmutableError)
+    expect{au.pending_faculty!}.to raise_error(AnonymousUserIsImmutableError)
+    expect{au.rejected_faculty!}.to raise_error(AnonymousUserIsImmutableError)
+    expect{au.confirmed_faculty!}.to raise_error(AnonymousUserIsImmutableError)
   end
 
 end

--- a/spec/models/anonymous_user_spec.rb
+++ b/spec/models/anonymous_user_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe AnonymousUser do
+  let!(:au) { AnonymousUser.instance }
+
+  it 'handles faculty status enum methods' do
+    expect(au.no_faculty_info?).to be_truthy
+    expect(au.pending_faculty?).to be_falsy
+    expect(au.rejected_faculty?).to be_falsy
+    expect(au.confirmed_faculty?).to be_falsy
+
+    expect(au.faculty_status).to eq "no_faculty_info"
+    expect{au.faculty_status="blah"}.not_to raise_error
+
+    expect{au.no_faculty_info!}.not_to raise_error
+    expect{au.pending_faculty!}.not_to raise_error
+    expect{au.rejected_faculty!}.not_to raise_error
+    expect{au.confirmed_faculty!}.not_to raise_error
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -143,6 +143,12 @@ class ActionDispatch::TestResponse
   end
 end
 
+def disable_sfdc_client
+  allow(ActiveForce)
+    .to receive(:sfdc_client)
+    .and_return(double('null object').as_null_object)
+end
+
 RSpec::Matchers.define :have_routine_error do |error_code|
   include RSpec::Matchers::Composable
 

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+describe UpdateUserSalesforceInfo do
+  let!(:user) { FactoryGirl.create :user }
+
+  let!(:contact_info) {
+    email = AddEmailToUser.call("bob@example.com", user).outputs.email
+    ConfirmContactInfo.call(email)
+    email
+  }
+
+  NOTIFICATION_EMAIL = 'to@example.com'
+
+  before(:each) {
+    (SECRET_SETTINGS[:mail_recipients] ||= {}).merge!(salesforce: NOTIFICATION_EMAIL)
+  }
+
+  context 'user has no SF info yet' do
+    it 'caches it when the SF info exists on SF' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})
+      described_class.call
+      expect_user_sf_data(user, id: "foo", faculty_status: :confirmed_faculty)
+    end
+
+    it 'does not explode when the SF info does not exist on SF' do
+      stub_contacts([])
+      described_class.call
+      expect_user_sf_data(user, id: nil, faculty_status: :no_faculty_info)
+    end
+  end
+
+  context 'user has SF info that is up to date' do
+    before {
+      user.salesforce_contact_id = 'foo'
+      user.faculty_status = :confirmed_faculty
+      user.save!
+    }
+
+    it 'does not trigger a save on the user' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})
+      expect_any_instance_of(User).not_to receive(:save!)
+      described_class.call
+    end
+  end
+
+  context 'user has SF info that is out of date' do
+    before {
+      user.salesforce_contact_id = 'bar'
+      user.faculty_status = :confirmed_faculty
+      user.save!
+    }
+
+    it 'corrects faculty status' do
+      stub_contacts({id: 'bar', email: 'bob@example.com', faculty_verified: "Pending"})
+      described_class.call
+      expect_user_sf_data(user, id: "bar", faculty_status: :pending_faculty)
+    end
+
+    it 'corrects sf ID' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})
+      described_class.call
+      expect_user_sf_data(user, id: "foo", faculty_status: :confirmed_faculty)
+    end
+
+    it 'corrects both' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Pending"})
+      described_class.call
+      expect_user_sf_data(user, id: "foo", faculty_status: :pending_faculty)
+    end
+  end
+
+  context 'user maps to multipe SF contacts' do
+    it 'sends an error message' do
+      email = AddEmailToUser.call("otherbob@example.com", user).outputs.email
+      ConfirmContactInfo.call(email)
+      stub_contacts([{id: 'foo', email: 'bob@example.com', faculty_verified: "Pending"},
+                     {id: 'foo2', email: 'otherbob@example.com', faculty_verified: "Pending"}])
+      expect(Rails.logger).to receive(:warn)
+      expect { described_class.call }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  context 'user matches SF info via unverified email' do
+    it 'does not sync that SF info' do
+      AddEmailToUser.call("unverified@example.com", user)
+      stub_contacts({id: 'foo', email: 'unverified@example.com', faculty_verified: "Confirmed"})
+      described_class.call
+      expect_user_sf_data(user, id: nil, faculty_status: :no_faculty_info)
+    end
+  end
+
+  context 'exceptions happen gracefully' do
+    it 'rescues in the first pass' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})
+      allow_any_instance_of(User).to receive(:salesforce_contact_id).and_raise("boom")
+      expect_any_instance_of(described_class).to receive(:error!)
+      expect{ described_class.call }.not_to raise_error
+    end
+
+    it 'rescues in the second pass' do
+      stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})
+      allow_any_instance_of(EmailAddress).to receive(:verified?).and_raise("boom")
+      expect_any_instance_of(described_class).to receive(:error!)
+      expect{ described_class.call }.not_to raise_error
+    end
+  end
+
+  context '#cache_contact_data_in_user' do
+    it 'handles nil contacts' do
+      described_class.new.cache_contact_data_in_user(nil, user)
+      expect(user.salesforce_contact_id).to be_nil
+      expect(user.faculty_status).to eq 'no_faculty_info'
+    end
+
+    it 'handles Confirmed faculty status' do
+      contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Confirmed")
+      described_class.new.cache_contact_data_in_user(contact, user)
+      expect(user.salesforce_contact_id).to eq 'foo'
+      expect(user.faculty_status).to eq 'confirmed_faculty'
+    end
+
+    it 'handles Pending faculty status' do
+      contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Pending")
+      described_class.new.cache_contact_data_in_user(contact, user)
+      expect(user.salesforce_contact_id).to eq 'foo'
+      expect(user.faculty_status).to eq 'pending_faculty'
+    end
+
+    it 'handles Rejected faculty status' do
+      contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Rejected")
+      described_class.new.cache_contact_data_in_user(contact, user)
+      expect(user.salesforce_contact_id).to eq 'foo'
+      expect(user.faculty_status).to eq 'rejected_faculty'
+    end
+
+    it 'handles Rejected2 faculty status' do
+      contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Rejected2")
+      described_class.new.cache_contact_data_in_user(contact, user)
+      expect(user.salesforce_contact_id).to eq 'foo'
+      expect(user.faculty_status).to eq 'rejected_faculty'
+    end
+
+    it 'raises for unknown faculty status' do
+      contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Diddly")
+      expect{
+        described_class.new.cache_contact_data_in_user(contact, user)
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  it 'does not do an N+1 query on user contact infos' do
+    contacts = []
+
+    10.times do |ii|
+      user = FactoryGirl.create :user
+      email = AddEmailToUser.call("bob#{ii}@example.com", user).outputs.email
+      ConfirmContactInfo.call(email)
+      contacts.push({id: "foo#{ii}", email: "bob#{ii}@example.com", faculty_verified: "Confirmed"})
+    end
+
+    stub_contacts(contacts)
+    expect{described_class.call}.to make_database_queries(matching: /^SELECT/, count: 3)
+  end
+
+  def stub_contacts(contacts)
+    contacts = [contacts].flatten.map do |contact|
+      case contact
+      when Salesforce::Contact
+        contact
+      when Hash
+        Salesforce::Contact.new(id: contact[:id],
+                                email: contact[:email],
+                                faculty_verified: contact[:faculty_verified])
+      end
+    end
+
+    allow(Salesforce::Contact).to receive(:select).and_return(contacts)
+  end
+
+  def expect_user_sf_data(user, id: nil, faculty_status: :no_faculty_info)
+    user.reload
+    expect(user.salesforce_contact_id).to eq id
+    expect(user.faculty_status).to eq faculty_status.to_s
+  end
+end

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -9,12 +9,6 @@ describe UpdateUserSalesforceInfo do
     email
   }
 
-  NOTIFICATION_EMAIL = 'to@example.com'
-
-  before(:each) {
-    (SECRET_SETTINGS[:mail_recipients] ||= {}).merge!(salesforce: NOTIFICATION_EMAIL)
-  }
-
   context 'user has no SF info yet' do
     it 'caches it when the SF info exists on SF' do
       stub_contacts({id: 'foo', email: 'bob@example.com', faculty_verified: "Confirmed"})


### PR DESCRIPTION
Links Accounts users to SF contacts.  Caches their faculty verification information and provides it to product sites via the user JSON.

Added a full page admin console...

![image](https://cloud.githubusercontent.com/assets/1001691/19621556/256d768c-9849-11e6-93e5-a9fadddb5a16.png)

Salesforce management screen:

![image](https://cloud.githubusercontent.com/assets/1001691/19621560/3ab2a7c4-9849-11e6-88cf-c0deb42f36bd.png)

Left the popup admin console in for now with a link to the full page one...

![image](https://cloud.githubusercontent.com/assets/1001691/19621553/17170620-9849-11e6-9428-54341acf6a2f.png)

User detail page shows faculty status info, SF contact ID (with link)

## TODO

* [x] Include faculty verification status in oauth info returned to product sites
  * this will be handled in accounts-rails
* [x] Include faculty verification status in user GET API
* [ ] Update deployment repo to have new secrets (wait for Rails 4 merge; salesforce keys and salesforce mail recipient)
* [x] Handle `Email_alt`
* [x] Update AnonymousUser to match interface of User
* [x] Code to read recently updated SF Contacts in batches and copy SF ID and faculty verification status to Accounts User (when verified email matches) (store last modified date read for last Contact pulled from)
* [x] Cron scheduling of that code
* [x] Make sure admin views return to the admin dialog after login / destroy SF user
* [x] Provide a manual trigger for an admin to re-read all fac verification info
* [x] Spec to make sure only /api/user returns SF info.
* [X] SPECS!