### PR TITLE
Allow add social where collides w current user email

### DIFF
--- a/app/handlers/sessions_create.rb
+++ b/app/handlers/sessions_create.rb
@@ -126,7 +126,8 @@ class SessionsCreate
 
     return :new_signin_required if user_signin_is_too_old?
 
-    return :email_already_in_use if ContactInfo.verified.where(value: @data.email).any?
+    return :email_already_in_use if ContactInfo.verified.where(value: @data.email)
+                                                        .where{user_id != my{current_user.id}}.any?
 
     run(TransferAuthentications, authentication, current_user)
     run(TransferOmniauthData, @data, current_user) if authentication.provider != 'identity'

--- a/spec/features/add_social_auth_spec.rb
+++ b/spec/features/add_social_auth_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Add social auth', js: true do
 
-  scenario "adding social and email collides with existing user's verified email" do
+  scenario "adding social and email collides with a different existing user's verified email" do
     create_email_address_for(create_user('other_user'), 'user@example.com')
 
     user = create_user 'user'
@@ -20,6 +20,27 @@ feature 'Add social auth', js: true do
       screenshot!
       expect_profile_page
       expect(page).to have_content("already in use")
+    end
+  end
+
+  scenario "adding social and email collides with the current user's verified email" do
+    user = create_user 'user'
+    create_email_address_for(user, 'user@example.com')
+
+    log_in('user', 'password')
+
+    expect_profile_page
+
+    click_link (t :"users.edit.enable_other_sign_in_options")
+    wait_for_animations
+    expect(page).to have_content('Facebook')
+
+    with_omniauth_test_mode(email: 'user@example.com') do
+      find('.authentication[data-provider="facebook"] .add').click
+      wait_for_ajax
+      expect_profile_page
+      expect(page).not_to have_content("already in use")
+      expect(page).to have_content('Facebook')
     end
   end
 


### PR DESCRIPTION
When social is added and it comes back with an email that is on the current user, don't freak out.