### PR TITLE
Redirect to specified URL after logout

### DIFF
--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -89,4 +89,9 @@ ActionController::Base.class_exec do
     store_url(url: url)
   end
 
+  def return_url_specified_and_allowed?
+    # This returns true iff `save_redirect` actually saved the URL
+    params[:r] && params[:r] == stored_url
+  end
+
 end

--- a/spec/features/log_out_spec.rb
+++ b/spec/features/log_out_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Log out', type: :feature, js: true do
+  scenario 'redirects to caller-specified URL if in whitelist' do
+    test_log_out_redirect(url: "https://something.openstax.org/howdy?blah=true", expect_to_redirect_there: true)
+  end
+
+  scenario 'does not redirect to a caller-specified URL if not in whitelist' do
+    test_log_out_redirect(url: "http://www.google.com", expect_to_redirect_there: false)
+  end
+
+  def test_log_out_redirect(url:, expect_to_redirect_there:)
+    create_user 'user'
+
+    arrive_from_app
+    complete_login_username_or_email_screen('user')
+    complete_login_password_screen('password')
+
+    to_or_not_to = expect_to_redirect_there ? :to : :not_to
+    expect_any_instance_of(ActionController::Base).send(to_or_not_to, receive(:redirect_to)).with(url, anything())
+
+    visit "/logout?r=#{url}"
+  end
+end
+


### PR DESCRIPTION
If apps hit the logout URL on Accounts and pass in a URL via an `r` parameter, Accounts will redirect to that URL if it is in the `valid_redirect_host_regexes` as specified in the secrets (e.g. [this for dev and test](https://github.com/openstax/accounts/blob/master/config/secrets.yml.example#L60-L66)).

E.g. going to 

`https://accounts.openstax.org/logout?r=https://something.openstax.org/blah?hi=there`

will log the user out and then redirect to `https://something.openstax.org/blah?hi=there`