### PR TITLE
unconfirmed styling, change email mods to one per line

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -110,27 +110,36 @@
       top: 15px;
     }
     .controls {
-      height: 0px;
+      display: none;
       overflow: hidden;
       margin-left: 20px;
-      transition: height 0.4s;
+      margin-top: 4px;
+      font-size: 13px;
+      div {
+        margin-top: 4px;
+      }
       .searchable-toggle {
-        font-style: italic;
-        font-size: 11px;
+        label { font-weight: normal; }
       }
       input[type='checkbox'] {
         margin-left: 6px;
+        margin-right: 4px;
       }
       .delete {
-        margin-left: 1rem;
-        font-size: 13px;
+        margin-left: 6px;
+        a {
+          font-size: 13px;
+          margin-left: 8px;
+        }
       }
     }
     &.expanded {
-      .controls { height: 30px; }
+      .controls {
+        display: block;
+      }
     }
     .resend-confirmation {
-      margin-left: 20px;
+      margin-left: 7px;
       form {
         display: inline;
         div { display: inline; }
@@ -143,6 +152,8 @@
         border: 0;
         background: transparent;
         height: 20px;
+        text-decoration: underline;
+        margin-left: 3px;
       }
     }
     &.new {

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -136,7 +136,7 @@
         div { display: inline; }
       }
       input {
-        color: $link-color;
+        color: $os_link_color;
         padding: 0;
         font-size: 13px;
         display: inline;

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -36,15 +36,16 @@ module ProfileHelper
 
   def email_entry(value:, id:, is_verified:, is_searchable:)
     verify_link = is_verified ? '' : ""
+    unconfirmed_link =
+      is_verified ?
+        '' :
+        %Q[&nbsp;[ <span class='email'><span class='unconfirmed-warning'>#{I18n.t :'users.edit.unconfirmed_warning'}</span></span> ]]
+
     (
       <<-SNIPPET
         <div class="email-entry #{'verified' if is_verified}" data-id="#{id}">
-          <span class="email editable-click">
-             <span class="value">#{value}</span>
-             <span class="unconfirmed-warning">
-               #{I18n.t :"users.edit.unconfirmed_warning"}
-             </span>
-          </span>
+          <span class="email editable-click"><span class="value">#{value}</span></span>
+          #{unconfirmed_link}
           <div class="controls">
             <span class="searchable-toggle">
               <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -47,14 +47,16 @@ module ProfileHelper
           <span class="email editable-click"><span class="value">#{value}</span></span>
           #{unconfirmed_link}
           <div class="controls">
-            <span class="searchable-toggle">
-              <input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}
-              <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="#{I18n.t :"users.edit.check_searchable_if_you_want_to_be_searchable"}"></i>
-            </span>
-            <span class="glyphicon glyphicon-trash mod delete"></span>
-            <span class='resend-confirmation'>
+            <div class='resend-confirmation'>
+              <i class='fa fa-envelope-o'></i>
               #{button_to((I18n.t :"users.edit.resend_confirmation"), resend_confirmation_contact_info_path(id: id), method: :put )}
-            </span>
+            </div>
+            <div class="delete">
+              <span class="glyphicon glyphicon-trash"></span><a href="#">Delete</a>
+            </div>
+            <div class="searchable-toggle">
+              <label><input type="checkbox" class='searchable' #{'checked="IS_SEARCHABLE"' if is_searchable}> #{I18n.t :"users.edit.searchable"}</label>
+            </div>
           </div>
           <i class="spinner fa fa-spinner fa-spin fa-lg" style="display:none"></i>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,4 +510,4 @@ en:
       resend_confirmation: 'Resend confirmation email'
       unconfirmed_warning: unconfirmed
       password: Password
-      searchable: Searchable
+      searchable: Let other users find me by this email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,7 +507,7 @@ en:
       check_searchable_if_you_want_to_be_searchable: >-
         Check the Searchable box if you want other OpenStax users to find you
         using this email address.
-      resend_confirmation: '[Resend Confirmation Email]'
-      unconfirmed_warning: (Unconfirmed)
+      resend_confirmation: 'Resend confirmation email'
+      unconfirmed_warning: unconfirmed
       password: Password
       searchable: Searchable

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -27,6 +27,8 @@ feature 'User manages emails', js: true do
       within(:css, '.email-entry.new') {
         find('input').set('user@mysite.com')
         find('.glyphicon-ok').click
+        wait_for_ajax
+        find(".unconfirmed-warning").click
       }
       expect(page).to have_no_missing_translations
       expect(page).to have_button(t :"users.edit.resend_confirmation")
@@ -127,7 +129,7 @@ feature 'User manages emails', js: true do
     let(:unverified_emails) { ['user@unverified.com'] }
 
     scenario 'success' do
-      find(".email-entry[data-id=\"#{user.id}\"] .email").click
+      find(".email-entry[data-id=\"#{user.id}\"] .value").click
       click_button (t :"users.edit.resend_confirmation")
       expect(page).to have_no_missing_translations
       expect(page).to have_content(t :"controllers.contact_infos.verification_sent", address: "user@unverified.com")


### PR DESCRIPTION
Builds on @nathanstitt's improvements to make the "Searchable" toggle clearer and to make the "email edits" have a similar style.

![image](https://cloud.githubusercontent.com/assets/1001691/21091551/d0949318-bffb-11e6-8d3d-c5849cc855dc.png)

![image](https://cloud.githubusercontent.com/assets/1001691/21091557/d952f0bc-bffb-11e6-9ca2-30ef073f5088.png)
