### PR TITLE
only email SF user update errors on real production

### DIFF
--- a/app/controllers/admin/salesforce_controller.rb
+++ b/app/controllers/admin/salesforce_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def update_users
-      UpdateUserSalesforceInfo.call(enable_error_email: true)
+      UpdateUserSalesforceInfo.call(allow_error_email: true)
       flash[:notice] = "The update completed."
       redirect_to admin_salesforce_path
     end

--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -1,12 +1,12 @@
 class UpdateUserSalesforceInfo
 
-  def initialize(enable_error_email:)
-    @enable_error_email = enable_error_email
+  def initialize(allow_error_email:)
+    @allow_error_email = allow_error_email
     @errors = []
   end
 
-  def self.call(enable_error_email: false)
-    new(enable_error_email: enable_error_email).call
+  def self.call(allow_error_email: false)
+    new(allow_error_email: allow_error_email).call
   end
 
   def call
@@ -140,13 +140,13 @@ class UpdateUserSalesforceInfo
     return if @errors.empty?
     Rails.logger.warn("UpdateUserSalesforceInfo errors: " + @errors.inspect)
 
-    return unless @enable_error_email
-
-    DevMailer.inspect_object(
-      object: @errors,
-      subject: "UpdateUserSalesforceInfo errors",
-      to: Rails.application.secrets[:salesforce]['mail_recipients']
-    ).deliver_later
+    if @allow_error_email && is_real_production?
+      DevMailer.inspect_object(
+        object: @errors,
+        subject: "UpdateUserSalesforceInfo errors",
+        to: Rails.application.secrets[:salesforce]['mail_recipients']
+      ).deliver_later
+    end
   end
 
   def is_real_production?

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,7 +12,7 @@ set :runner_command, "#{bundle_command} rails runner"
 every 1.hour, at: 45 do
   runner <<-CMD
     OpenStax::RescueFrom.this{
-      UpdateUserSalesforceInfo.call(enable_error_email: Time.zone.now.hour == 0)
+      UpdateUserSalesforceInfo.call(allow_error_email: Time.zone.now.hour == 0)
     }
   CMD
 end

--- a/spec/controllers/admin/salesforce_controller_spec.rb
+++ b/spec/controllers/admin/salesforce_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::SalesforceController, type: :controller do
   end
 
   it 'enables emails on manual user updates' do
-    expect(UpdateUserSalesforceInfo).to receive(:call).with(enable_error_email: true)
+    expect(UpdateUserSalesforceInfo).to receive(:call).with(allow_error_email: true)
     post :update_users
   end
 end

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -84,7 +84,7 @@ describe UpdateUserSalesforceInfo do
     }
 
     it 'sends an error message if enabled' do
-      expect { described_class.call(enable_error_email: true) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { described_class.call(allow_error_email: true) }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
 
     it 'does not send an error message by default' do
@@ -119,35 +119,35 @@ describe UpdateUserSalesforceInfo do
 
   context '#cache_contact_data_in_user' do
     it 'handles nil contacts' do
-      described_class.new(enable_error_email: true).cache_contact_data_in_user(nil, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user(nil, user)
       expect(user.salesforce_contact_id).to be_nil
       expect(user.faculty_status).to eq 'no_faculty_info'
     end
 
     it 'handles Confirmed faculty status' do
       contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Confirmed")
-      described_class.new(enable_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'confirmed_faculty'
     end
 
     it 'handles Pending faculty status' do
       contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Pending")
-      described_class.new(enable_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'pending_faculty'
     end
 
     it 'handles Rejected faculty status' do
       contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Rejected")
-      described_class.new(enable_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'rejected_faculty'
     end
 
     it 'handles Rejected2 faculty status' do
       contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Rejected2")
-      described_class.new(enable_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'rejected_faculty'
     end
@@ -155,7 +155,7 @@ describe UpdateUserSalesforceInfo do
     it 'raises for unknown faculty status' do
       contact = Salesforce::Contact.new(id: 'foo', faculty_verified: "Diddly")
       expect{
-        described_class.new(enable_error_email: true).cache_contact_data_in_user(contact, user)
+        described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
       }.to raise_error(RuntimeError)
     end
   end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -25,14 +25,14 @@ describe 'whenever schedule' do
 
       it 'does not send error emails at 5pm' do
         Timecop.freeze(Chronic.parse("5 pm")) do
-          expect(::UpdateUserSalesforceInfo).to receive(:call).with(enable_error_email: false)
+          expect(::UpdateUserSalesforceInfo).to receive(:call).with(allow_error_email: false)
           schedule.jobs[:runner].each { |job| eval job[:task] }
         end
       end
 
       it 'does send error emails in the midnight hour' do
         Timecop.freeze(Chronic.parse("12:30 am")) do
-          expect(::UpdateUserSalesforceInfo).to receive(:call).with(enable_error_email: true)
+          expect(::UpdateUserSalesforceInfo).to receive(:call).with(allow_error_email: true)
           schedule.jobs[:runner].each { |job| eval job[:task] }
         end
       end


### PR DESCRIPTION
Otherwise it is confusing to SF people because errors from -dev or -qa aren't really something they should deal with.