### PR TITLE
prohibit colons in email addresses

### DIFF
--- a/lib/email_address_validations.rb
+++ b/lib/email_address_validations.rb
@@ -22,6 +22,11 @@ module EmailAddressValidations
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
           without: /`/,
           message: "\"%{value}\" should not contain a tick (`)"
+        },
+        {
+          # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
+          without: /:/,
+          message: "\"%{value}\" should not contain a colon"
         }
       ]
     end

--- a/spec/lib/email_address_validations_spec.rb
+++ b/spec/lib/email_address_validations_spec.rb
@@ -39,6 +39,10 @@ describe EmailAddressValidations do
     expect_invalid('bob@gmail.com`')
   end
 
+  it 'returns errors for email addresses with a colon' do
+    expect_invalid('something:bob@example.com')
+  end
+
   it 'returns errors for a username looking entry' do
     expect_invalid('bobbybobby')
   end


### PR DESCRIPTION
another AWS error handled