### PR TITLE
full console user search with restored functionality

### DIFF
--- a/app/assets/javascripts/signin/login.coffee
+++ b/app/assets/javascripts/signin/login.coffee
@@ -5,7 +5,6 @@ class OX.Signin.Login
     new OX.Signin.Login(card) if card.length
 
   constructor: (@el) ->
-    console.log @el.find('a.trouble')
     @el.find('a.trouble').click(@onHelpClick)
 
   onHelpClick: (ev) =>

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,6 +1,7 @@
 @import "bootstrap";
 @import "common_colors";
 @import "admin_navbar";
+@import "font-awesome";
 
 .underlined-spaced-row {
   border-bottom: 1px solid gray;
@@ -11,3 +12,91 @@
 nav.navbar.production {
   border-bottom: 2px solid red;
 }
+
+
+body.admin {
+  .user-search-help {
+    float: right;
+    margin-top: -16px;
+    font-size: 10px;
+    margin-bottom: 10px;
+  }
+}
+
+#search-results-list {
+  width: 100%;
+
+  td {
+    padding: 3px;
+  }
+  th {
+    // background-color: #ddd;
+    padding-bottom: 5px;
+    border-bottom: 1px solid black;
+  }
+
+  th.expand {
+    width: 40px;
+  }
+
+  a.expand {
+    padding-left: 8px;
+  }
+
+  tr {
+    &.even {
+      td {
+        background-color: #eee;
+      }
+    }
+
+    &.details {
+      display: none;
+      font-size: 12px;
+      td {
+        padding-top: 5px;
+        padding-bottom: 10px;
+      }
+    }
+  }
+
+  .admin {
+    color: red;
+  }
+
+  .btn {
+    border: 0px solid transparent;
+  }
+
+  .user-search-item {
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+    padding: 0px;
+  }
+
+  .created i, .updated i {
+    display: inline-block;
+    width: 55px;
+  }
+
+}
+
+#new-search-results-pagination {
+  clear: both;
+  margin: 20px 0;
+  color: #aaa;
+  .count {
+    float: right;
+  }
+  .pages {
+    float: right;
+    .btn {
+      color: #aaa;
+      &.hover {
+        color: black;
+      }
+    }
+  }
+}
+
+

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,11 +1,21 @@
 module Admin
   class UsersController < BaseController
+    layout 'admin', except: :js_search
 
     before_filter :get_user, only: [:edit, :update, :destroy, :become]
 
-    def index
+    # Used by dialog
+    def js_search
       security_log :users_searched_by_admin, search: params[:search]
       handle_with(UsersSearch, complete: lambda { render 'search' })
+    end
+
+    def index; end
+
+    # Used by full console page
+    def search
+      security_log :users_searched_by_admin, search: params[:search]
+      handle_with(UsersSearch, complete: lambda { render 'index' })
     end
 
     def update

--- a/app/handlers/admin/users_search.rb
+++ b/app/handlers/admin/users_search.rb
@@ -2,10 +2,12 @@ module Admin
   class UsersSearch
 
     lev_handler transaction: :no_transaction
-    
+
     paramify :search do
       attribute :terms, type: String
+      attribute :order_by, type: String
       attribute :page, type: Integer
+      attribute :per_page, type: Integer
     end
 
     uses_routine Admin::SearchUsers,
@@ -21,8 +23,11 @@ module Admin
     def handle
       outputs[:query] = search_params.terms
       outputs[:page] = search_params.page || 0
-      outputs[:per_page] = 20
-      run(:search_users, outputs[:query], page: outputs[:page])
+      outputs[:per_page] = search_params.per_page || 20
+      run(:search_users, outputs[:query],
+                         order_by: search_params.order_by,
+                         page: outputs[:page],
+                         per_page: outputs[:per_page])
     end
 
   end

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -30,7 +30,7 @@ class SearchUsers
 
   protected
 
-  SORTABLE_FIELDS = ['username', 'first_name', 'last_name', 'id']
+  SORTABLE_FIELDS = ['username', 'first_name', 'last_name', 'id', 'role']
   SORT_ASCENDING = 'ASC'
   SORT_DESCENDING = 'DESC'
   MAX_MATCHING_USERS = 10
@@ -139,7 +139,7 @@ class SearchUsers
     order_bys.compact!
 
     # Use a default sort if none provided
-    order_bys = ['username', SORT_ASCENDING] if order_bys.empty?
+    order_bys = [['username', SORT_ASCENDING]] if order_bys.empty?
 
     # Convert to query style
     order_bys = order_bys.map{|order_by| "#{order_by[0]} #{order_by[1]}"}
@@ -150,6 +150,8 @@ class SearchUsers
       # clause is not in the select clause
       users = users.order("users.#{order_by}")
     end
+
+    users = users.includes(:contact_infos)
 
     # Select only distinct records
 

--- a/app/views/admin/base/_users.html.erb
+++ b/app/views/admin/base/_users.html.erb
@@ -2,14 +2,14 @@
 
 <h4>Users</h4>
 
-<%= lev_form_for :search, 
-                 url: (override_search_path ||= admin_users_path), 
+<%= lev_form_for :search,
+                 url: (override_search_path ||= js_search_admin_users_path),
                  remote: true,
                  method: :get,
                  html: {class: 'form-inline'} do |f| %>
 
-  Search for 
-  <%= f.search_field :terms, style: 'width:500px;', class: 'form-control' %> 
+  Search for
+  <%= f.search_field :terms, style: 'width:500px;', class: 'form-control' %>
 
   <%= f.submit 'Search', class: 'btn btn-primary' %>
 

--- a/app/views/admin/users/_new_search_pagination.html.erb
+++ b/app/views/admin/users/_new_search_pagination.html.erb
@@ -1,0 +1,45 @@
+<%
+  num_users = @handler_result.outputs[:total_count]
+  page = @handler_result.outputs[:page]
+  per_page = @handler_result.outputs[:per_page]
+  pages = (num_users * 1.0 / per_page).ceil
+%>
+
+<div id='new-search-results-pagination'>
+  <%= pluralize(num_users, 'user') %> found.
+
+  <% if pages > 1 %>
+  <div class="pages">
+
+    <%
+      linked_page_numbers = [page+1]
+      linked_page_numbers.push(1)
+      linked_page_numbers.push(pages)
+      linked_page_numbers.push(page+1-1, page+1-2, page+1+1, page+1+2)
+      linked_page_numbers.reject!{|pp| pp < 1 || pp > pages}
+      linked_page_numbers.uniq!
+      linked_page_numbers.sort!
+    %>
+
+    <% linked_page_numbers.each do |lpn| %>
+      <% if lpn == page + 1 %>
+        <%= "<span class='btn btn-default btn-sm disabled'>#{lpn}</span>".html_safe %>
+      <% else %>
+        <%= link_to(
+              "<span class='btn btn-default btn-sm'>#{lpn}</span>".html_safe,
+              search_admin_users_path(
+                search: {
+                  terms: @handler_result.outputs[:query],
+                  order_by: params[:search][:order_by],
+                  page: lpn-1,
+                  per_page: per_page
+                }
+              )
+            )
+        %>
+      <% end %>
+
+    <% end %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,140 @@
+<%# Renderer's of this partial can direct the form's target with 'override_search_path' %>
+
+<% @page_header = "Users" %>
+
+<%= lev_form_for :search,
+                 url: search_admin_users_path,
+                 method: :get,
+                 html: {class: 'form-horizontal'} do |f| %>
+
+
+  <div class="input-group" style="width:100%">
+    <%= f.search_field :terms,  class: 'form-control', placeholder: "Search terms" %>
+  </div>
+  <div class="input-group" style="margin-bottom: 20px" >
+    <%= f.search_field :order_by,  class: 'form-control', placeholder: "Ordered by" %>
+    <span class="input-group-btn">
+      <%= f.submit 'Search', class: 'btn btn-primary' %>
+    </span>
+  </div>
+  <div class="user-search-help"><%= link_to "Search help", "/api/docs/v1/users/index" %></div>
+
+  <%= f.hidden_field :per_page, value: 50 %>
+
+<% end %>
+
+
+<% if @handler_result %>
+
+<%= render partial: 'new_search_pagination' %>
+
+<table id="search-results-list">
+
+    <tr>
+      <th class="expand"></th>
+      <th>ID</th>
+      <th>First Name</th>
+      <th>Last Name</th>
+      <th>Username</th>
+      <th>Faculty Status</th>
+      <th>Role</th>
+      <th></th>
+    </tr>
+    <% @handler_result.outputs[:items].each do |user| %>
+      <% zebra = cycle('odd', 'even') %>
+      <tr class="<%= zebra %>">
+        <td>
+          <a class="expand" href="#">
+            <i class="fa fa-plus" aria-hidden="false"></i></a>
+        </td>
+        <td><%= link_to user.id, edit_admin_user_path(user), target: '_blank' %></td>
+        <td><%= user.first_name || '---' %></td>
+        <td><%= user.last_name || '---' %></td>
+        <td><%= user.username || '(none)' %></td>
+        <td><%= user.faculty_status %></td>
+        <td><%= user.unknown_role? ? "Unknown" : user.role.capitalize %></td>
+        <td>
+          <%= link_to become_admin_user_path(user),
+                      method: :post,
+                      data: {confirm: "Log in as user #{user.id}, #{user.full_name || '(no name)'}?"} do %>
+            <i class="fa fa-key" aria-hidden="false"></i>
+          <% end %>
+        </td>
+      </tr>
+      <tr class="<%= zebra %> details">
+        <td></td>
+        <td colspan=6>
+          <div>
+            <div style="float:right">
+              <span class="created"><i>Created:</i> <%= user.created_at.in_time_zone('Central Time (US & Canada)') %></span>
+              <br/>
+              <span class="updated"><i>Updated:</i> <%= user.updated_at.in_time_zone('Central Time (US & Canada)') %></span>
+            </div>
+
+            <span class="full-name"><%= user.full_name || '(no name)' %></span> |
+
+            <% if user.is_administrator %>
+              <span class="admin">Administrator</span> |
+            <% end %>
+
+            <% sf_id = user.salesforce_contact_id %>
+
+            <% if sf_id.present? %>
+              <% sf_user = SalesforceUser.first %>
+              <span class="sf">
+                <i>Salesforce:</i>
+
+                <% if sf_user.nil? %>
+                  <%= sf_id %>
+                <% else %>
+                  <%= link_to sf_id, sf_user.instance_url + "/" + sf_id, target: '_blank' %>
+                <% end %>
+              </span> |
+            <% end %>
+
+            <% security_log_params = { query: "id:\"#{user.id}\"" } %>
+
+            <span class="security_log">
+              <%= link_to "Security Log", admin_security_log_path(search: security_log_params), target: '_blank' %>
+            </span> |
+
+            <span class="state">
+              <i>State:</i> <%= user.state %>
+            </span>
+
+            <% if user.self_reported_school.present? %>
+              | <span class="school">
+                <i>Self-reported school:</i> <%= user.self_reported_school %>
+              </span>
+            <% end %>
+
+            <% user.contact_infos.each do |contact_info| %>
+              <div class="email">
+                <%= link_to contact_info.value, "mailto:#{contact_info.value}" %>
+                (<%= contact_info.verified ? "confirmed" : "NOT confirmed" %>)
+              </div>
+            <% end %>
+
+          </div>
+        </td>
+        <td></td>
+      </tr>
+    <% end %>
+
+</table>
+
+<%= render partial: 'new_search_pagination' %>
+
+<% end %>
+
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    $('.expand').click(function(e) {
+      $(this).parent().parent().next('tr').toggle();
+      $(this).find("i").toggleClass("fa-plus");
+      $(this).find("i").toggleClass("fa-minus");
+      e.preventDefault();
+    });
+  </script>
+
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -37,9 +37,11 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav">
 
-            <li><%= link_to 'Security Log', admin_security_log_path %></li>
-            <li><%= link_to 'Salesforce', admin_salesforce_path %></li>
-            <li><%= link_to 'Settings', admin_rails_settings_ui_path %></li>
+            <li><%= link_to 'Users', main_app.admin_users_path %></li>
+            <li><%= link_to 'Security Log', main_app.admin_security_log_path %></li>
+            <li><%= link_to 'Salesforce', main_app.admin_salesforce_path %></li>
+            <li><%= link_to 'Settings', main_app.admin_rails_settings_ui_path %></li>
+            <li><%= link_to 'Terms', main_app.fine_print_path %></li>
 
 <% if false %>
             <li class="dropdown">
@@ -59,7 +61,7 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><%= current_user.username %> <span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><%= link_to 'Sign out!', signout_path %></li>
+                <li><%= link_to 'Sign out!', main_app.signout_path %></li>
               </ul>
             </li>
           </ul>
@@ -76,6 +78,8 @@
 
       <%= yield %>
     </div>
+
+  <%= yield :javascript %>
 
   </body>
 </html>

--- a/config/initializers/fine_print.rb
+++ b/config/initializers/fine_print.rb
@@ -4,7 +4,7 @@ FinePrint.configure do |config|
 
   # Layout to be used for FinePrint's controllers
   # Default: 'application'
-  config.layout = 'application'
+  config.layout = 'admin'
 
   # Array of custom helpers for FinePrint's controllers
   # Default: [] (no custom helpers)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,8 @@ Rails.application.routes.draw do
 
     resources :users, only: [:index, :update, :edit] do
       post 'become', on: :member
+      get 'search', on: :collection
+      get 'js_search', on: :collection
     end
 
     resource :security_log, only: [:show]


### PR DESCRIPTION
Leaves the current dialog-based user search as is, but adds a new user search on the "full console" screen.  

![image](https://cloud.githubusercontent.com/assets/1001691/22363928/b4df4118-e422-11e6-8762-3d5e78d7f108.png)

* Role is shown in the search results (can't currently be searched, but can be sorted)
* Sorting works now via the `Ordered by` field (see "Search help" page at bottom)
* Faculty status is shown in the search results
* Search doesn't use Javascript, so you can copy and paste a search URL and share it
* Extra details are expandable under each search result (admin status, account state, created at / updated at dates, self-reported school, securlty log link (fixed), full name, emails and confirmation status)
* Edit the user by clicking the ID hyperlink
* Log in as the user by clicking the "key" button at the far right of each result
* And sorry if you didn't know this, but you could always do complex searches like `first_name:bobby last_name:tables`.

also adds fine print to the full admin console and layout