### PR TITLE
Don't error when user has 2 emails matching primary and alt email of 1 SF contact

### DIFF
--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -67,7 +67,10 @@ class UpdateUserSalesforceInfo
         # of which are verified and some are not, and in case `user.contact_infos` gets
         # those, add this extra `select(&:verified?)` call
 
-        contacts = user.contact_infos.select(&:verified?).map{|ci| contacts_by_email[ci.value]}
+        contacts = user.contact_infos
+                       .select(&:verified?)
+                       .map{|ci| contacts_by_email[ci.value]}
+                       .uniq
 
         next if contacts.size == 0
 

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -92,6 +92,19 @@ describe UpdateUserSalesforceInfo do
     end
   end
 
+  context 'user has two verified emails that are the primary and alt email on one contact' do
+    before(:each) {
+      email = AddEmailToUser.call("bobalt@example.com", user).outputs.email
+      ConfirmContactInfo.call(email)
+      stub_contacts([{id: 'foo', email: 'bob@example.com', email_alt: 'bobalt@example.com', faculty_verified: "Pending"}])
+    }
+
+    it 'does not find that one contact twice and freak out' do
+      expect(Rails.logger).not_to receive(:warn)
+      described_class.call
+    end
+  end
+
   context 'user matches SF info via unverified email' do
     it 'does not sync that SF info' do
       AddEmailToUser.call("unverified@example.com", user)


### PR DESCRIPTION
Without this change we were getting error emails like:

`More than one SF contact (sf_contact_id_foo, sf_contact_id_foo) for user 1`