### PR TITLE
single email per account / multi email login validation 

### DIFF
--- a/app/assets/stylesheets/signinup.scss
+++ b/app/assets/stylesheets/signinup.scss
@@ -19,6 +19,13 @@ body.sessions {
     }
   }
 
+  .identity-password {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    input { margin: 0; }
+  }
+
   .separator-line {
     text-align: center;
     position: relative;
@@ -40,6 +47,5 @@ body.sessions {
       position: absolute;
       top: 50%;
     }
-
   }
 }

--- a/app/handlers/sessions_lookup_login.rb
+++ b/app/handlers/sessions_lookup_login.rb
@@ -19,11 +19,6 @@ class SessionsLookupLogin
 
   def handle
     run(GetLoginInfo, username_or_email: login_params.username_or_email)
-    fatal_error(code: :several_accounts_for_one_email) if input_is_email? && outputs.names.many?
   end
 
-
-  def input_is_email?
-    login_params.username_or_email.include?('@')
-  end
 end

--- a/app/handlers/sessions_lookup_login.rb
+++ b/app/handlers/sessions_lookup_login.rb
@@ -19,5 +19,11 @@ class SessionsLookupLogin
 
   def handle
     run(GetLoginInfo, username_or_email: login_params.username_or_email)
+    fatal_error(code: :several_accounts_for_one_email) if input_is_email? && outputs.names.many?
+  end
+
+
+  def input_is_email?
+    login_params.username_or_email.include?('@')
   end
 end

--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -24,7 +24,7 @@ class ContactInfo < ActiveRecord::Base
 
   before_save :add_unread_update
   before_destroy :check_if_last_verified
-  before_create :check_if_email_taken
+  before_save :check_if_email_taken
 
   def confirmed;  verified;  end
   def confirmed?; verified?; end
@@ -62,7 +62,7 @@ class ContactInfo < ActiveRecord::Base
   end
 
   def check_if_email_taken
-    if self.new_record? && self.email? && ContactInfo.email_addresses.where(value: value).any?
+    if (new_record? || value_changed?) && ContactInfo.email_addresses.where(value: value).any?
       errors.add(:value, 'email is already in use')
       return false
     end

--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -24,9 +24,12 @@ class ContactInfo < ActiveRecord::Base
 
   before_save :add_unread_update
   before_destroy :check_if_last_verified
+  before_create :check_if_email_taken
 
   def confirmed;  verified;  end
   def confirmed?; verified?; end
+
+  def email?; type == 'EmailAddress' end
 
   def to_subclass
     return self unless valid?
@@ -54,6 +57,13 @@ class ContactInfo < ActiveRecord::Base
   def check_if_last_verified
     if verified? and not user.contact_infos.verified.many? and not destroyed_by_association
       errors.add(:user, 'unable to delete last verified email address')
+      return false
+    end
+  end
+
+  def check_if_email_taken
+    if self.new_record? && self.email? && ContactInfo.email_addresses.where(value: value).any?
+      errors.add(:value, 'email is already in use')
       return false
     end
   end

--- a/app/views/sessions/authenticate.html.erb
+++ b/app/views/sessions/authenticate.html.erb
@@ -42,7 +42,7 @@
     </div>
 
     <% end %>
-    <%= lev_form_for :login, url: '/auth/identity/callback' do |f| %>
+    <%= lev_form_for :login, url: '/auth/identity/callback', html: {class: "identity-password"} do |f| %>
 
       <%= f.password_field :password, placeholder: t(".password")  %>
 
@@ -50,12 +50,9 @@
 
       <input type="submit" class="primary" value="<%= t '.login' %>" />
 
-      <div class="footer">
-
-         </div>
     <% end %>
 
-    <p>
+    <p class="footer">
       <%= t(:'.trouble_logging_in') %>
       <%= link_to(t(:'.reset_password'), password_send_reset_path, method: :post) %>
     </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,12 +29,6 @@ en:
         You are logged in as %{user_name}. A different %{authentication} account
         is already linked to your OpenStax account. Only one %{authentication}
         account can be linked to your OpenStax account at a time.
-      several_accounts_for_one_email: >-
-        We found several accounts with your email address. Please sign in using
-        your username.
-      no_users: >-
-          We have no account for the username or email you provided. Email
-          addresses must be verified in out system to use them during sign in.
       sign_in_option_already_used: >-
         That sign in option is already used by someone else. If that someone is
         you, remove it from your other account and try again.
@@ -244,18 +238,17 @@ en:
       email: Email
       email_placeholder: Email or username
       username_placeholder: Username
-      unrecognized_email: We don’t recognize this email, please try again.
       next: Next
-      cannot_find_user: 'Cannot find user'
-      unknown_username: We don't recognize this username.  Please try again or try your email instead.
-      unknown_email: We don't recognize this email. Please try again.
+      cannot_find_user: Cannot find user
+      unknown_username: We don’t recognize this username.  Please try again or try your email instead.
+      unknown_email: We don’t recognize this email, please try again.
       multiple_users:
         # %{link}   a hyperlink that sends usernames to the email being used for log in.
         #           The label is defined by the .click_here key.
         content_html: >-
           We found several accounts with this email. Please log in using your username.<br/>
           Forgot your username? %{link}.
-        click_here: Click here and we'll email them to you
+        click_here: Click here and we’ll email them to you
       sent_multiple_usernames: >-
         Please check <strong>%{email}</strong> for an email listing your usernames, and use one to log in.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
       several_accounts_for_one_email: >-
         We found several accounts with your email address. Please sign in using
         your username.
+      no_users: >-
+          We have no account for the username or email you provided. Email
+          addresses must be verified in out system to use them during sign in.
       sign_in_option_already_used: >-
         That sign in option is already used by someone else. If that someone is
         you, remove it from your other account and try again.
@@ -150,9 +153,6 @@ en:
     please_enable_javascript: >-
       Please enable JavaScript in your browser! Some site contet will not work
       properly without it.
-    no_account_for_username_or_email: >-
-        We have no account for the username or email you provided. Email
-        addresses must be verified in out system to use them during sign in.
     alert: 'Alert: '
     any:
       appology_message_html: >-

--- a/lib/import_users.rb
+++ b/lib/import_users.rb
@@ -37,7 +37,7 @@ class ImportUsers
                           row[:title], row[:first_name], row[:last_name],
                           row[:email_address])
               FindOrCreateApplicationUser.call(@app_id, @user.id) unless @app_id.nil?
-            rescue ActiveRecord::RecordInvalid => e
+            rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid => e
               model_name = e.record.class.name
               error = "#{model_name} #{e.inspect}"
             rescue ActiveRecord::StatementInvalid => e

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
   factory :user do
     username { SecureRandom.hex(3) }
     state 'activated' # otherwise the default from DB will be to 'temp'
-    first_name Faker::Name.first_name
-    last_name  Faker::Name.last_name
+    first_name { Faker::Name.first_name }
+    last_name  { Faker::Name.last_name  }
     trait :admin do
       is_administrator true
     end

--- a/spec/features/user_cant_sign_in_spec.rb
+++ b/spec/features/user_cant_sign_in_spec.rb
@@ -32,9 +32,10 @@ feature "User can't sign in", js: true do
     scenario "multiple accounts match email" do
       email_address = 'user@example.com'
       user1 = create_user 'user1'
-      create_email_address_for(user1, email_address)
+      email1 = create_email_address_for(user1, 'user@example.com')
       user2 = create_user 'user2'
-      create_email_address_for(user2, email_address)
+      email2 = create_email_address_for(user2, 'user-2@example.com')
+      ContactInfo.where(id: email2.id).update_all(value: email1.value)
 
       complete_login_username_or_email_screen(email_address)
       expect(page).to have_content(t(:"sessions.new.multiple_users.content_html").split('.')[0])

--- a/spec/features/user_cant_sign_in_spec.rb
+++ b/spec/features/user_cant_sign_in_spec.rb
@@ -32,7 +32,7 @@ feature "User can't sign in", js: true do
     scenario "multiple accounts match email" do
       email_address = 'user@example.com'
       user1 = create_user 'user1'
-      email1 = create_email_address_for(user1, 'user@example.com')
+      email1 = create_email_address_for(user1, email_address)
       user2 = create_user 'user2'
       email2 = create_email_address_for(user2, 'user-2@example.com')
       ContactInfo.where(id: email2.id).update_all(value: email1.value)

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -146,7 +146,7 @@ feature 'User logs in as a local user', js: true do
 
       email = create_email_address_for(another_user, 'temp@example.com')
       # "update_attribute" skips model validation
-      email.update_attribute('value', 'user@example.com')
+      ContactInfo.where(id: email.id).update_all(value: 'user@example.com')
 
       arrive_from_app
       complete_login_username_or_email_screen 'user@example.com'

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -39,7 +39,7 @@ feature 'User logs in as a local user', js: true do
     with_forgery_protection do
       arrive_from_app
       complete_login_username_or_email_screen 'user'
-      expect(page).to have_content(t :"controllers.sessions.no_users")
+      expect(page).to have_content(t :"sessions.new.unknown_username")
     end
   end
 
@@ -120,19 +120,12 @@ feature 'User logs in as a local user', js: true do
   scenario 'with an unverified email address and password' do
     with_forgery_protection do
       arrive_from_app
-
       user = create_user 'user'
       create_email_address_for user, 'user@example.com', 'unverified'
-
       complete_login_username_or_email_screen 'user@example.com'
-
       expect(page).to have_content(t :"sessions.new.unknown_email")
-
-      expect(page).to have_content(t :"controllers.sessions.no_users")
-
       complete_login_username_or_email_screen 'user'
       complete_login_password_screen 'password'
-
       expect_back_at_app
     end
   end
@@ -151,7 +144,7 @@ feature 'User logs in as a local user', js: true do
       arrive_from_app
       complete_login_username_or_email_screen 'user@example.com'
       expect_sign_in_page
-      expect(page).to have_content(t :"controllers.sessions.several_accounts_for_one_email")
+      expect(page).to have_content(t("sessions.new.multiple_users.content_html").sub('<br/>', ' ').sub(' %{link}.', ''))
 
       complete_login_username_or_email_screen 'user'
       complete_login_password_screen 'password'

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -144,7 +144,9 @@ feature 'User logs in as a local user', js: true do
       create_email_address_for(user, 'user@example.com')
       another_user = create_user 'another_user'
 
-      create_email_address_for(another_user, 'user@example.com')
+      email = create_email_address_for(another_user, 'temp@example.com')
+      # "update_attribute" skips model validation
+      email.update_attribute('value', 'user@example.com')
 
       arrive_from_app
       complete_login_username_or_email_screen 'user@example.com'

--- a/spec/lib/tasks/find_duplicate_accounts_spec.rb
+++ b/spec/lib/tasks/find_duplicate_accounts_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe "find_duplicate_accounts" do
       FactoryGirl.create :email_address, user: user_1, verified: true
     end
     let!(:same_email_diff_user) do
-      email = FactoryGirl.create :email_address, user: user_2#, value: email_1.value
-      email.update_attribute('value', email_1.value)
-      email
+      email = FactoryGirl.create :email_address, user: user_2
+      ContactInfo.where(id: email.id).update_all(value: email_1.value)
+      email.reload
     end
 
     let!(:authentication) { FactoryGirl.create :authentication, user: user_1, provider: "facebook" }

--- a/spec/lib/tasks/find_duplicate_accounts_spec.rb
+++ b/spec/lib/tasks/find_duplicate_accounts_spec.rb
@@ -126,7 +126,9 @@ RSpec.describe "find_duplicate_accounts" do
       FactoryGirl.create :email_address, user: user_1, verified: true
     end
     let!(:same_email_diff_user) do
-      FactoryGirl.create :email_address, user: user_2, value: email_1.value
+      email = FactoryGirl.create :email_address, user: user_2#, value: email_1.value
+      email.update_attribute('value', email_1.value)
+      email
     end
 
     let!(:authentication) { FactoryGirl.create :authentication, user: user_1, provider: "facebook" }

--- a/spec/models/contact_info_spec.rb
+++ b/spec/models/contact_info_spec.rb
@@ -28,16 +28,19 @@ describe ContactInfo do
   end
 
   context 'user emails' do
+    let(:user1){ FactoryGirl.create :user }
+    let(:user2){ FactoryGirl.create :user }
 
-    let!(:email1) { FactoryGirl.build(:email_address, verified: true,
-                                      value: 'my@email.com') }
-    let!(:email2) { FactoryGirl.build(:email_address, verified: true,
-                                      value: 'my@email.com') }
+    let!(:email1) { FactoryGirl.build(:email_address, user: user1,
+                                      verified: true, value: 'my1@email.com') }
+    let!(:email2) { FactoryGirl.build(:email_address, user: user2,
+                                      verified: true, value: 'my2@email.com') }
 
     it 'does not allow the same user to have a repeated email address' do
       email1.save!
       expect(email2).to be_valid
       email2.user = email1.user
+      email2.value = email1.value
       expect(email2).not_to be_valid
       expect(email2.errors.types[:value]).to include(:taken)
     end
@@ -53,6 +56,15 @@ describe ContactInfo do
       expect(email2.destroyed?).to be false
       expect(email2.errors[:user].to_s).to include('unable to delete')
     end
+
+    it 'does not allow a user to add an already used email' do
+      email1.save
+      email2.save
+      newemail = user2.email_addresses.build value: email1.value
+      expect(newemail.save).to be false
+      expect(newemail.errors[:value].to_s).to include('email is already in use')
+    end
+
 
   end
 

--- a/spec/models/contact_info_spec.rb
+++ b/spec/models/contact_info_spec.rb
@@ -57,15 +57,24 @@ describe ContactInfo do
       expect(email2.errors[:user].to_s).to include('unable to delete')
     end
 
-    it 'does not allow a user to add an already used email' do
-      email1.save
-      email2.save
-      newemail = user2.email_addresses.build value: email1.value
-      expect(newemail.save).to be false
-      expect(newemail.errors[:value].to_s).to include('email is already in use')
+    context 'when altering email value' do
+      before(:each){
+        email1.save
+        email2.save
+      }
+      it 'does not allow a user to add an already used email' do
+        newemail = user2.email_addresses.build value: email1.value
+        expect(newemail.save).to be false
+        expect(newemail.errors[:value].to_s).to include('email is already in use')
+      end
+
+      it 'does not allow a user to update their email to be a duplicate' do
+        email1.save!
+        email2.save!
+        email1.value = email2.value
+        expect(email1.save).to be false
+        expect(email1.errors[:value].to_s).to include('email is already in use')
+      end
     end
-
-
   end
-
 end

--- a/spec/routines/confirm_by_pin_spec.rb
+++ b/spec/routines/confirm_by_pin_spec.rb
@@ -61,8 +61,11 @@ describe ConfirmByPin do
 
     it 'can succeed after other contact info with same value is confirmed (would be by code)' do
       other_user = FactoryGirl.create(:user)
-      AddEmailToUser.call("bob@example.com", other_user)
-      other_contact_info = other_user.contact_infos.first
+
+      AddEmailToUser.call("bob-2@example.com", other_user)
+      other_contact_info = other_user.contact_infos.last
+      other_contact_info.update_attribute('value', 'bob@example.com')
+
 
       expect(
         described_class.call(contact_info: contact_info, pin: contact_info.confirmation_pin)

--- a/spec/routines/confirm_by_pin_spec.rb
+++ b/spec/routines/confirm_by_pin_spec.rb
@@ -64,9 +64,8 @@ describe ConfirmByPin do
 
       AddEmailToUser.call("bob-2@example.com", other_user)
       other_contact_info = other_user.contact_infos.last
-      other_contact_info.update_attribute('value', 'bob@example.com')
-
-
+      ContactInfo.where(id: other_contact_info.id).update_all(value: 'bob@example.com')
+      other_contact_info.reload
       expect(
         described_class.call(contact_info: contact_info, pin: contact_info.confirmation_pin)
       ).to have_routine_error(:no_pin_confirmation_attempts_remaining)

--- a/spec/routines/merge_unclaimed_users_spec.rb
+++ b/spec/routines/merge_unclaimed_users_spec.rb
@@ -10,13 +10,19 @@ describe MergeUnclaimedUsers do
     end
     let!(:matching_user) do
       u = FactoryGirl.create(:user)
-      AddEmailToUser.call('unclaimeduser@example.com', u)
+      AddEmailToUser.call('matched@example.com', u)
       u
+    end
+    let(:matching_email) do
+      email = matching_user.contact_infos.last
+      email.value = 'unclaimeduser@example.com'
+      email.save(validate: false)
+      email
     end
 
     it "is claimed when email matches" do
       expect do
-        MergeUnclaimedUsers.call(matching_user.contact_infos.first)
+        MergeUnclaimedUsers.call(matching_email)
       end.to change(User,:count).by(-1)
       expect{ unclaimed_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -31,7 +37,7 @@ describe MergeUnclaimedUsers do
       application_user = FactoryGirl.create :application_user,
                                             application: application, user: unclaimed_user
 
-      MergeUnclaimedUsers.call(matching_user.contact_infos.first)
+      MergeUnclaimedUsers.call(matching_email)
       expect(matching_user.member_groups).to include(group)
       expect(matching_user.owned_groups).to  include(group)
 


### PR DESCRIPTION
Hey, I made this one against the correct branch on the FIRST try

This enforces no shared emails between accounts.  Existing duplicates are ok, but a new email can't be added or it's `value` updated to have a duplicate email.

This implements the error message for when someone attempts to login with an email that's shared between multiple accounts.

![screen shot 2016-11-22 at 2 04 59 pm](https://cloud.githubusercontent.com/assets/79566/20539966/b17e4e2c-b0bc-11e6-8942-d69f7bc447f1.png)
