### PR TITLE
resetting lead interest dropdown values to correct SF values

### DIFF
--- a/app/views/signup/profile.html.erb
+++ b/app/views/signup/profile.html.erb
@@ -24,16 +24,17 @@
     <%= fh.text_field name: :num_students, only: :instructor %>
     <%= fh.text_field name: :url, except: :student %>
 
+    <%# These dropdown option values are dictated by Salesforce and should not be changed %>
     <%= fh.select name: :using_openstax,
                   only: :instructor,
                   options: options_for_select(
                   [
                     [t('.instructor_use.how'), ""],
-                    [t('.instructor_use.fully'), t('.instructor_use.fully')],
-                    [t('.instructor_use.recommended'), t('.instructor_use.recommended')],
-                    [t('.instructor_use.piloting'), t('.instructor_use.piloting')],
-                    [t('.instructor_use.interested'), t('.instructor_use.interested')],
-                    [t('.instructor_use.nope'), t('.instructor_use.nope')]
+                    [t('.instructor_use.fully'), 'Confirmed Adoption Won'],
+                    [t('.instructor_use.recommended'), 'Confirmed Will Recommend'],
+                    [t('.instructor_use.piloting'), 'Piloting book this semester'],
+                    [t('.instructor_use.interested'), 'High Interest in Adopting'],
+                    [t('.instructor_use.nope'), 'Not using']
                    ],
                    selected: (params.try(:[], 'profile').try(:[], 'using_openstax') || ''),
                    disabled: "", hidden: "") %>

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -305,7 +305,7 @@ feature 'User signs up', js: true do
       complete_signup_profile_screen(
         attrs.merge(
           newsletter: true,
-          using_openstax: t('signup.profile.instructor_use.piloting'),
+          using_openstax: "primary",
           role: :instructor,
           num_students: "-9", # invalid!
           agree: true,
@@ -315,7 +315,8 @@ feature 'User signs up', js: true do
       attrs.each do |key, value|
         expect(page).to have_field(t("signup.profile.#{key}"), with: value)
       end
-      expect(page).to have_field("profile_using_openstax", with: t('signup.profile.instructor_use.piloting'))
+
+      expect(page).to have_field("profile_using_openstax", with: 'Confirmed Adoption Won')
       expect(page).to have_checked_field('profile_newsletter')
       screenshot!
     end


### PR DESCRIPTION
The interest values in the signup profile dropdown got mistakenly changed in https://github.com/openstax/accounts/commit/2a5b7403556cc83b3707da0a9b0b70d72c8b2613 -- they need to be specific values to make SF happy.