### PR TITLE
Prevent double click on help page's submit button

### DIFF
--- a/app/views/sessions/help.html.erb
+++ b/app/views/sessions/help.html.erb
@@ -14,7 +14,7 @@
   <div class="col-sm-6">
     <%= lev_form_for :help, url: '' do |f| %>
       <%= standard_field form: f, name: :username_or_email, type: :text_field, label: 'Username or Email' %>
-      <%= submit_tag 'Submit', class: 'btn btn-primary' %>
+      <%= submit_tag 'Submit', disable_with: "Submitting...", class: 'btn btn-primary' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This PR adds to the **Submit** button `disable_with: "Submitting..."`

To **_try_** to prevent this error:
```
A PG::UniqueViolation occurred in sessions#help:

  ERROR:  duplicate key value violates unique constraint "index_password_reset_codes_on_identity_id"
DETAIL:  Key (identity_id)=(3532) already exists.

  activerecord (3.2.22) lib/active_record/connection_adapters/postgresql_adapter.rb:1176:in `get_last_result'
```