### PR TITLE
various style tweaks

### DIFF
--- a/app/assets/stylesheets/application_layout.scss
+++ b/app/assets/stylesheets/application_layout.scss
@@ -15,7 +15,7 @@ body {
 
 body, p, ol, ul, td, a {
   font-family: $os_font_family;
-  font-size:   13px;
+  font-size:   14px;
   font-weight: normal;
   font-color:  black;
 }

--- a/app/assets/stylesheets/application_layout.scss
+++ b/app/assets/stylesheets/application_layout.scss
@@ -14,7 +14,7 @@ body {
 }
 
 body, p, ol, ul, td, a {
-  font-family: verdana, arial, helvetica, sans-serif;
+  font-family: $os_font_family;
   font-size:   13px;
   font-weight: normal;
   font-color:  black;
@@ -110,7 +110,7 @@ body, p, ol, ul, td, a {
   height: $application_footer_height;
   color:            $os_gray;
   font-size:        10px;
-  font-family:      verdana, arial, helvetica, sans-serif;
+
   line-height:      14px;
 
   div {

--- a/app/assets/stylesheets/application_layout.scss
+++ b/app/assets/stylesheets/application_layout.scss
@@ -134,7 +134,6 @@ body, p, ol, ul, td, a {
     }
   }
 
-
 }
 
 #upper-corner-console {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -7,5 +7,6 @@
 @import "compass/utilities";
 
 $os_font_family: 'HelveticaNeue', 'Helvetica Neue', Arial, sans-serif;
+$os-section-spacing: 30px;
 
 $os_heading_font_family: 'HelveticaNeue-Bold', 'Helvetica Neue Bold', 'Helvetica Neue', Arial, sans-serif;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -6,4 +6,6 @@
 @import "compass/css3";
 @import "compass/utilities";
 
-$os_heading_font_family: 'HelveticaNeue-Bold', 'Helvetica Neue Bold', 'Helvetica Neue';
+$os_font_family: 'HelveticaNeue', 'Helvetica Neue', Arial, sans-serif;
+
+$os_heading_font_family: 'HelveticaNeue-Bold', 'Helvetica Neue Bold', 'Helvetica Neue', Arial, sans-serif;

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -46,11 +46,6 @@
     &[type="text"],
     &[type="password"] {
       border: 1px solid darken($os_light_gray, 10%);
-      &:focus {
-        border: 1px solid $os_dark;
-        box-shadow: none;
-        outline: none;
-      }
     }
   }
 

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -1,5 +1,6 @@
 .ox-card {
   $input-height: 50px;
+  $input-border-color: darken($os_light_gray, 10%);
 
   display: block;
   margin: auto;
@@ -29,6 +30,9 @@
     width: 50%;
     float: left;
   }
+  .card-body {
+    min-height: 250px;
+  }
   .footer {
     margin-top: $os-section-spacing;
     padding-top: $os-section-spacing;
@@ -50,12 +54,12 @@
     }
     &[type="text"],
     &[type="password"] {
-      border: 1px solid darken($os_light_gray, 10%);
+      border: 1px solid $input-border-color;
     }
   }
 
   select:not([multiple]) {
-    background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='50px' height='50px'><polyline points='46.139,15.518 25.166,36.49 4.193,15.519'/></svg>") right no-repeat;
+    background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='50px' height='50px'><polyline fill='" + $input-border-color +"' points='46.139,15.518 25.166,36.49 4.193,15.519'/></svg>") right no-repeat;
     background-position: right 1rem center;
     background-size: 18px 18px;
     background-color: white;

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -31,7 +31,7 @@
     float: left;
   }
   .card-body {
-    min-height: 250px;
+    min-height: 200px;
   }
   .footer {
     margin-top: $os-section-spacing;

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -6,7 +6,7 @@
   margin: auto;
   max-width: 570px;
   background-color: $os_light_gray;
-  padding: 20px 50px;
+  padding: 30px 50px 50px 50px;
   font-size: 14px;
 
   h1, h2, h3, .minor-heading {

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -1,4 +1,6 @@
 .ox-card {
+  $input-height: 50px;
+
   display: block;
   margin: auto;
   max-width: 570px;
@@ -36,9 +38,9 @@
     color: $os_gray;
     font-size: 16px;
     border-radius: 0px;
+    height: $input-height;
     &:not([type="checkbox"]):not([type="radio"]):not([type="submit"]) {
       width: 100%;
-      padding: 1rem 0.8rem;
       margin: 0.5rem 0;
     }
     &[type="text"],
@@ -51,7 +53,6 @@
       }
     }
   }
-  .form-control { height: inherit; }
 
   select:not([multiple]) {
     background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='50px' height='50px'><polyline points='46.139,15.518 25.166,36.49 4.193,15.519'/></svg>") right no-repeat;
@@ -61,6 +62,7 @@
     border-radius: 0px;
     padding: 1rem 0.8rem;
     font-size: 16px;
+    height: $input-height;
     // don't dispaly the selection arrow since we're using a SVG icon for it
     appearance: none;
     -webkit-appearance: none;
@@ -77,6 +79,7 @@
 
   input[type=submit] {
     width: inherit;
+    height: $input-height;
     &.primary {
       @extend .btn;
       text-transform: uppercase;

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -14,13 +14,13 @@
     color: $os_dark;
   }
   h1.title {
-    margin: 10px 0 20px 0;
+    margin: 0 0 $os-section-spacing 0;
     text-align: center;
     font-size: 18px;
   }
   .minor-heading {
-    margin-top: 18px;
-    margin-bottom: 8px;
+    margin-top: $os-section-spacing;
+    margin-bottom: $os-section-spacing / 2;
   }
   h3 { font-size: 16px; }
   h3 { font-size: 15px; }
@@ -30,18 +30,23 @@
     float: left;
   }
   .footer {
-    margin-top: 1rem;
-    padding-top: 1rem;
+    margin-top: $os-section-spacing;
+    padding-top: $os-section-spacing;
     border-top: 2px solid darken($os_light_gray, 10%);
+    .extra-info {
+      margin-top: $os-section-spacing * 0.3;
+    }
   }
   input {
     color: $os_gray;
     font-size: 16px;
     border-radius: 0px;
-    height: $input-height;
-    &:not([type="checkbox"]):not([type="radio"]):not([type="submit"]) {
-      width: 100%;
-      margin: 0.5rem 0;
+    &:not([type="checkbox"]):not([type="radio"]){
+      height: $input-height;
+      &:not([type="submit"]) {
+        width: 100%;
+        padding-left: 5px;
+      }
     }
     &[type="text"],
     &[type="password"] {
@@ -75,8 +80,10 @@
   input[type=submit] {
     width: inherit;
     height: $input-height;
+    display: block;
     &.primary {
       @extend .btn;
+      display: block;
       text-transform: uppercase;
       border-radius: 0;
       padding: 1rem 2rem;
@@ -111,10 +118,30 @@
     border: 0;
     padding: 0;
   }
+  .warning {
+    color: $state-danger-text; // bs variable
+  }
 
   a:not(.btn) {
     color: $os_link_color;
     text-decoration: underline;
+  }
+
+  .form-group {
+    margin-bottom: 0;
+    & + .warning {
+      margin-top: 5px;
+    }
+  }
+  // elements that should be treated as a "section" and have extra spacing after them
+  // unless they are the last item or their followed by footer
+  select,
+  section,
+  .warning,
+  .form-group {
+    & + *:not(.footer):not(.alert):not(.warning):not(.errors) {
+      margin-top: $os-section-spacing;
+    }
   }
 
 }

--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -4,6 +4,7 @@
   max-width: 570px;
   background-color: $os_light_gray;
   padding: 20px 50px;
+  font-size: 14px;
 
   h1, h2, h3, .minor-heading {
     font-family: $os_heading_font_family;
@@ -33,7 +34,7 @@
   }
   input {
     color: $os_gray;
-    font-size: 1.8rem;
+    font-size: 16px;
     border-radius: 0px;
     &:not([type="checkbox"]):not([type="radio"]):not([type="submit"]) {
       width: 100%;
@@ -59,7 +60,7 @@
     background-color: white;
     border-radius: 0px;
     padding: 1rem 0.8rem;
-    font-size: 1.8rem;
+    font-size: 16px;
     // don't dispaly the selection arrow since we're using a SVG icon for it
     appearance: none;
     -webkit-appearance: none;

--- a/app/assets/stylesheets/ox-controls.scss
+++ b/app/assets/stylesheets/ox-controls.scss
@@ -12,7 +12,7 @@
 .ox-separator-line {
   text-align: center;
   position: relative;
-  margin: 10px 0;
+  margin: $os-section-spacing 0;
   &:after {
     border-top: 2px solid $os_line_color;
     content: '';

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -108,6 +108,9 @@
         color: $link-color;
         padding: 0;
         font-size: 13px;
+        display: inline;
+        border: 0;
+        background: transparent;
       }
     }
     &.new {

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -13,7 +13,7 @@ body.signup {
   .subjects {
     // Height of list is selected to chop off in middle of line to provide an
     // indication that there's items that can be scrolled to
-    max-height: 139px;
+    max-height: 235px;
     overflow-y: scroll;
     border: 1px solid #ccc;
     padding: 5px;
@@ -34,27 +34,29 @@ body.signup {
     }
 
     .subject {
-      height: 30px;
       display: flex;
-      align-items: center;
+      height: 50px;
 
       & + .subject { border-top: 1px solid $os_line_color; }
       > * {
         margin: 0;
         padding: 0;
+        display: flex;
+        align-items: center;
       }
 
       input {
         margin-top: 0px;
+        align-self: center;
       }
 
       label {
         font-weight: inherit;
         font-size: 15px;
-        display: inline;
         margin-left: 0.5rem;
         flex: 1;
         cursor: pointer;
+        align-self: stretch;
       }
     }
   }

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -10,11 +10,6 @@ body.signup {
     display: none;
   }
 
-  .edu-warning {
-    // bs variable
-    color: $state-danger-text;
-  }
-
   .subjects {
     // Height of list is selected to chop off in middle of line to provide an
     // indication that there's items that can be scrolled to

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -15,18 +15,30 @@ body.signup {
     // indication that there's items that can be scrolled to
     max-height: 139px;
     overflow-y: scroll;
-
     border: 1px solid #ccc;
     padding: 5px;
     background-color: white;
+
+    &::-webkit-scrollbar {
+      -webkit-appearance: none;
+      &:vertical { width: 11px; }
+    }
+    &::-webkit-scrollbar-thumb {
+      border-radius: 8px;
+      border: 2px solid white; /* should match background, can't be transparent */
+      background-color: rgba(0, 0, 0, .5);
+    }
+    &::-webkit-scrollbar-track {
+      background-color: #fff;
+      border-radius: 8px;
+    }
 
     .subject {
       height: 30px;
       display: flex;
       align-items: center;
-      // &:first-child,
+
       & + .subject { border-top: 1px solid $os_line_color; }
-      // &:last-child { border-bottom: 1px solid $os_line_color; }
       > * {
         margin: 0;
         padding: 0;

--- a/app/views/sessions/_authenticate_options.html.erb
+++ b/app/views/sessions/_authenticate_options.html.erb
@@ -41,20 +41,22 @@
     <%= lev_form_for :login, url: '/auth/identity/callback',
         html: {class: collect_errors.any? ? 'is-invalid identity-password' : 'identity-password'} do |f| %>
 
-    <%= f.password_field :password, placeholder: t(".password")  %>
+    <section>
+      <%= f.password_field :password, placeholder: t(".password")  %>
+      <%= render(partial: "layouts/attention") %>
+      <%= f.hidden_field :username_or_email, value: username_or_email %>
+    </section>
 
-    <%= f.hidden_field :username_or_email, value: username_or_email %>
-
+  <section class="footer">
     <input type="submit" class="primary" value="<%= t '.login' %>" />
+    <p class="extra-info">
+      <%= t(:'.forgot_password') %>
+      <%= link_to(t(:'.reset_password'), password_send_reset_path, method: :post) %>.
+    </p>
+  </section>
 
   <% end %>
 
-  <%= render(partial: "layouts/attention") %>
-
-  <p class="footer">
-    <%= t(:'.forgot_password') %>
-    <%= link_to(t(:'.reset_password'), password_send_reset_path, method: :post) %>.
-  </p>
 <% else %>
   <p>
     <%= t(:'.trouble_logging_in') %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -26,11 +26,11 @@
       <% fh = FormHelper::One.new(f: f,
          context: self, errors: @handler_result.try(:errors)) %>
 
-      <section>
+      <div class="card-body">
         <%= fh.text_field name: :username_or_email,
             label: '.email_placeholder' %>
         <%= render(partial: "layouts/attention") %>
-      </section>
+      </div>
 
 
       <section class="footer">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -23,19 +23,23 @@
   <%= lev_form_for :login, url: lookup_login_path,
       html: {class: collect_errors.any? ? 'is-invalid' : ''} do |f| %>
 
-    <%= standard_field form: f, name: :username_or_email,
-        type: :text_field, options: { placeholder: t('.email_placeholder') } %>
+      <% fh = FormHelper::One.new(f: f,
+         context: self, errors: @handler_result.try(:errors)) %>
 
-      <%= render(partial: "layouts/attention") %>
+      <section>
+        <%= fh.text_field name: :username_or_email,
+            label: '.email_placeholder' %>
+        <%= render(partial: "layouts/attention") %>
+      </section>
 
-      <input type="submit" value="<%= t '.next' %>" class="primary" />
 
-      <div class="footer">
-        <p>
+      <section class="footer">
+        <input type="submit" value="<%= t '.next' %>" class="primary" />
+        <p class="extra-info">
           <%= t '.no_account_q' %>
           <%= link_to(t('.sign_up'), signup_password_path) %>.
         </p>
-      </div>
+      </section>
   <% end %>
 
 </div>

--- a/app/views/signup/password.html.erb
+++ b/app/views/signup/password.html.erb
@@ -10,9 +10,11 @@
     <% fh = FormHelper::One.new(f: f,
                                 context: self,
                                 errors: @handler_result.try(:errors)) %>
-    <%= fh.text_field name: :password, type: :password %>
-    <%= fh.text_field name: :password_confirmation, type: :password %>
-    <%= render(partial: "layouts/attention") %>
+    <section>
+      <%= fh.text_field name: :password, type: :password %>
+      <%= fh.text_field name: :password_confirmation, type: :password %>
+      <%= render(partial: "layouts/attention") %>
+    </section>
     <%= f.submit (t :".create_password"), class: 'primary' %>
   <% end %>
 

--- a/app/views/signup/start.html.erb
+++ b/app/views/signup/start.html.erb
@@ -38,12 +38,14 @@ signup_roles = {
       </div>
 
       <%= fh.text_field name: :email, value: signup_email, label: :'.email_placeholder' %>
-      <p class="edu-warning">
+      <p class="warning">
         <%= t '.teacher_school_email_warning', button: (t :'.next').downcase %>
       </p>
       <%= render(partial: "layouts/attention") %>
     </div>
-    <%= f.submit (t :".next"), class: 'primary' %>
+    <section class="footer">
+      <%= f.submit (t :".next"), class: 'primary' %>
+    </section>
   <% end %>
 
 </div>

--- a/app/views/signup/verify_email.html.erb
+++ b/app/views/signup/verify_email.html.erb
@@ -24,7 +24,12 @@
 
       <%= fh.text_field name: :pin %>
       <%= render(partial: "layouts/attention") %>
-      <%= f.submit (t :".confirm"), class: 'primary' %>
+      <section class="footer">
+        <%= f.submit (t :".confirm"), class: 'primary' %>
+        <p class="extra-info">
+          <%= t :".used_wrong_email" %> <%= link_to (t :".edit_email_address"), signup_path %>.
+        </p>
+      </section>
     <% end %>
 
   <% else %>
@@ -41,7 +46,5 @@
 
     <%= render(partial: "layouts/attention") %>
   <% end %>
-
-  <p><%= t :".used_wrong_email" %> <%= link_to (t :".edit_email_address"), signup_path %>.</p>
 
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,7 @@ en:
       check_your_email: Check your inbox for %{email}!
       you_will_have_received: You will have received a six-digit PIN. Enter it below.
       pin_not_correct: This PIN is incorrect.  Please enter the correct PIN.
+      blank: cannot be blank.
       no_pin_confirmation_attempts_remaining:
         content_html: >-
           You have run out of attempts at confirming this email using a PIN.  Please


### PR DESCRIPTION
Per @Fredasaurus TODO is:
* [x] set font to HelveticaNeue everywhere, currently text inputs are still using Verdana
* [x] 16px font for inputs
* [x] 14px base font size elsewhere
* [x] 50px height for inputs
* [x] use bootstrap light blue diffused border for focused inputs
* [x] 30px bottom margin to separate different elements on cards
* [x] 480(ish) min-height on cards, but with footer at bottom. Make an inner div that has an appropriate min-height
* [x] use ox light gray for the dropdown arrow icon
* [x] attempt to get scrollbars always visible on profile screen
* [x] 50px height for each line of the subjects on instructors screen
* [x] enlarge subjects to fit 4.5 rows
* [x] set card's padding to 30px 50px 50px 50px 
~~~attempt to highlight individual fields with red "error" status~~~ <- Will need to get with @jpslav to figure this out

![screen shot 2016-12-02 at 10 23 02 am](https://cloud.githubusercontent.com/assets/79566/20841455/84b2d326-b879-11e6-989f-e3d6afe97c18.png)
