### PR TITLE
downgrade omniauth-facebook to make it work again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'doorkeeper', '2.2.2'
 # OAuth clients
 gem 'omniauth'
 gem 'omniauth-identity'
-gem 'omniauth-facebook'
+gem 'omniauth-facebook', '~>3.0.0'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-facebook (4.0.0)
+    omniauth-facebook (3.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.4.1)
       jwt (~> 1.5.2)
@@ -629,7 +629,7 @@ DEPENDENCIES
   oj
   oj_mimic_json
   omniauth
-  omniauth-facebook
+  omniauth-facebook (~> 3.0.0)
   omniauth-google-oauth2
   omniauth-identity
   omniauth-salesforce


### PR DESCRIPTION
omniauth-facebook 4.0.0 wasn't working, so I downgraded to 3.0.0, which is what production is using (what we had before our Rails 4 upgrade).  Added issue 262 to https://github.com/mkdynamic/omniauth-facebook to document my troubles.