### PR TITLE
Show only email, display controls when clicked

### DIFF
--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -10,7 +10,7 @@ class Email
     @id = this.$el.attr('data-id')
     this.$el.find('.searchable').change(@saveSearchable)
     this.$el.find('.verify').click(@sendVerification)
-    this.$el.find('.toggle-properties').click(@toggleProperties)
+    this.$el.find('.email').click(@toggleProperties)
     @update()
 
   update: ->

--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -9,7 +9,7 @@ class Email
     this.$el = $(@el)
     @id = this.$el.attr('data-id')
     this.$el.find('.searchable').change(@saveSearchable)
-    this.$el.find('.verify').click(@sendVerification)
+    this.$el.find('.resend-confirmation').click(@sendVerification)
     this.$el.find('.email').click(@toggleProperties)
     @update()
 
@@ -97,9 +97,8 @@ OX.Profile.Email = {
 
   onAddEmail: ->
     email = $('#email-template').children().clone().addClass('new')
-    input = $(email).insertBefore(@addEmail).find('.email')
+    input = $(email).insertBefore(@addEmail).find('.email .value')
     @addEmail.hide()
-
     input.editable(
       url: BASE_URL
       params: (params) ->

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -94,7 +94,10 @@
         text-decoration: none;
       }
     }
-
+    &.verified {
+      .unconfirmed-warning { display: none; }
+      .resend-confirmation { display: none; }
+    }
     .alert {
       margin-left: 0px;
       margin-right: 0px;
@@ -110,9 +113,11 @@
       height: 0px;
       overflow: hidden;
       margin-left: 20px;
-      font-style: italic;
-      font-size: 11px;
       transition: height 0.4s;
+      .searchable-toggle {
+        font-style: italic;
+        font-size: 11px;
+      }
       input[type='checkbox'] {
         margin-left: 6px;
       }
@@ -123,9 +128,8 @@
     }
     &.expanded {
       .controls { height: 30px; }
-
     }
-    .verify {
+    .resend-confirmation {
       margin-left: 20px;
       form {
         display: inline;
@@ -142,8 +146,7 @@
       }
     }
     &.new {
-      .verify, .controls { display: none; }
-
+      .resend-confirmation, .unconfirmed-warning, .controls { display: none; }
     }
   }
 

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -86,6 +86,15 @@
     &:first-child {
       .alert { margin-top: 0; }
     }
+    .email {
+      color: $os_link_color;
+      text-decoration: underline;
+      cursor: pointer;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+
     .alert {
       margin-left: 0px;
       margin-right: 0px;
@@ -97,18 +106,20 @@
       left: -20px;
       top: 15px;
     }
-    .properties {
-      display: none;
+    .controls {
+      height: 0px;
+      overflow: hidden;
       margin-left: 20px;
       font-style: italic;
       font-size: 11px;
+      transition: height 0.4s;
       input[type='checkbox'] {
         margin-left: 6px;
       }
     }
     &.expanded {
-      .properties { display: block; }
-      .toggle-properties { color: black; }
+      .controls { height: 30px; }
+
     }
     .verify {
       margin-left: 20px;
@@ -127,17 +138,8 @@
       }
     }
     &.new {
-      .verify, .properties, .mod-holder { display: none; }
-    }
-    &.controls-hidden {
-      .email {
-        color: $link-color;
-        cursor: pointer;
-        text-decoration: none;
-        border-bottom: dashed 1px #0088cc;
-        &:hover{ text-decoration: none; }
-      }
-      .properties, .mod-holder { display: none; }
+      .verify, .controls { display: none; }
+
     }
   }
 

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -116,6 +116,10 @@
       input[type='checkbox'] {
         margin-left: 6px;
       }
+      .delete {
+        margin-left: 1rem;
+        font-size: 13px;
+      }
     }
     &.expanded {
       .controls { height: 30px; }

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -35,17 +35,25 @@ module ProfileHelper
   end
 
   def email_entry(value:, id:, is_verified:, is_searchable:)
-    verify_link = is_verified ? '' : "<span class='verify'>(#{button_to((I18n.t :"users.edit.click_to_verify"), resend_confirmation_contact_info_path(id: id), method: :put ) })</span>"
+    verify_link = is_verified ? '' : ""
     (
       <<-SNIPPET
         <div class="email-entry #{'verified' if is_verified}" data-id="#{id}">
-          <span class="email editable-click">#{value}</span>
-          #{verify_link}
-
+          <span class="email editable-click">
+             <span class="value">#{value}</span>
+             <span class="unconfirmed-warning">
+               #{I18n.t :"users.edit.unconfirmed_warning"}
+             </span>
+          </span>
           <div class="controls">
-            <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}
-            <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="#{I18n.t :"users.edit.check_searchable_if_you_want_to_be_searchable"}"></i>
+            <span class="searchable-toggle">
+              <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}
+              <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="#{I18n.t :"users.edit.check_searchable_if_you_want_to_be_searchable"}"></i>
+            </span>
             <span class="glyphicon glyphicon-trash mod delete"></span>
+            <span class='resend-confirmation'>
+              #{button_to((I18n.t :"users.edit.resend_confirmation"), resend_confirmation_contact_info_path(id: id), method: :put )}
+            </span>
           </div>
           <i class="spinner fa fa-spinner fa-spin fa-lg" style="display:none"></i>
         </div>

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -43,10 +43,9 @@ module ProfileHelper
           #{verify_link}
 
           <div class="controls">
-            <span class="glyphicon glyphicon-trash mod delete"></span>
             <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}
             <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="#{I18n.t :"users.edit.check_searchable_if_you_want_to_be_searchable"}"></i>
-
+            <span class="glyphicon glyphicon-trash mod delete"></span>
           </div>
           <i class="spinner fa fa-spinner fa-spin fa-lg" style="display:none"></i>
         </div>

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -39,13 +39,11 @@ module ProfileHelper
     (
       <<-SNIPPET
         <div class="email-entry #{'verified' if is_verified}" data-id="#{id}">
-          <span class="email">#{value}</span>
+          <span class="email editable-click">#{value}</span>
           #{verify_link}
-          <span class="mod-holder">
+
+          <div class="controls">
             <span class="glyphicon glyphicon-trash mod delete"></span>
-            <span class="glyphicon glyphicon-cog mod toggle-properties"></span>
-          </span>
-          <div class="properties">
             <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}
             <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="#{I18n.t :"users.edit.check_searchable_if_you_want_to_be_searchable"}"></i>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,6 +505,7 @@ en:
       check_searchable_if_you_want_to_be_searchable: >-
         Check the Searchable box if you want other OpenStax users to find you
         using this email address.
-      click_to_verify: Click to confirm
+      resend_confirmation: '[Resend Confirmation Email]'
+      unconfirmed_warning: (Unconfirmed)
       password: Password
       searchable: Searchable

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -71,14 +71,14 @@ feature 'User manages emails', js: true do
     end
 
     scenario 'toggles searchable field' do
-      entry = ".email-entry[data-id=\"#{user.id}\"]"
-      expect(page).to_not have_selector("#{entry} .properties", visible: true)
-      find('.toggle-properties').click
-      expect(page).to have_selector("#{entry} .properties", visible: true)
+      expect(page).to_not have_content(t('users.edit.searchable'))
+      find(".email-entry[data-id=\"#{user.id}\"] .email").click
+      expect(page).to have_content(t('users.edit.searchable'))
       screenshot!
     end
 
   end
+
 
   # TODO screenshots all around
   # TODO spec to show can't add already-used email

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -29,7 +29,7 @@ feature 'User manages emails', js: true do
         find('.glyphicon-ok').click
       }
       expect(page).to have_no_missing_translations
-      expect(page).to have_button(t :"users.edit.click_to_verify")
+      expect(page).to have_button(t :"users.edit.resend_confirmation")
       expect(page).to have_content('user@mysite.com')
     end
 
@@ -44,11 +44,12 @@ feature 'User manages emails', js: true do
       original_link_path = get_path_from_absolute_link(current_email, 'a')
 
       expect(page).to have_no_missing_translations
-      expect(page).to have_button(t :"users.edit.click_to_verify")
-      click_button(t :"users.edit.click_to_verify")
-
+      within all(".email-entry").last do
+        find(".unconfirmed-warning").click
+        expect(page).to have_button(t :"users.edit.resend_confirmation")
+        click_button(t :"users.edit.resend_confirmation")
+      end
       visit(original_link_path)
-
       expect(page).to have_content(t :"contact_infos.confirm.page_heading.success")
     end
 
@@ -78,7 +79,6 @@ feature 'User manages emails', js: true do
     end
 
   end
-
 
   # TODO screenshots all around
   # TODO spec to show can't add already-used email
@@ -127,10 +127,11 @@ feature 'User manages emails', js: true do
     let(:unverified_emails) { ['user@unverified.com'] }
 
     scenario 'success' do
-      click_button (t :"users.edit.click_to_verify")
+      find(".email-entry[data-id=\"#{user.id}\"] .email").click
+      click_button (t :"users.edit.resend_confirmation")
       expect(page).to have_no_missing_translations
       expect(page).to have_content(t :"controllers.contact_infos.verification_sent", address: "user@unverified.com")
-      expect(page).to have_button((t :"users.edit.click_to_verify"), disabled: true)
+      expect(page).to have_button((t :"users.edit.resend_confirmation"), disabled: true)
     end
   end
 


### PR DESCRIPTION
Moves the delete and resend confirmation down in the "controls" area which slides down when email is clicked.



<img width="667" alt="screen shot 2016-12-11 at 6 01 59 pm" src="https://cloud.githubusercontent.com/assets/79566/21084625/2320a1ce-bfcc-11e6-92af-e11f8d0ec6f8.png">
