### PR TITLE
Keep signup email pin & token unchanged if email value unchanged

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -23,7 +23,6 @@ class SignupController < ApplicationController
 
   def start
     if request.post?
-      clear_signup_state # start fresh
       handle_with(SignupStart,
                   existing_signup_state: signup_state,
                   return_to: session[:return_to],
@@ -33,6 +32,7 @@ class SignupController < ApplicationController
                   end,
                   failure: lambda do
                     @role = params[:signup][:role]
+                    @signup_email = params[:signup][:email]
                     @handler_result.errors.each do | error |   # TODO move to view?
                       error.message = I18n.t("signup.start.#{error.code}", signin_url: signin_url)
                     end

--- a/app/views/signup/start.html.erb
+++ b/app/views/signup/start.html.erb
@@ -40,7 +40,7 @@ signup_roles = {
         <h3><%= t '.student_email' %></h3>
       </div>
 
-      <%= fh.text_field name: :email, value: signup_email, label: :'.email_placeholder' %>
+      <%= fh.text_field name: :email, value: @signup_email || signup_email, label: :'.email_placeholder' %>
       <p class="warning edu">
         <%= t '.teacher_school_email_warning', button: (t :'.next').downcase %>
       </p>

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -187,6 +187,24 @@ feature 'User signs up', js: true do
       expect(page).not_to have_content("bob@bob.edu")
     end
 
+    scenario 'user edits email to same value, PIN/token remains, no email' do
+      expect(SignupState.count).to eq 1
+
+      original_pin = SignupState.first.confirmation_pin
+      original_code = SignupState.first.confirmation_code
+
+      click_link (t :'signup.verify_email.edit_email_address')
+
+      expect{
+        complete_signup_email_screen("Instructor","bob@bob.edu")
+      }.to change { ActionMailer::Base.deliveries.count }.by(0)
+
+      expect(SignupState.count).to eq 1
+
+      expect(SignupState.first.confirmation_pin).to eq original_pin
+      expect(SignupState.first.confirmation_code).to eq original_code
+    end
+
     scenario 'user gets PIN wrong' do
       complete_signup_verify_screen(pass: false)
       expect_signup_verify_screen
@@ -424,6 +442,7 @@ feature 'User signs up', js: true do
     fill_in (t :"signup.start.email_placeholder"), with: "bob@bob.edu"
 
     click_button(t :"signup.start.next")
+
     expect(page).to have_content 'Email already in use'
     expect(page).to have_xpath("//input[@value='bob@bob.edu']")
   end


### PR DESCRIPTION
We previously had code to keep a signup process' PIN and confirmation code the same if the email was "edited" but unchanged, but a "fix" we made during doomsday effectively overrode this feature.  This PR removes that heavy handed "fix" and replaces it with something more mellow.  The PR also adds a spec to make sure that the PIN/code don't change if the email is unchanged and that no emails are sent out (again) in this case.