### PR TITLE
Copy cleanup

### DIFF
--- a/app/mailers/signup_confirmation_mailer.rb
+++ b/app/mailers/signup_confirmation_mailer.rb
@@ -5,7 +5,7 @@ class SignupConfirmationMailer < SiteMailer
     @show_pin = ConfirmByPin.sequential_failure_for(@signup_state).attempts_remaining?
 
     res = mail to: "#{signup_state.contact_info_value}",
-         subject: @show_pin ? "Confirm your email address using code #{signup_state.confirmation_pin}" :
+         subject: @show_pin ? "Confirm your email address using PIN #{signup_state.confirmation_pin}" :
                               "Confirm your email address"
 
     signup_state.update_column(:confirmation_sent_at, Time.now)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,8 +383,8 @@ en:
         If not, please enter your school email address.
 
     verify_email:
-      page_heading_pin: Enter your PIN to confirm your email
-      page_heading_token: Confirm your email
+      page_heading_pin: Check your email
+      page_heading_token: Check your email
       pin: Enter PIN
       confirm: Confirm
       used_wrong_email: Used the wrong email?
@@ -445,7 +445,7 @@ en:
       more_things_heading: And a few more things...
       phone_number: Phone number
       school: School
-      url: Your specific school web page
+      url: A web page that shows you are faculty
       num_students: Number of students per semester
       using_openstax: Already using OpenStax?
       create_account: Create Account
@@ -454,7 +454,7 @@ en:
       timeout: Please log in again to complete your sign up
 
     instructor_access_pending:
-      page_heading: Welcome to OpenStax!
+      page_heading: Almost done...
       message: >-
         Your instructor access is pending. We will verify your instructor status
         within 3-4 business days. In the meantime, you can access all books and
@@ -495,7 +495,7 @@ en:
         nope: Not using OpenStax
       phone_number: Phone number
       school: School
-      url: Your specific school web page
+      url: A web page that shows you are faculty
       num_students: Number of students per semester
       using_openstax: Already using OpenStax?
       titles_interested: Select all OpenStax titles that interest you

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -30,6 +30,7 @@ feature 'User manages emails', js: true do
         wait_for_ajax
         find(".unconfirmed-warning").click
       }
+      capture_email!(address: 'user@mysite.com')
       expect(page).to have_no_missing_translations
       expect(page).to have_button(t :"users.edit.resend_confirmation")
       expect(page).to have_content('user@mysite.com')


### PR DESCRIPTION
PIN email verification page during sign up emphasizes in the heading that people need to check their email.  Also changed the wording of 2nd sentence.

![image](https://cloud.githubusercontent.com/assets/1001691/21397766/da2d4e3c-c759-11e6-842d-90344dd8d8fc.png)

Forms for getting faculty information replace "Your specific school web page" with "A web page that shows you are faculty"

![image](https://cloud.githubusercontent.com/assets/1001691/21397319/2e7345b6-c758-11e6-8ae8-ef6b39b145dc.png)

Page at end of faculty signup now titled "Almost done..."

![image](https://cloud.githubusercontent.com/assets/1001691/21397336/46411b64-c758-11e6-9cb9-f76c45ec35e7.png)

Also makes sure that all "confirm your email" emails talk about "PIN"s not "code"s
