### PR TITLE
Restored random parallel spec ordering

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,4 +1,3 @@
---order defined
 --require rspec/instafail
 --format RSpec::Instafail
 --format progress

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem 'chronic'
 gem 'restforce'
 gem 'omniauth-salesforce'
 # Fork that supports Ruby >= 2.1
-gem 'active_force', github: 'openstax/active_force', ref: '9695896f5'
+gem 'active_force', git: 'https://github.com/openstax/active_force', ref: '9695896f5'
 
 # Allows 'ap' alternative to 'pp', used in a mailer
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/openstax/active_force.git
+  remote: https://github.com/openstax/active_force
   revision: 9695896f576ea850d6ca60fb7b8af9c0dd07e8ea
   ref: 9695896f5
   specs:


### PR DESCRIPTION
Turns out that random ordering also affects the ordering of tests within each file, so for fully random parallel tests we need to leave this setting enabled.