### PR TITLE
Remove min-height on card body

### DIFF
--- a/app/assets/stylesheets/controls/_card.scss
+++ b/app/assets/stylesheets/controls/_card.scss
@@ -30,9 +30,6 @@
     width: 50%;
     float: left;
   }
-  .card-body {
-    min-height: 200px;
-  }
   .footer {
     margin-top: $os-section-spacing;
     padding-top: $os-section-spacing;


### PR DESCRIPTION
This allows the footer to move up beside the inputs.

Note: The footer has 30px top padding + 30px top margin, which means it'll always have 60px of space between the last element and it.

I think that was by design though, so I've left it.  We can adjust if @Fredasaurus thinks best.

<img width="650" alt="screen shot 2016-12-15 at 6 07 11 pm" src="https://cloud.githubusercontent.com/assets/79566/21246930/5327ef80-c2f1-11e6-9105-6ca69afc21ed.png">

<img width="651" alt="screen shot 2016-12-15 at 6 07 04 pm" src="https://cloud.githubusercontent.com/assets/79566/21246931/5329701c-c2f1-11e6-8b56-4f94992a0f53.png">
