### PR TITLE
Include user authentications, remove dependency on a specific order, add preloads

### DIFF
--- a/lib/tasks/find_duplicate_accounts.rake
+++ b/lib/tasks/find_duplicate_accounts.rake
@@ -7,6 +7,7 @@ task :find_duplicate_accounts => [:environment] do
             'Email Address(es)',
             'User ID',
             'Applications',
+            'Authentications',
             'Signup Successful?',
             'Reset Password Help Requested?',
             'Help Request Failed?',
@@ -17,7 +18,7 @@ task :find_duplicate_accounts => [:environment] do
                     .on{
                       (same.id != ~id) & (lower(same.first_name) == lower(~first_name)) & (lower(same.last_name) == lower(~last_name))
                     }
-                  }.uniq.order(:first_name, :last_name).includes(:security_logs)
+                  }.uniq.preload(:security_logs, :applications, :authentications, :contact_infos)
 
     where_names_match.find_each do |user|
       csv << [user.first_name,
@@ -26,6 +27,7 @@ task :find_duplicate_accounts => [:environment] do
               (user.contact_infos.any? ? user.contact_infos.map{ |ci| "#{ci.value} #{ci.verified ? '(verified)' : '(NOT verified)'}" }.join(", ") : ""),
               user.id,
               (user.applications.any? ? ( user.applications.map(&:name).join(", ") ) : ""),
+              (user.authentications.any? ? user.authentications.map(&:display_name).join(", ") : ""),
               sign_up_successful(user),
               help_requested(user),
               help_request_failed(user),
@@ -42,6 +44,7 @@ task :find_duplicate_accounts => [:environment] do
             'User Last Name',
             'User ID',
             'Applications',
+            'Authentications',
             'Signup Successful?',
             'Reset Password Help Requested?',
             'Help Request Failed?',
@@ -50,21 +53,23 @@ task :find_duplicate_accounts => [:environment] do
 
     where_email_addresses_match = ContactInfo.joins{ ContactInfo.unscoped.as(same)
                                                .on{ (same.id != ~id) & (lower(same.value) == lower(value)) }
-                                    }.joins{ user.outer }.preload(:user).uniq
+                                    }.joins{ user.outer }.preload(user: [:security_logs, :applications, :authentications]).uniq
 
     where_email_addresses_match.find_each do |contact_info|
+      user = contact_info.user
       csv << [
               "#{contact_info.value} #{contact_info.verified ? '(verified)' : '(NOT verified)'}",
               contact_info.created_at.to_s,
               contact_info.id,
-              contact_info.user.try(:first_name),
-              contact_info.user.try(:last_name),
-              contact_info.user.try(:id),
-              (contact_info.user && contact_info.user.applications.any?) ? contact_info.user.applications.map(&:name).join(", ") : "",
-              sign_up_successful(contact_info.user),
-              help_requested(contact_info.user),
-              help_request_failed(contact_info.user),
-              authentication_transfer_failed(contact_info.user)
+              user.try(:first_name),
+              user.try(:last_name),
+              user.try(:id),
+              (user && user.applications.any?)    ? user.applications.map(&:name).join(", ") : "",
+              (user && user.authentications.any?) ? user.authentications.map(&:display_name).join(", ") : "",
+              sign_up_successful(user),
+              help_requested(user),
+              help_request_failed(user),
+              authentication_transfer_failed(user)
              ]
     end
   end


### PR DESCRIPTION
Per Debshila's request.

I also removed the `order`ing by `first_name` and `last_name` because it won't work with `find_each` anyway (it orders by `id`).

Also preloaded more stuff and removed dependency on a specific order for records to get returned.