### PR TITLE
Submit below pw & other things

### DIFF
--- a/app/assets/javascripts/signup/type-selector.coffee
+++ b/app/assets/javascripts/signup/type-selector.coffee
@@ -17,6 +17,7 @@ class OX.Signup.TypeSelector
     if initial.length
       @el.val('student') if @el.val() is 'initial'
       initial.remove()
+      @onChange()
 
   onChange: ->
     @getEmail().setType(@el.val())

--- a/app/assets/stylesheets/ox-controls.scss
+++ b/app/assets/stylesheets/ox-controls.scss
@@ -35,11 +35,11 @@
   input {
     color: $os_gray;
     font-size: 1.8rem;
-    padding: 1rem 0.8rem;
-    margin: 0.5rem 0;
     border-radius: 0px;
     &:not([type="checkbox"]):not([type="radio"]):not([type="submit"]) {
       width: 100%;
+      padding: 1rem 0.8rem;
+      margin: 0.5rem 0;
     }
     &[type="text"],
     &[type="password"] {

--- a/app/assets/stylesheets/ox-controls.scss
+++ b/app/assets/stylesheets/ox-controls.scss
@@ -55,7 +55,7 @@
 
   select:not([multiple]) {
     background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='50px' height='50px'><polyline points='46.139,15.518 25.166,36.49 4.193,15.519'/></svg>") right no-repeat;
-    background-position: right 1rem top $input-height-base / 4;
+    background-position: right 1rem center;
     background-size: 18px 18px;
     background-color: white;
     border-radius: 0px;

--- a/app/assets/stylesheets/ox-controls.scss
+++ b/app/assets/stylesheets/ox-controls.scss
@@ -38,7 +38,7 @@
     padding: 1rem 0.8rem;
     margin: 0.5rem 0;
     border-radius: 0px;
-    &:not([type="checkbox"],[type="radio"]) {
+    &:not([type="checkbox"]):not([type="radio"]):not([type="submit"]) {
       width: 100%;
     }
     &[type="text"],

--- a/app/assets/stylesheets/signinup.scss
+++ b/app/assets/stylesheets/signinup.scss
@@ -19,16 +19,4 @@ body.sessions {
     }
   }
 
-  .identity-password {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    input {
-      margin: 0;
-      width: 46%;
-      &[type=submit].primary { width: 46%; }
-    }
-
-  }
-
 }

--- a/app/views/signup/profile.html.erb
+++ b/app/views/signup/profile.html.erb
@@ -15,7 +15,6 @@
                                 context: self,
                                 errors: @handler_result.try(:errors)) %>
 
-    <h3><%= t('.name_heading') %></h3>
     <%= fh.text_field name: :first_name, value: current_user.first_name %>
     <%= fh.text_field name: :last_name, value: current_user.last_name %>
     <%= fh.text_field name: :suffix %>
@@ -100,9 +99,7 @@
           <%= f.check_box :i_agree %>
           <%= t :".have_read_terms_and_agree_html",
                 terms_of_use: contract_links[0],
-                privacy_policy: contract_links[1]
-              %><br/>
-          <i><%= t :".policies_notice" %></i>
+                privacy_policy: contract_links[1] %>
         </label>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -354,7 +354,6 @@ en:
 
     profile:
       page_heading: Complete your account
-      name_heading: Name
       instructor_verification_heading: Instructor verification
       instructor_verification_help: >-
         We need information to help verify you’re an instructor and give you access


### PR DESCRIPTION
Sets the password field to be full width and submit below it

Calls onChange so the email field is displayed even if a selection isn't explicitly made on the signup field.

Removes the Name heading and policy notice from signup.

<img width="677" alt="screen shot 2016-11-28 at 9 45 31 pm" src="https://cloud.githubusercontent.com/assets/79566/20695790/3217dce6-b5b4-11e6-85c3-98fd4ded599c.png">

<img width="675" alt="screen shot 2016-11-28 at 9 37 59 pm" src="https://cloud.githubusercontent.com/assets/79566/20695741/e029fb44-b5b3-11e6-921d-7980fa57d039.png">