### PR TITLE
Add trouble logging in link to kb article

### DIFF
--- a/app/assets/stylesheets/signinup.scss
+++ b/app/assets/stylesheets/signinup.scss
@@ -7,8 +7,12 @@ body.sessions {
   &.new {
     .ox-card .form-group +
     a:not(.footer).trouble {
-      display: block;
+      display: inline-block;
       margin-top: 10px;
+    }
+    i {
+      color: $os_link_color;
+      margin-left: 6px;
     }
   }
 }

--- a/app/assets/stylesheets/signinup.scss
+++ b/app/assets/stylesheets/signinup.scss
@@ -4,5 +4,11 @@ body.sessions {
     display: block;
     margin: auto;
   }
-
+  &.new {
+    .ox-card .form-group +
+    a:not(.footer).trouble {
+      display: block;
+      margin-top: 10px;
+    }
+  }
 }

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -27,6 +27,9 @@
       <div class="card-body">
         <%= fh.text_field name: :username_or_email,
             label: '.email_placeholder', autofocus: true %>
+        <a class="trouble" target="_blank" href="http://openstax.force.com/support/articles/How_To/Can-t-log-in-to-your-OpenStax-account">
+          <%= t '.having_trouble' %> <i class="fa fa-external-link" aria-hidden="true"></i>
+        </a>
       </div>
 
       <section class="footer">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -28,8 +28,8 @@
         <%= fh.text_field name: :username_or_email,
             label: '.email_placeholder', autofocus: true %>
         <a class="trouble" target="_blank" href="http://openstax.force.com/support/articles/How_To/Can-t-log-in-to-your-OpenStax-account">
-          <%= t '.having_trouble' %> <i class="fa fa-external-link" aria-hidden="true"></i>
-        </a>
+          <%= t '.having_trouble' %>
+        </a><i class="fa fa-external-link" aria-hidden="true"></i>
       </div>
 
       <section class="footer">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,6 +275,7 @@ en:
       cannot_find_user: Cannot find user
       unknown_username: We don’t recognize this username.  Please try again or use your email address instead.
       unknown_email: We don’t recognize this email.  Please try again.
+      having_trouble: Trouble logging in?
       multiple_users:
         # %{link}   a hyperlink that sends usernames to the email being used for log in.
         #           The label is defined by the .click_here key.


### PR DESCRIPTION
This is based off production's `0a0ba57b31145500b48ee6d3f0bf587722098831` https://github.com/openstax/accounts/compare/0a0ba57b31145500b48ee6d3f0bf587722098831...trouble-link

![image](https://cloud.githubusercontent.com/assets/1001691/21788936/63824abc-d686-11e6-8e6d-d76d168ac9f6.png)