### PR TITLE
background on admin edit user, handle no usernames on user search

### DIFF
--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,6 +1,8 @@
 <%# Copyright 2011-2016 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
-<%= page_heading 'User Detail' %>
+<%= ox_card(heading: "User Detail") do %>
 
-<%= render 'form' %>
+  <%= render 'form' %>
+
+<% end %>

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -14,7 +14,7 @@
           Proc.new { |user| user.id.to_s },
           Proc.new do |user|
             security_log_params = { query: "user:\"#{user.username}\"" }
-            link_to user.username, admin_security_log_path(search: security_log_params)
+            link_to (user.username || '(none)'), admin_security_log_path(search: security_log_params)
           end,
           Proc.new { |user| user.first_name || '---' },
           Proc.new { |user| user.last_name || '---' },


### PR DESCRIPTION
Users without usernames had a URL in their "username" column before this

![image](https://cloud.githubusercontent.com/assets/1001691/21660073/b05c40ca-d282-11e6-830e-e3bd361c8540.png)

This page didn't have a "card" background before:

![image](https://cloud.githubusercontent.com/assets/1001691/21660080/b6a2ca1c-d282-11e6-941a-1554ee1e0c46.png)
