### PR TITLE
add infrastructure for changing Salesforce login site

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,6 +3,9 @@
 
 secrets = Rails.application.secrets
 
+salesforce_client_options =
+  secrets[:salesforce]['login_site'] ? { site: secrets[:salesforce]['login_site'] } : {}
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :facebook, secrets[:facebook_app_id], secrets[:facebook_app_secret],
            client_options: {
@@ -14,7 +17,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :custom_identity
 
   provider :salesforce, secrets[:salesforce]['consumer_key'],
-                        secrets[:salesforce]['consumer_secret']
+                        secrets[:salesforce]['consumer_secret'],
+                        client_options: salesforce_client_options
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -30,6 +30,7 @@ development:
   salesforce:
     consumer_key: my_salesforce_key
     consumer_secret: my_salesforce_secret
+    login_site: <%= ENV["SALESFORCE_LOGIN_SITE"] || 'https://test.salesforce.com' %>
     mail_recipients: 'recipients@example.org'
 
   # If this timeout is exceeded, the current job is aborted


### PR DESCRIPTION
Adds a secret for setting the Salesforce login site.  The default value, `https://login.salesforce.com` works for production Salesforce, but to use a sandbox version of SF we need the value to be `https://test.salesforce.com`.