### PR TITLE
remove brackets from account search description

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     You can also add search terms without prefixes, separated by spaces.
 
     If there are two uprefixed search terms, they will be treated as
-    a search for <first name> <last name>. Each name will use wildcard matches,
+    a search for (first-name AND last-name). Each name will use wildcard matches,
     but they both must match.
 
     If more or less than two words are given, the terms  will be searched for in all of


### PR DESCRIPTION
Apparently some versions of Maraku choke on them,  @gregfitch sees an escaping error when he viewed the docs.

<img width="300" alt="screen_shot_2017-02-20_at_10 04 13_am" src="https://cloud.githubusercontent.com/assets/79566/23133412/91d5ba5c-f756-11e6-973d-f06efaa37f08.png">
