### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
-comment:
-  layout: "header, diff, changes, uncovered, tree"
-  behavior: default
+# Configures when (if at all) codecov will create GitHub comments on a Pull Request
+# and what should be included in the comment.
+comment: false
 
-# To Turn off comments completely:
-# comment: false
+#comment:
+#  layout: "header, diff, changes, uncovered, tree"
+#  behavior: default

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ cucumber_rerun.txt
 # Ignore byebug history files
 .byebug_history
 
-# Ignore Coveralls reports
+# Ignore Coverage reports
 coverage/*
 
 # Ignore Brakeman security scan results

--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ group :development, :test do
   gem 'timecop'
 
   # Codecov integration
-  gem 'codecov', :require => false
+  gem 'codecov', require: false
 
   # Speedup and run specs when files change
   gem 'spring'
@@ -186,11 +186,11 @@ group :test do
   # Test database cleanup gem with multiple strategies
   gem 'database_cleaner'
 
-  # CodeClimate integration
-  gem "codeclimate-test-reporter", require: false
   gem 'db-query-matchers'
+
   # Headless Capybara driver
   gem 'poltergeist'
+
   # Testing emails
   gem 'capybara-email'
 

--- a/Gemfile
+++ b/Gemfile
@@ -160,8 +160,9 @@ group :development, :test do
   # Time travel
   gem 'timecop'
 
-  # Coveralls integration
-  gem 'coveralls', require: false
+  # Codecov integration
+  gem 'codecov', :require => false
+
   # Speedup and run specs when files change
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,8 +87,6 @@ GEM
     chronic (0.10.2)
     chunky_png (1.3.7)
     cliver (0.3.2)
-    codeclimate-test-reporter (0.6.0)
-      simplecov (>= 0.7.1, < 1.0.0)
     codecov (0.1.9)
       json
       simplecov
@@ -601,7 +599,6 @@ DEPENDENCIES
   capybara-email
   capybara-screenshot
   chronic
-  codeclimate-test-reporter
   codecov
   coffee-rails (~> 4.1.0)
   compass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,10 @@ GEM
     cliver (0.3.2)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    codecov (0.1.9)
+      json
+      simplecov
+      url
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -114,12 +118,6 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.0.2)
-    coveralls (0.8.15)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.12.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (>= 1.6.0, < 2)
     css_parser (1.4.5)
       addressable
     daemons (1.2.4)
@@ -570,6 +568,7 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    url (0.3.2)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -603,9 +602,9 @@ DEPENDENCIES
   capybara-screenshot
   chronic
   codeclimate-test-reporter
+  codecov
   coffee-rails (~> 4.1.0)
   compass-rails
-  coveralls
   daemons
   database_cleaner
   db-query-matchers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/openstax/accounts.png?branch=master)](https://travis-ci.org/openstax/accounts)
 [![Code Climate](https://codeclimate.com/github/openstax/accounts.png)](https://codeclimate.com/github/openstax/accounts)
-[![Coverage Status](https://coveralls.io/repos/openstax/accounts/badge.png)](https://coveralls.io/r/openstax/accounts)
+[![Coverage Status](https://img.shields.io/codecov/c/github/openstax/accounts.svg)](https://codecov.io/gh/openstax/accounts)
 
 OpenStax Accounts is a centralized provider of account-related services for OpenStax products, including:
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,11 +1,8 @@
 require 'simplecov'
-require 'coveralls'
+require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]) if ParallelTests.first_process?
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 SimpleCov.at_exit do
   ParallelTests.wait_for_other_processes_to_finish if ParallelTests.first_process?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,17 +2,11 @@ require 'simplecov'
 require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
-
-SimpleCov.at_exit do
-  ParallelTests.wait_for_other_processes_to_finish if ParallelTests.first_process?
-  SimpleCov.result.format!
-end
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::Codecov
+]) if ENV['CI'] == 'true'
 
 SimpleCov.start 'rails'
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
 
 ENV['RAILS_ENV'] ||= 'test'
 


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- [x] When should coveralls make comments on the PR and what should be included
- [x] I used this recommendation from codecov.io: https://github.com/codecov/example-ruby