### PR TITLE
Save contact_info before delivering email

### DIFF
--- a/app/routines/send_contact_info_confirmation.rb
+++ b/app/routines/send_contact_info_confirmation.rb
@@ -11,7 +11,7 @@ class SendContactInfoConfirmation
     contact_info.confirmation_code    = SecureRandom.hex(32)
     contact_info.confirmation_sent_at = Time.now
     contact_info.save
-    transfer_errors_from(contact_info, {type: :verbatim, fail_if_errors: true})
+    transfer_errors_from(contact_info, {type: :verbatim}, true)
 
     case contact_info.type
     when 'EmailAddress'

--- a/app/routines/send_contact_info_confirmation.rb
+++ b/app/routines/send_contact_info_confirmation.rb
@@ -7,8 +7,11 @@ class SendContactInfoConfirmation
   def exec(contact_info:, send_pin: false)
     return if contact_info.verified
 
-    contact_info.confirmation_code = SecureRandom.hex(32)
-    contact_info.confirmation_pin = SecureRandom.random_number(1000000).to_s.rjust(6,"0") if send_pin
+    contact_info.confirmation_pin     = SecureRandom.random_number(1_000_000).to_s.rjust(6,"0") if send_pin
+    contact_info.confirmation_code    = SecureRandom.hex(32)
+    contact_info.confirmation_sent_at = Time.now
+    contact_info.save
+    transfer_errors_from(contact_info, {type: :verbatim, fail_if_errors: true})
 
     case contact_info.type
     when 'EmailAddress'
@@ -22,10 +25,6 @@ class SendContactInfoConfirmation
       fatal_error(code: :not_yet_implemented, data: contact_info)
     end
 
-    contact_info.confirmation_sent_at = Time.now
-    contact_info.save
-
-    transfer_errors_from(contact_info, {type: :verbatim})
   end
 
 end


### PR DESCRIPTION
Otherwise the contact_info will be reloaded by the deliver_later and the
email will contain the original confirmation_code, not our freshly
generated one.