### PR TITLE
Hide the role selection when :go param is "signup_student"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ default_transaction_isolation = 'repeatable read'
 
 ## Using
 
-* OAuth requests that arrive with query param `go=signup` will skip log in and go straight to signup
+* OAuth requests that arrive with query param `go=signup` will skip log in and go straight to signup. `go=student_signup` will skip to signup and force the signup to have the "student" role.
 * OAuth requests that arrive with query param `signup_at=blah` will redirect users to `blah` if they click the
 link to sign up.
 

--- a/app/assets/javascripts/signup/email-value.coffee
+++ b/app/assets/javascripts/signup/email-value.coffee
@@ -5,7 +5,7 @@ class OX.Signup.EmailValue
   constructor: ->
     _.bindAll(@, 'onChange', 'onSubmit')
     @group = $('.email-input-group')
-    @email = @group.find('#signup_email').slideDown()
+    @email = @group.find('#signup_email').show()
     @email.change(@onChange)
     @group.closest('form').submit(@onSubmit)
     @userType = ''

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -235,10 +235,11 @@ class SessionsController < ApplicationController
     # fails.  Also these methods perform checks on the alternate signup URL.
     set_client_app(params[:client_id])
     set_alternate_signup_url(params[:signup_at])
+    set_student_signup_role(params[:go] == 'student_signup')
   end
 
   def maybe_skip_to_sign_up
-    redirect_to signup_path if params[:go] == 'signup'
+    redirect_to signup_path if %w{signup student_signup}.include?(params[:go])
   end
 
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -38,6 +38,8 @@ class SignupController < ApplicationController
                     end
                     render :start
                   end)
+    else
+      @role = signup_role # select whatever value the role was previously set to
     end
   end
 

--- a/app/handlers/signup_start.rb
+++ b/app/handlers/signup_start.rb
@@ -22,6 +22,7 @@ class SignupStart
 
     # Return if user went back, didn't change anything, and resubmitted
     if existing_signup_state.try(:contact_info_value) == email
+      existing_signup_state.update_attributes(role: signup_params.role)
       outputs.signup_state = existing_signup_state
       return
     end

--- a/app/views/signup/start.html.erb
+++ b/app/views/signup/start.html.erb
@@ -22,12 +22,17 @@ signup_roles = {
                                 context: self,
                                 errors: @handler_result.try(:errors),
                                 error_field_classes: "alert alert-danger") %>
-    <%# TODO put select in form helper %>
 
-    <%= f.select :role,
-                 options_for_select(signup_roles.invert.to_a,
-                                    selected: @role || 'initial', disabled: "initial", hidden: "initial" ),
-                 {}, {autofocus: true} %>
+    <% if session[:signup_role] %>
+      <%= f.hidden_field(:role, value: session[:signup_role]) %>
+    <% else %>
+      <%= fh.select name: :role,
+          options: options_for_select(signup_roles.invert.to_a,
+            selected: @role || 'initial',
+            disabled: "initial",
+            hidden: "initial" )
+        %>
+    <% end %>
 
     <div class="email-input-group card-body">
       <div class="audience-help" data-audience="instructor">

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -123,8 +123,6 @@ module UserSessionManagement
 
   # called when user arrived at app with go == 'student_signup'
   def set_student_signup_role(is_student)
-      Rails.logger.warn '*'*80
-      Rails.logger.warn is_student
       session[:signup_role] = is_student ? 'student' : nil
   end
 

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -122,6 +122,8 @@ module UserSessionManagement
   end
 
   # called when user arrived at app with go == 'student_signup'
+  # note we're also clearning the session[:signup_role], that's important
+  # so the session var doesn't stick around if user later comes from a different origin
   def set_student_signup_role(is_student)
       session[:signup_role] = is_student ? 'student' : nil
   end

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -121,6 +121,13 @@ module UserSessionManagement
                       Doorkeeper::Application.find_by(id: session[:client_app])
   end
 
+  # called when user arrived at app with go == 'student_signup'
+  def set_student_signup_role(is_student)
+      Rails.logger.warn '*'*80
+      Rails.logger.warn is_student
+      session[:signup_role] = is_student ? 'student' : nil
+  end
+
   def set_alternate_signup_url(url)
     if url.blank? || !url.is_a?(String)
       session[:alt_signup] = nil

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -204,6 +204,16 @@ feature 'User signs up', js: true do
       expect(page).not_to have_content("bob@bob.edu")
     end
 
+    scenario 'user leaves verify screen to edit email and also changes role' do
+      click_link (t :'signup.verify_email.edit_email_address')
+      complete_signup_email_screen("Student","bob2@bob.com")
+      complete_signup_verify_screen(pass: true)
+      complete_signup_password_screen('password')
+      expect(page).to_not have_content(t('signup.profile.titles_interested'))
+      expect(page).to_not have_content(t('signup.profile.num_students'))
+
+    end
+
     scenario 'user edits email to same value, PIN/token remains, no email' do
       expect(SignupState.count).to eq 1
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -211,7 +211,15 @@ feature 'User signs up', js: true do
       complete_signup_password_screen('password')
       expect(page).to_not have_content(t('signup.profile.titles_interested'))
       expect(page).to_not have_content(t('signup.profile.num_students'))
-
+      complete_signup_profile_screen(
+        role: :student,
+        first_name: "Billy",
+        last_name: "Budd",
+        school: "Rice University"
+      )
+      ci = ContactInfo.where(value: "bob2@bob.com").first
+      expect(ci).to be_present
+      expect(ci.user.role).to eq 'student'
     end
 
     scenario 'user edits email to same value, PIN/token remains, no email' do

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -115,11 +115,12 @@ feature 'User signs up', js: true do
       expect(page).not_to have_content t('signup.start.teacher_school_email')
     end
 
-    scenario 'profile selection is set to student when coming from "student_signup"' do
+    scenario 'profile selection is set to student role and hidden when coming from "student_signup"' do
       visit signin_path(go: 'student_signup')
       expect(page).to have_selector('#signup_role', visible: false)
       expect(page.find('#signup_role', visible: false).value).to eq 'student'
       expect(page).to have_content 'Email'
+      screenshot!
     end
 
     scenario 'failure because email in use' do

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -115,6 +115,13 @@ feature 'User signs up', js: true do
       expect(page).not_to have_content t('signup.start.teacher_school_email')
     end
 
+    scenario 'profile selection is set to student when coming from "student_signup"' do
+      visit signin_path(go: 'student_signup')
+      expect(page).to have_selector('#signup_role', visible: false)
+      expect(page.find('#signup_role', visible: false).value).to eq 'student'
+      expect(page).to have_content 'Email'
+    end
+
     scenario 'failure because email in use' do
       create_email_address_for(create_user('user'), "bob@bob.edu")
       visit signup_path


### PR DESCRIPTION
Used by tutor to redirect to signup and also force the role to be student