### PR TITLE
pass param to jump straight to sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Accounts requires the repeatable read isolation level to work properly. If using
 default_transaction_isolation = 'repeatable read'
 ```
 
+## Using
+
+* OAuth requests that arrive with query param `go=signup` will skip log in and go straight to signup
+* OAuth requests that arrive with query param `signup_at=blah` will redirect users to `blah` if they click the
+link to sign up.
+
 ## Development Setup
 
 In development, Accounts can be run as a normal Rails app on your machine, or you can run it in a Vagrant virtual machine that mimics our production setup.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,6 +14,7 @@ class SessionsController < ApplicationController
 
   before_filter :save_new_params_in_session, only: [:new]
   before_filter :store_authorization_url_as_fallback, only: [:new, :create]
+  before_filter :maybe_skip_to_sign_up, only: [:new]
 
   # If the user arrives to :new already logged in, this means they got linked to
   # the login page somehow; attempt to redirect to the authorization url stored
@@ -217,6 +218,10 @@ class SessionsController < ApplicationController
     # fails.  Also these methods perform checks on the alternate signup URL.
     set_client_app(params[:client_id])
     set_alternate_signup_url(params[:signup_at])
+  end
+
+  def maybe_skip_to_sign_up
+    redirect_to signup_path if params[:go] == 'signup'
   end
 
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -19,8 +19,7 @@ class StaticPagesController < ApplicationController
     if signed_in?
       redirect_to profile_path
     else
-      store_url # needed for happy login flow, authenticate_user! does it too
-      redirect_to login_path
+      authenticate_user!
     end
   end
 

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -44,7 +44,7 @@ module UserSessionManagement
     return if signed_in?
 
     store_url
-    redirect_to main_app.login_path(params.slice(:client_id, :signup_at))
+    redirect_to main_app.login_path(params.slice(:client_id, :signup_at, :go))
   end
 
   def authenticate_admin!

--- a/spec/features/entry_params_spec.rb
+++ b/spec/features/entry_params_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+feature "Params given on entry", js: true do
+
+  context "go=signup" do
+    scenario "arriving from app" do
+      arrive_from_app(params: {go: "signup"}, do_expect: false)
+      expect_sign_up_page
+    end
+
+    scenario "straight to login" do
+      visit 'login?go=signup'
+      expect_sign_up_page
+    end
+  end
+
+  context "signup_at=something" do
+    before(:each) {
+      allow_any_instance_of(ApplicationController).to receive(:is_redirect_url?) { true }
+    }
+
+    let(:alt_signup_url) { "copyright" }
+    let(:alt_signup_content) { t :"static_pages.copyright.page_heading" }
+
+    scenario "arriving from app" do
+      arrive_from_app(params: {signup_at: alt_signup_url}, do_expect: false)
+      click_link(t :"sessions.new.sign_up")
+      expect(page).to have_content(alt_signup_content)
+    end
+
+    scenario "straight to login" do
+      visit "login?signup_at=#{alt_signup_url}"
+      click_link(t :"sessions.new.sign_up")
+      expect(page).to have_content(alt_signup_content)
+    end
+  end
+
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -130,8 +130,11 @@ def mock_bad_csrf_token
   end
 end
 
-def visit_authorize_uri(app=@app)
-  visit "/oauth/authorize?redirect_uri=#{app.redirect_uri}&response_type=code&client_id=#{app.uid}"
+def visit_authorize_uri(app: @app, params: {})
+  visit "/oauth/authorize?redirect_uri=#{app.redirect_uri}&" \
+                         "response_type=code&" \
+                         "client_id=#{app.uid}" \
+                         "#{'&' + params.to_query if params.any?}"
 end
 
 def app_callback_url
@@ -201,6 +204,11 @@ def expect_sign_in_page
   expect(page).to have_content(t :"sessions.new.page_heading")
 end
 
+def expect_sign_up_page
+  expect(page).to have_no_missing_translations
+  expect(page).to have_content(t :"signup.start.page_heading")
+end
+
 def expect_authenticate_page
   expect(page.body).to match(/Hi.*!/)
 end
@@ -220,10 +228,10 @@ def agree_and_click_create
   click_button (t :"signup.new_account.create_account")
 end
 
-def arrive_from_app
+def arrive_from_app(params: {}, do_expect: true)
   create_application unless @app.present?
-  visit_authorize_uri
-  expect_sign_in_page
+  visit_authorize_uri(params: params)
+  expect_sign_in_page if do_expect
 end
 
 def expect_back_at_app


### PR DESCRIPTION
Requests that arrive with query `go=signup` will skip log in and go straight to signup.