### PR TITLE
Remove fancy signup role option switch-a-roo

### DIFF
--- a/app/assets/javascripts/signup/type-selector.coffee
+++ b/app/assets/javascripts/signup/type-selector.coffee
@@ -5,21 +5,13 @@ class OX.Signup.TypeSelector
     @type_selector = new TypeSelector(role) if role.length
 
   constructor: (@el) ->
-    _.bindAll(@, 'onChange', 'onSelect')
-    @el.mousedown(@onSelect)
+    _.bindAll(@, 'onChange')
+    $("input[type='submit']").attr('disabled', true)
     @el.change(@onChange)
-    @onChange() if @el.val() isnt 'initial'
-
-
-  onSelect: (ev) ->
-     # remove the "I am a" option; it's an invalid selection
-    initial = this.el.find('option[value="initial"]')
-    if initial.length
-      @el.val('student') if @el.val() is 'initial'
-      initial.remove()
-      @onChange()
+    @onChange() if @el.val()
 
   onChange: ->
+    $("input[type='submit']").attr('disabled', false)
     @getEmail().setType(@el.val())
 
   getEmail: ->

--- a/app/views/signup/start.html.erb
+++ b/app/views/signup/start.html.erb
@@ -27,7 +27,8 @@ signup_roles = {
                                 errors: @handler_result.try(:errors)) %>
     <%# TODO put select in form helper %>
 
-    <%= f.select :role, options_for_select(signup_roles.invert.to_a, signup_role) %>
+    <%= f.select :role, options_for_select(signup_roles.invert.to_a,
+        selected: signup_role || 'initial', disabled: "initial", hidden: "initial" ) %>
 
     <div class="email-input-group card-body">
       <div class="audience-help" data-audience="instructor">


### PR DESCRIPTION
It was kinda weird having the email appear before a selection was really made.  Removing it allows us to disable the "Next" until a selection is made.