### PR TITLE
allow case insensitive login if no case sensitive matches

### DIFF
--- a/app/routines/get_login_info.rb
+++ b/app/routines/get_login_info.rb
@@ -21,7 +21,13 @@ class GetLoginInfo
     outputs.names = users.map(&:standard_name).uniq
     outputs.user_ids = users.map(&:id)
 
-    fatal_error(code: :multiple_users, offending_inputs: :username_or_email) if users.many?
+    if users.many?
+      if users.map(&:username).any?(&:nil?)
+        fatal_error(code: :multiple_users_missing_usernames, offending_inputs: :username_or_email)
+      else
+        fatal_error(code: :multiple_users, offending_inputs: :username_or_email)
+      end
+    end
 
     user = users.first
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,6 +13,12 @@
                      method: :post,
                      remote: true))
   end
+
+  translate_error(code: :multiple_users_missing_usernames) do
+    t(:".multiple_users_missing_usernames.content_html",
+      help_link: (mail_to "info@openstax.org",
+                  (t :".multiple_users_missing_usernames.help_link_text")))
+  end
 %>
 
 <%= ox_card(classes: "login", heading: (t :".page_heading")) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,7 @@ en:
         We did not find an account with the username or email you provided.
       found_account_but_it_has_no_emails: >-
         We found your account but can't send you an email because your account
-        doesn't have any email addresses listed. Please contact support for
+        doesn't have any email addresses listed. Please contact Support for
         assistance.
 
     signup_password:
@@ -126,7 +126,7 @@ en:
     terms_agree:
       you_must_agree_to_the_terms: >-
         You must agree to the terms to continue. If you have questions, please
-        contact support.
+        contact Support.
 
   routines:
     confirm_by_code:
@@ -189,7 +189,7 @@ en:
     password: Password
     there_was_a_problem_with_password_link: >-
       Unfortunately, there was a problem with your password link. If you
-      continue to have problems, please contact support.
+      continue to have problems, please contact Support.
     expired_password_link: >-
       The password link you used has expired.
     reset:
@@ -253,7 +253,7 @@ en:
           If you know your account's username or email address, please enter it
           below and we'll send you an email about how to regain access to your
           account. If you do not have this information, please %{link}.
-        contact_customer_support: contact customer support
+        contact_customer_support: contact Support
       page_heading: Get help logging in
       submit: Submit
       submitting: Submitting...
@@ -282,6 +282,11 @@ en:
       unknown_username: We don’t recognize this username.  Please try again or use your email address instead.
       unknown_email: We don’t recognize this email.  Please try again.
       having_trouble: Trouble logging in?
+      multiple_users_missing_usernames:
+        content_html: >-
+          We found several accounts with this email and unfortunately we can't tell which to use.
+          Please %{help_link}.
+        help_link_text: contact our Support team for assistance
       multiple_users:
         # %{link}   a hyperlink that sends usernames to the email being used for log in.
         #           The label is defined by the .click_here key.
@@ -406,7 +411,7 @@ en:
           click the link in the email that contains your PIN.  This will confirm your
           email.  If you did not receive the email, please check your spam folder.
           Need help?  %{help_link}.
-        help_link_text: Contact our customer service team
+        help_link_text: Contact our Support team
 
     password:
       page_heading: Choose your password

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -211,6 +211,28 @@ feature 'User logs in', js: true do
     end
   end
 
+  scenario 'with a username but different case' do
+    create_user 'user'
+
+    visit '/'
+
+    complete_login_username_or_email_screen 'UsER'
+    complete_login_password_screen 'password'
+
+    expect_profile_screen
+  end
+
+  scenario 'with an email with different case' do
+    create_email_address_for (create_user 'user'), 'user@example.com'
+
+    visit '/'
+
+    complete_login_username_or_email_screen 'USER@example.com'
+    complete_login_password_screen 'password'
+
+    expect_profile_screen
+  end
+
   scenario 'anonymous user GETs `/auth/identity/callback` directly' do
     visit '/auth/identity/callback'
     expect(page).not_to have_content(500)

--- a/spec/lib/lookup_users_spec.rb
+++ b/spec/lib/lookup_users_spec.rb
@@ -2,9 +2,53 @@ require 'rails_helper'
 
 describe LookupUsers do
 
-  it 'returns nothing for nil username lookup' do
-    FactoryGirl.create(:user, username: nil)
-    expect(described_class.by_email_or_username(nil)).to eq []
+  context '#by_email_or_username' do
+    it 'returns nothing for nil username lookup' do
+      FactoryGirl.create(:user, username: nil)
+      expect(described_class.by_email_or_username(nil)).to eq []
+    end
+
+    context 'when two of the same email with different case, both verified' do
+      before(:each) {
+        @email1 = FactoryGirl.create(:email_address, value: 'bob@example.com', verified: true)
+        @email2 = FactoryGirl.create(:email_address, value: 'bob@EXAMPLE.com')
+        # No longer allowed to have same address different case both verified, but used to be able
+        # to, so update `verified` without validations to simulate old data.
+        @email2.update_attribute(:verified, true)
+      }
+
+      it 'finds both email users when no case sensitive matches' do
+        expect(described_class.by_email_or_username('BOB@example.com')).to contain_exactly(@email1.user, @email2.user)
+      end
+
+      it 'finds one user when there is a case sensitive match' do
+        expect(described_class.by_email_or_username('bob@EXAMPLE.com')).to contain_exactly(@email2.user)
+      end
+    end
+
+    context 'when have two of the same username with different case' do
+      before(:each) {
+        @user1 = FactoryGirl.create(:user, username: 'bob')
+        @user2 = FactoryGirl.create(:user, username: 'temp')
+        # Used to be able to have case-insensitive dupes, but can't now, so skip validations
+        @user2.update_attribute(:username, 'BOB')
+      }
+
+      it 'finds an exact match' do
+        expect(described_class.by_email_or_username('BOB')).to eq [@user2]
+      end
+
+      it 'returns no results when no exact match' do
+        # An empty return is desired because we have no way to deal with multiple case
+        # insensitive username matches
+        expect(described_class.by_email_or_username('boB')).to eq []
+      end
+    end
+
+    it 'finds a user when there is only one case insensitive match by username' do
+      @user = FactoryGirl.create(:user, username: 'BOB')
+      expect(described_class.by_email_or_username('bob')).to eq [@user]
+    end
   end
 
 end


### PR DESCRIPTION
Allow case insensitive login if no case sensitive match found.

Relatedly, handle the case where a user has multiple emails with different case, but no usernames (possible if created between Jan 2017 and Feb 2017 releases.  Normally people with multiple accounts with the same email address who try to login with an email address would get an email saying "you have to log in with your username, which is 'foo' or 'bar'".  But when there are no usernames, this message would be bad and so we instead say "contact support".

![image](https://cloud.githubusercontent.com/assets/1001691/22270951/050602b8-e247-11e6-917d-9d94737c3736.png)
