### PR TITLE
Fix doomsday bugs

### DIFF
--- a/app/assets/javascripts/signup/email-value.coffee
+++ b/app/assets/javascripts/signup/email-value.coffee
@@ -20,6 +20,7 @@ class OX.Signup.EmailValue
     if @userType is 'instructor' and not ((@email.val() == '') or @showing_warning or IS_EDU.test(@email.val()))
       @showing_warning = true
       @group.addClass('has-error')
+      @group.find(".errors").empty()
       @group.find(".edu.warning").show()
       @email.focus()
       ev.preventDefault()

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -23,6 +23,7 @@ class SignupController < ApplicationController
 
   def start
     if request.post?
+      clear_signup_state # start fresh
       handle_with(SignupStart,
                   existing_signup_state: signup_state,
                   return_to: session[:return_to],

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -21,6 +21,7 @@ class TermsController < ApplicationController
     # Prevent routing error email when accessing this route for HTML format
     respond_to do |format|
       format.js
+      format.html
     end
   end
 

--- a/app/mailers/dev_mailer.rb
+++ b/app/mailers/dev_mailer.rb
@@ -2,7 +2,7 @@ class DevMailer < SiteMailer
 
   def inspect_object(object:, to: nil, subject:)
     @object = object
-    mail to: to || Rails.application.secrets.exception[:recipients],
+    mail to: to || Rails.application.secrets.exception['recipients'],
          subject: subject
   end
 

--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -40,12 +40,12 @@ class ContactInfo < ActiveRecord::Base
     user.add_unread_update
   end
 
-  def reset_confirmation_pin!
-    self.confirmation_pin = TokenMaker.contact_info_confirmation_pin
+  def init_confirmation_pin!
+    self.confirmation_pin ||= TokenMaker.contact_info_confirmation_pin
   end
 
-  def reset_confirmation_code!
-    self.confirmation_code = TokenMaker.contact_info_confirmation_code
+  def init_confirmation_code!
+    self.confirmation_code ||= TokenMaker.contact_info_confirmation_code
   end
 
   protected

--- a/app/routines/send_contact_info_confirmation.rb
+++ b/app/routines/send_contact_info_confirmation.rb
@@ -7,8 +7,8 @@ class SendContactInfoConfirmation
   def exec(contact_info:, send_pin: false)
     return if contact_info.verified
 
-    contact_info.reset_confirmation_pin! if send_pin
-    contact_info.reset_confirmation_code!
+    contact_info.init_confirmation_pin! if send_pin
+    contact_info.init_confirmation_code!
     contact_info.save
     transfer_errors_from(contact_info, {type: :verbatim}, true)
 

--- a/app/views/confirmation_mailer/instructions.html.erb
+++ b/app/views/confirmation_mailer/instructions.html.erb
@@ -13,6 +13,10 @@
 <% end %>
 
 
-<p><%= confirm_url(code: @email_address.confirmation_code) %></p>
+<%
+  token_url = confirm_url(code: @email_address.confirmation_code)
+%>
+
+<p><%= link_to token_url, token_url %></p>
 
 <%= render :partial => 'shared/email_closing' %>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,11 +1,12 @@
 <%# Copyright 2011-2016 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<%= page_heading (t :".page_heading") %>
+<%= ox_card(heading: (t :".page_heading")) do %>
 
-<% contract_links = @contracts.collect do |contract|
-     link_to contract.title, term_path(contract), remote: true
-   end %>
+  <% contract_links = @contracts.collect do |contract|
+       link_to contract.title, term_path(contract), remote: true
+     end %>
 
+  <p><%= t :".notice_html", site_name: SITE_NAME, terms_of_use: contract_links[0], privacy_policy: contract_links[1] %></p>
 
-<p><%= t :".notice_html", site_name: SITE_NAME, terms_of_use: contract_links[0], privacy_policy: contract_links[1] %></p>
+<% end %>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,0 +1,5 @@
+<%= ox_card(heading: @contract.title) do %>
+
+  <%= @contract.content.html_safe %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,4 +198,8 @@ Rails.application.routes.draw do
     end
   end
 
+  if Rails.env.test?
+    get '/external_app_for_specs' => 'external_app_for_specs#index'
+  end
+
 end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -133,6 +133,19 @@ feature 'User signs up', js: true do
       screenshot!
     end
 
+    scenario 'non-school warning clears other errors' do
+      create_email_address_for(create_user('otheruser'), "bob@bob.edu")
+      visit signup_path
+      select 'Instructor', from: "signup_role"
+      fill_in (t :"signup.start.email_placeholder"), with: "bob@bob.edu"
+      click_button(t :"signup.start.next")
+      expect(page).to have_content 'Email already in use'
+      fill_in (t :"signup.start.email_placeholder"), with: "non@school.com"
+      click_button(t :"signup.start.next")
+      expect(page).to have_content 'To access faculty-only materials'
+      expect(page).not_to have_content 'Email already in use'
+    end
+
     scenario 'failure because email blank' do
       visit signup_path
       select 'Instructor', from: "signup_role"

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -366,6 +366,31 @@ feature 'User signs up', js: true do
     end
   end
 
+  scenario "email already in use doesn't revert to previous error email" do
+    # This test revealed the need to clear the signup state when the start
+    # action is posted to (in the case that the post fails, we don't set
+    # a new signup state and the form renders with whatever the old signup
+    # state was)
+
+    create_email_address_for(create_user('otheruser'), "bob@bob.edu")
+    arrive_from_app
+    click_sign_up
+    complete_signup_email_screen("Instructor", "somebody@somewhere.com")
+
+    visit '/'
+    click_sign_up
+    expect(page).to have_content(t :"signup.start.page_heading")
+
+    select "Instructor", from: "signup_role"
+    wait_for_ajax
+    wait_for_animations
+    fill_in (t :"signup.start.email_placeholder"), with: "bob@bob.edu"
+
+    click_button(t :"signup.start.next")
+    expect(page).to have_content 'Email already in use'
+    expect(page).to have_xpath("//input[@value='bob@bob.edu']")
+  end
+
   context "user tries to make a duplicate account" do
     scenario "detected by reusing social auth" do
       existing_user = create_user('existing')

--- a/spec/mailers/dev_mailer_spec.rb
+++ b/spec/mailers/dev_mailer_spec.rb
@@ -21,6 +21,13 @@ describe DevMailer, type: :mailer do
         DevMailer.inspect_object object: nil, to: "bob@example.com", subject: "Howdy"
       }.not_to raise_error
     end
+
+    it 'does not explode without a to and uses a default' do
+      expect{
+        mail = (DevMailer.inspect_object object: nil, subject: "Howdy")
+        expect(mail.to).not_to be_empty
+      }.not_to raise_error
+    end
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -268,3 +268,12 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+
+class ExternalAppForSpecsController < ActionController::Base
+  skip_filter *_process_action_callbacks.map(&:filter)
+
+  def index
+    render plain: 'This is a fake external application'
+  end
+end


### PR DESCRIPTION
* Styles the terms index
* Adds HTML views for the individual terms "show" pages for trouble maker Kevin Burleigh
* "Is this your school address?" warning now clears old errors
* Signup state is cleared when signup starts again to prevent confusing state from prior aborted signups from creeping in.
* Fixes bad secrets syntax in DevMailer `to` default
* Makes confirmation tokens not get reset.  Ditto for PINs.  So if your email is slow you can use an old email to confirm.
* makes the external application that simulates the source of oauth calls actually be a local route so we don't constantly grab example.com/blah in our feature specs.