### PR TITLE
Bugfixes from accounts testing

### DIFF
--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -10,15 +10,16 @@ class Email
     @id = this.$el.attr('data-id')
     this.$el.find('.searchable').change(@saveSearchable)
     this.$el.find('.resend-confirmation').click(@sendVerification)
-    this.$el.find('.email').click(@toggleProperties)
+    this.$el.find('.email, .unconfirmed-warning').click(@toggleProperties)
     @update()
 
   update: ->
     delBtn = this.$el.find('.delete')
+    delBtn.off('click', @confirmDelete)
     if @isOnlyVerifiedEmail()
       delBtn.hide()
     else
-      delBtn.click(@confirmDelete)
+      delBtn.on('click', @confirmDelete)
 
   toggleProperties: ->
     this.$el.toggleClass('expanded')

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -86,7 +86,8 @@
     &:first-child {
       .alert { margin-top: 0; }
     }
-    .email {
+    .email,
+    .unconfirmed-warning .msg {
       color: $os_link_color;
       text-decoration: underline;
       cursor: pointer;
@@ -94,6 +95,7 @@
         text-decoration: none;
       }
     }
+    .unconfirmed-warning .msg { margin: 0 0.5rem; }
     &.verified {
       .unconfirmed-warning { display: none; }
       .resend-confirmation { display: none; }
@@ -157,6 +159,7 @@
       }
     }
     &.new {
+      .editable-click { border-bottom: 0; }
       .resend-confirmation, .unconfirmed-warning, .controls { display: none; }
     }
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   fine_print_skip :general_terms_of_use, :privacy_policy, only: [:update]
 
   before_filter :allow_iframe_access, only: [:edit, :update]
-
+  before_filter :prevent_caching, only: [:edit, :update]
 
   def edit
     OSU::AccessPolicy.require_action_allowed!(:update, current_user, current_user)
@@ -28,6 +28,12 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def prevent_caching
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
 
   def user_params
     params[:value].is_a?(Hash) ? params[:value] : {params[:name] => params[:value]}

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -36,10 +36,11 @@ module ProfileHelper
 
   def email_entry(value:, id:, is_verified:, is_searchable:)
     verify_link = is_verified ? '' : ""
-    unconfirmed_link =
-      is_verified ?
-        '' :
-        %Q[&nbsp;[ <span class='email'><span class='unconfirmed-warning'>#{I18n.t :'users.edit.unconfirmed_warning'}</span></span> ]]
+    unconfirmed_link = is_verified ? '' : <<-EOV
+      <span class='unconfirmed-warning'>[<span class='msg editable-click'>
+        #{I18n.t :'users.edit.unconfirmed_warning'}
+      </span>]</span>
+    EOV
 
     (
       <<-SNIPPET

--- a/app/views/signup/profile.html.erb
+++ b/app/views/signup/profile.html.erb
@@ -29,12 +29,14 @@
                   options: options_for_select(
                   [
                     [t('.instructor_use.how'), ""],
-                    [t('.instructor_use.fully'), 'Confirmed Adoption Won'],
-                    [t('.instructor_use.recommended'), 'Confirmed Will Recommend'],
-                    [t('.instructor_use.piloting'), 'Piloting book this semester'],
-                    [t('.instructor_use.interested'), 'High Interest in Adopting'],
-                    [t('.instructor_use.nope'), 'Not using']
-                  ], selected: "", disabled: "", hidden: "") %>
+                    [t('.instructor_use.fully'), t('.instructor_use.fully')],
+                    [t('.instructor_use.recommended'), t('.instructor_use.recommended')],
+                    [t('.instructor_use.piloting'), t('.instructor_use.piloting')],
+                    [t('.instructor_use.interested'), t('.instructor_use.interested')],
+                    [t('.instructor_use.nope'), t('.instructor_use.nope')]
+                   ],
+                   selected: (params.try(:[], 'profile').try(:[], 'using_openstax') || ''),
+                   disabled: "", hidden: "") %>
 
     <% if role != :student %>
 

--- a/app/views/static_pages/copyright.html.erb
+++ b/app/views/static_pages/copyright.html.erb
@@ -1,7 +1,7 @@
-<%= page_heading (t :".page_heading") %>
+<%= ox_card(classes: "copyright", heading: (t :".page_heading")) do %>
+   <p><%= t :".content_copyright_notice_html", copyright_holder: COPYRIGHT_HOLDER %></p>
 
-<p><%= t :".content_copyright_notice_html", copyright_holder: COPYRIGHT_HOLDER %></p>
+   <p><%= t :".opensource_notice_html", site_name: SITE_NAME %></p>
 
-<p><%= t :".opensource_notice_html", site_name: SITE_NAME %></p>
-
-<p><%= t :".other_copyright_notice_html", copyright_holder: COPYRIGHT_HOLDER %></p>
+   <p><%= t :".other_copyright_notice_html", copyright_holder: COPYRIGHT_HOLDER %></p>
+<% end %>

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -71,7 +71,7 @@ ActionController::Base.class_exec do
 
     url = params["r"]
 
-    return true if url.blank?
+    return true unless url.present?
 
     valid_hosts = Rails.application.secrets.valid_iframe_origins.map do |origin|
       URI.parse(origin).host

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -71,7 +71,7 @@ ActionController::Base.class_exec do
 
     url = params["r"]
 
-    return true unless url.present?
+    return true if url.blank?
 
     valid_hosts = Rails.application.secrets.valid_iframe_origins.map do |origin|
       URI.parse(origin).host
@@ -81,7 +81,7 @@ ActionController::Base.class_exec do
 
     uri = URI.parse(url)
 
-    return true unless valid_hosts.any?{|valid_host| uri.host.ends_with?(valid_host)}
+    return true unless uri.host.present? && valid_hosts.any?{|valid_host| uri.host.ends_with?(valid_host)}
 
     store_url(url: url)
   end

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe "Controllers affected by initializers/controllers.rb", type: :controller do
+
+  context "#save_redirect" do
+
+    controller do
+      skip_filter *(_process_action_callbacks.map(&:filter) - [:save_redirect])
+
+      def index
+        head :ok
+      end
+    end
+
+    it 'saves a properly formatted redirect' do
+      expect_to_save_redirect("https://openstax.org/hi")
+      get :index, r: "https://openstax.org/hi"
+    end
+
+    context "does not store a redirect if" do
+      before(:each) { expect_not_to_save_redirect }
+
+      it 'has a nil param' do
+        get :index, r: nil
+      end
+
+      it 'has a blank param' do
+        get :index, r: ""
+      end
+
+      it 'has a param without a host' do
+        get :index, r: "/"
+      end
+
+      it 'has a param not matching valid iframe origins' do
+        get :index, r: "https://openstax.badsite.org/hi"
+      end
+
+      it 'uses a non HTML format' do
+        get :index, format: :json
+      end
+
+      it 'has an badly formatted valid URL' do
+        get :index, r: "openstax.org/blah"
+      end
+    end
+  end
+
+  def expect_not_to_save_redirect
+    expect(controller).to receive(:save_redirect).and_call_original
+    expect(controller).not_to receive(:store_url)
+  end
+
+  def expect_to_save_redirect(url)
+    expect(controller).to receive(:save_redirect).and_call_original
+    expect(controller).to receive(:store_url).with(url: url)
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,10 +5,17 @@ RSpec.describe UsersController, type: :controller do
   let!(:user) { FactoryGirl.create :user, :terms_agreed }
 
   context 'GET edit' do
+    before(:each) { controller.sign_in! user }
+
     it 'renders the edit profile page' do
-      controller.sign_in! user
       get 'edit'
       expect(response.status).to eq 200
+    end
+
+    it 'sets headers to prevent caching' do
+      get 'edit'
+      expect(response.headers['Pragma']).to eq 'no-cache'
+      expect(response.headers['Cache-Control']).to eq('no-cache, no-store')
     end
   end
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 feature 'User signs up', js: true do
@@ -293,10 +294,30 @@ feature 'User signs up', js: true do
       screenshot!
     end
 
-    scenario 'submit without agreement' do
-      # TODO This could maybe be a controller spec; just want to make sure
-      # we don't let people submit on this screen without agreeing to
-      # terms.
+    scenario 'submit with invalid fields retains other values' do
+      attrs = {
+        first_name: "Bob",
+        last_name: "Smith",
+        phone_number: "999-9999",
+        school: "CC University",
+        url: "cc.com.edu",
+      }
+      complete_signup_profile_screen(
+        attrs.merge(
+          newsletter: true,
+          using_openstax: t('signup.profile.instructor_use.piloting'),
+          role: :instructor,
+          num_students: "-9", # invalid!
+          agree: true,
+        )
+      )
+      expect(page).to have_content("must be greater than or equal to 0")
+      attrs.each do |key, value|
+        expect(page).to have_field(t("signup.profile.#{key}"), with: value)
+      end
+      expect(page).to have_field("profile_using_openstax", with: t('signup.profile.instructor_use.piloting'))
+      expect(page).to have_checked_field('profile_newsletter')
+      screenshot!
     end
   end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -471,7 +471,7 @@ def complete_faculty_access_apply_screen(role: nil, first_name: nil, last_name: 
   subjects.each do |subject|
     find_field(subject).set("1")
   end
-
+  page.check('profile[newsletter]') if newsletter
   click_button (t :"faculty_access.apply.submit")
   expect(page).to have_no_missing_translations
 end


### PR DESCRIPTION
Fixes:
* [x] 500 error when `r` param is nil
* [x] copyright page has transparent background, making it illegible
* [x] disallow caching the profile page in order to force a reload when back is pressed
* [x] signup profile doesn't retain existing values on error
* [x] hide "mystery" brackets that appeared when adding an email on profile page
* [x] multiple confirm popups when deleting email
* [ ] white background in iOS when pulled up/down

and probably more