### PR TITLE
Hide searchable checkbox behind edit cog icon

### DIFF
--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -21,7 +21,7 @@ class Email
       delBtn.click(@confirmDelete)
 
   toggleProperties: ->
-    this.$el.find('.properties').toggle()
+    this.$el.toggleClass('expanded')
 
   toggleSpinner: (show) ->
     this.$el.find('.spinner').toggle(_.isBoolean(show) and show)

--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -10,6 +10,7 @@ class Email
     @id = this.$el.attr('data-id')
     this.$el.find('.searchable').change(@saveSearchable)
     this.$el.find('.verify').click(@sendVerification)
+    this.$el.find('.toggle-properties').click(@toggleProperties)
     @update()
 
   update: ->
@@ -18,6 +19,9 @@ class Email
       delBtn.hide()
     else
       delBtn.click(@confirmDelete)
+
+  toggleProperties: ->
+    this.$el.find('.properties').toggle()
 
   toggleSpinner: (show) ->
     this.$el.find('.spinner').toggle(_.isBoolean(show) and show)

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -48,7 +48,7 @@
   }
 
   .info .mod-holder {
-    width: 20px;
+    width: 45px;
     display: inline-block;
     margin-left:15px;
   }
@@ -98,6 +98,7 @@
       top: 15px;
     }
     .properties {
+      display: none;
       margin-left: 20px;
       font-style: italic;
       font-size: 11px;
@@ -118,6 +119,7 @@
         display: inline;
         border: 0;
         background: transparent;
+        height: 20px;
       }
     }
     &.new {

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -106,6 +106,10 @@
         margin-left: 6px;
       }
     }
+    &.expanded {
+      .properties { display: block; }
+      .toggle-properties { color: black; }
+    }
     .verify {
       margin-left: 20px;
       form {

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -43,6 +43,7 @@ module ProfileHelper
           #{verify_link}
           <span class="mod-holder">
             <span class="glyphicon glyphicon-trash mod delete"></span>
+            <span class="glyphicon glyphicon-cog mod toggle-properties"></span>
           </span>
           <div class="properties">
             <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -70,6 +70,14 @@ feature 'User manages emails', js: true do
       expect(page).to have_content('Value "user" is not a valid email address')
     end
 
+    scenario 'toggles searchable field' do
+      entry = ".email-entry[data-id=\"#{user.id}\"]"
+      expect(page).to_not have_selector("#{entry} .properties", visible: true)
+      find('.toggle-properties').click
+      expect(page).to have_selector("#{entry} .properties", visible: true)
+      screenshot!
+    end
+
   end
 
   # TODO screenshots all around


### PR DESCRIPTION
I wish the icons were aligned, and tried a few things to fix 'em, but couldn't figure much out other than right-aligning,  which then places them way over on the right, making it difficult to figure out icon goes with the email.

Something we could also consider would be to move the delete icon into the expanded row, maybe before the "searchable" checkbox.

<img width="627" alt="screen shot 2016-12-11 at 12 17 29 pm" src="https://cloud.githubusercontent.com/assets/79566/21082174/e6191a02-bf9b-11e6-953f-d5ea21e85426.png">