### PR TITLE
use slideToggle to reveal help

### DIFF
--- a/app/assets/javascripts/signin/login.coffee
+++ b/app/assets/javascripts/signin/login.coffee
@@ -9,4 +9,4 @@ class OX.Signin.Login
 
   onHelpClick: (ev) =>
     ev.preventDefault()
-    @el.find('.login-help').toggle('fast')
+    @el.find('.login-help').slideToggle('fast')

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -250,6 +250,7 @@ feature 'User logs in', js: true do
     click_link t :"sessions.new.having_trouble"
     expect(page).to have_content(t :"sessions.new.help")
     expect(page).to have_link(t :"sessions.new.knowledge_base", target: "_blank")
+    screenshot!
   end
 
 end


### PR DESCRIPTION
That slides the text down vertically, rather than expanding it both vertically and horizontally

@Fredasaurus and @gregfitch didn't like how the previous animated.

