### PR TITLE
fb and rescue from fixes (HOTFIX)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'openstax_utilities', '~> 4.2.0'
 gem 'openstax_api', '~> 8.0.0'
 
 # Notify developers of Exceptions in production
-gem 'openstax_rescue_from', '~> 1.6.0'
+gem 'openstax_rescue_from', '~> 1.7.1'
 
 # Lev framework
 gem 'lev', '~> 7.0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'doorkeeper', '2.2.2'
 # OAuth clients
 gem 'omniauth'
 gem 'omniauth-identity'
-gem 'omniauth-facebook'
+gem 'omniauth-facebook', '~>3.0.0'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
       responders
       roar (>= 1.0)
       roar-rails (>= 1.0)
-    openstax_rescue_from (1.6.0)
+    openstax_rescue_from (1.7.1)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
     openstax_utilities (4.2.3)
@@ -515,7 +515,7 @@ DEPENDENCIES
   omniauth-salesforce
   omniauth-twitter
   openstax_api (~> 8.0.0)
-  openstax_rescue_from (~> 1.6.0)
+  openstax_rescue_from (~> 1.7.1)
   openstax_utilities (~> 4.2.0)
   p3p
   parallel_tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-facebook (4.0.0)
+    omniauth-facebook (3.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.4.1)
       jwt (~> 1.5.2)
@@ -509,7 +509,7 @@ DEPENDENCIES
   oj
   oj_mimic_json
   omniauth
-  omniauth-facebook
+  omniauth-facebook (~> 3.0.0)
   omniauth-google-oauth2
   omniauth-identity
   omniauth-salesforce


### PR DESCRIPTION
Includes the Facebook hotfix (https://github.com/openstax/accounts/pull/440) plus a hotfix to upgrade openstax_rescue_from so that the `OpenStax::RescueFrom.this{...}` call in the cron jobs will work.