### PR TITLE
Treat unprefixed two word searches as first/last name

### DIFF
--- a/spec/routines/admin/search_users_spec.rb
+++ b/spec/routines/admin/search_users_spec.rb
@@ -75,8 +75,8 @@ describe Admin::SearchUsers, type: :routine do
   end
 
   it "should gather space-separated unprefixed search terms" do
-    outcome = described_class.call("john mighty").outputs.items.to_a
-    expect(outcome).to eq [user_3, user_1, user_2]
+    outcome = described_class.call("john strav").outputs.items.to_a
+    expect(outcome).to eq [user_1]
   end
 
   context "pagination and sorting" do

--- a/spec/routines/search_application_users_spec.rb
+++ b/spec/routines/search_application_users_spec.rb
@@ -90,8 +90,8 @@ describe SearchApplicationUsers do
   end
 
   it "should gather space-separated unprefixed search terms" do
-    outcome = SearchApplicationUsers.call(application, "john mighty").outputs.items.to_a
-    expect(outcome).to eq [user_3, user_1, user_2]
+    outcome = SearchApplicationUsers.call(application, "john strav").outputs.items.to_a
+    expect(outcome).to eq [user_1]
   end
 
   context "pagination and sorting" do

--- a/spec/routines/search_users_spec.rb
+++ b/spec/routines/search_users_spec.rb
@@ -102,9 +102,9 @@ describe SearchUsers, type: :routine do
     expect(outcome).to eq []
   end
 
-  it "should gather space-separated unprefixed search terms" do
-    outcome = described_class.call("john mighty").outputs.items.to_a
-    expect(outcome).to eq [user_3, user_1, user_2]
+  it 'should match both first and last name for an unprefixed search for two words' do
+    outcome = described_class.call('john stravinsky').outputs.items.to_a
+    expect(outcome).to eq [user_1] # Not user_2 even though his first name is John
   end
 
   context "sorting" do


### PR DESCRIPTION
On production a search for common names is pulling up to many results to be useful.

This requires both last name and first name to match if the term is two words, which is the most common search.