### PR TITLE
Add created_at information to find duplicate accounts rake task

### DIFF
--- a/lib/tasks/find_duplicate_accounts.rake
+++ b/lib/tasks/find_duplicate_accounts.rake
@@ -3,10 +3,11 @@ task :find_duplicate_accounts => [:environment] do
   CSV.open("duplicate_users_by_name.csv", 'w+') do |csv|
     csv << ['User First Name',
             'User Last Name',
+            'Created At',
             'Email Address(es)',
             'User ID',
             'Applications',
-            'Social Signup Successful?',
+            'Signup Successful?',
             'Reset Password Help Requested?',
             'Help Request Failed?',
             'Authentication Transfer Failed?'
@@ -21,6 +22,7 @@ task :find_duplicate_accounts => [:environment] do
     where_names_match.find_each do |user|
       csv << [user.first_name,
               user.last_name,
+              user.created_at.to_s,
               (user.contact_infos.any? ? user.contact_infos.map{ |ci| "#{ci.value} #{ci.verified ? '(verified)' : '(NOT verified)'}" }.join(", ") : ""),
               user.id,
               (user.applications.any? ? ( user.applications.map(&:name).join(", ") ) : ""),
@@ -34,12 +36,13 @@ task :find_duplicate_accounts => [:environment] do
 
   CSV.open("duplicate_users_by_email.csv", 'w+') do |csv|
     csv << ['Email Address',
+            'Created At',
             'ContactInfo ID',
             'User First Name',
             'User Last Name',
             'User ID',
             'Applications',
-            'Social Signup Successful?',
+            'Signup Successful?',
             'Reset Password Help Requested?',
             'Help Request Failed?',
             'Authentication Transfer Failed?'
@@ -52,6 +55,7 @@ task :find_duplicate_accounts => [:environment] do
     where_email_addresses_match.find_each do |contact_info|
       csv << [
               "#{contact_info.value} #{contact_info.verified ? '(verified)' : '(NOT verified)'}",
+              contact_info.created_at.to_s,
               contact_info.id,
               contact_info.user.try(:first_name),
               contact_info.user.try(:last_name),

--- a/spec/lib/tasks/find_duplicate_accounts_spec.rb
+++ b/spec/lib/tasks/find_duplicate_accounts_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe "find_duplicate_accounts" do
 
       expect(result[0]["User First Name"]).to eq user_1.first_name
       expect(result[0]["User Last Name"]).to eq user_1.last_name
+      expect(result[0]["Created At"]).to eq user_1.created_at.to_s
       expect(result[0]["Email Address(es)"]).to eq "#{email_2_user_1.value} (verified), #{email_1_user_1.value} (NOT verified)"
       expect(result[0]["User ID"]).to eq user_1.id.to_s
-      expect(result[0]["Social Signup Successful?"]).to eq "On #{sus_user_1.created_at}"
+      expect(result[0]["Signup Successful?"]).to eq "On #{sus_user_1.created_at}"
       expect(result[0]["Reset Password Help Requested?"]).to eq "On #{help_req_1_user_1.created_at} and On #{help_req_2_user_1.created_at}"
       expect(result[0]["Help Request Failed?"]).to eq "On #{help_req_fail_user_1.created_at}"
       expect(result[0]["Authentication Transfer Failed?"]).to be_empty
@@ -51,9 +52,10 @@ RSpec.describe "find_duplicate_accounts" do
 
       expect(result[1]["User First Name"]).to eq same_name.first_name
       expect(result[1]["User Last Name"]).to eq same_name.last_name
+      expect(result[1]["Created At"]).to eq same_name.created_at.to_s
       expect(result[1]["Email Address(es)"]).to eq "#{email_1_user_same_name.value} (verified)"
       expect(result[1]["User ID"]).to eq same_name.id.to_s
-      expect(result[1]["Social Signup Successful?"]).to eq "On #{sus_user_same_name.created_at}"
+      expect(result[1]["Signup Successful?"]).to eq "On #{sus_user_same_name.created_at}"
       expect(result[1]["Reset Password Help Requested?"]).to be_empty
       expect(result[1]["Help Request Failed?"]).to be_empty
       expect(result[1]["Authentication Transfer Failed?"]).to eq "On #{auth_transfer_fail_user_same_name.created_at}"
@@ -103,23 +105,25 @@ RSpec.describe "find_duplicate_accounts" do
       expect(SecurityLog.count).to eq 6
 
       expect(result[0]["Email Address"]).to eq "#{email_1.value} (verified)"
+      expect(result[0]["Created At"]).to eq email_1.created_at.to_s
       expect(result[0]["ContactInfo ID"]).to eq email_1.id.to_s
       expect(result[0]["User First Name"]).to eq user_1.first_name
       expect(result[0]["User Last Name"]).to eq user_1.last_name
       expect(result[0]["User ID"]).to eq user_1.id.to_s
       expect(result[0]["Applications"]).to eq "#{user_1.applications.first.name}, #{user_1.applications.second.name}"
-      expect(result[0]["Social Signup Successful?"]).to eq "On #{sus_user_1.created_at}"
+      expect(result[0]["Signup Successful?"]).to eq "On #{sus_user_1.created_at}"
       expect(result[0]["Reset Password Help Requested?"]).to eq "On #{help_req_1_user_1.created_at} and On #{help_req_2_user_1.created_at}"
       expect(result[0]["Help Request Failed?"]).to eq "On #{help_req_fail_user_1.created_at}"
       expect(result[0]["Authentication Transfer Failed?"]).to be_empty
 
       expect(result[1]["Email Address"]).to eq "#{same_email_diff_user.value} (NOT verified)"
+      expect(result[1]["Created At"]).to eq email_1.created_at.to_s
       expect(result[1]["ContactInfo ID"]).to eq same_email_diff_user.id.to_s
       expect(result[1]["User First Name"]).to eq user_2.first_name
       expect(result[1]["User Last Name"]).to eq user_2.last_name
       expect(result[1]["User ID"]).to eq user_2.id.to_s
       expect(result[1]["Applications"]).to be_empty
-      expect(result[1]["Social Signup Successful?"]).to eq "On #{sus_user_2.created_at}"
+      expect(result[1]["Signup Successful?"]).to eq "On #{sus_user_2.created_at}"
       expect(result[1]["Reset Password Help Requested?"]).to be_empty
       expect(result[1]["Help Request Failed?"]).to be_empty
       expect(result[1]["Authentication Transfer Failed?"]).to eq "On #{auth_transfer_fail_user_2.created_at}"


### PR DESCRIPTION
Only newer accounts create a security log for sign up successful. So this PR gets the actual `created_at` information from the record itself.

Done per Debshila's request.

Also, the security log `:sign_up_successful` _isn't_ only for social sign up, so I corrected the wording on the CSV file.