### PR TITLE
get SF user info 3 times an hour

### DIFF
--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -16,6 +16,8 @@ class UpdateUserSalesforceInfo
   def call
     return if !OpenStax::Salesforce.ready_for_api_usage?
 
+    info("Starting")
+
     prepare_contacts
 
     # Go through all users that have already have a Salesforce ID and make sure
@@ -127,6 +129,8 @@ class UpdateUserSalesforceInfo
 
     notify_errors
 
+    info("Finished")
+
     self
   end
 
@@ -183,7 +187,7 @@ class UpdateUserSalesforceInfo
 
   def cache_contact_data_in_user(contact, user)
     if contact.nil?
-      log(
+      warn(
         "User #{user.id} previously linked to contact #{user.salesforce_contact_id} but" \
         " that contact is no longer present; resetting user's faculty status and contact ID"
       )
@@ -247,13 +251,17 @@ class UpdateUserSalesforceInfo
     @errors.push(error)
   end
 
-  def log(message)
+  def info(message)
+    Rails.logger.info("UpdateUserSalesforceInfo: " + message)
+  end
+
+  def warn(message)
     Rails.logger.warn("UpdateUserSalesforceInfo: " + message)
   end
 
   def notify_errors
     return if @errors.empty?
-    Rails.logger.warn("UpdateUserSalesforceInfo errors: " + @errors.inspect)
+    warn("errors: " + @errors.inspect)
 
     if @allow_error_email && Settings::Salesforce.user_info_error_emails_enabled
       DevMailer.inspect_object(

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,10 +9,10 @@ set :runner_command, "#{bundle_command} rails runner"
 #   * https://github.com/javan/whenever/issues/481
 #   * https://github.com/javan/whenever/pull/239
 
-every 1.hour, at: 45 do
+every '5,25,45 * * * *' do
   runner <<-CMD
     OpenStax::RescueFrom.this{
-      UpdateUserSalesforceInfo.call(allow_error_email: Time.zone.now.hour == 0)
+      UpdateUserSalesforceInfo.call(allow_error_email: Time.zone.now.hour == 0 && Time.zone.now.min < 10)
     }
   CMD
 end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -30,9 +30,16 @@ describe 'whenever schedule' do
         end
       end
 
-      it 'does send error emails in the midnight hour' do
-        Timecop.freeze(Chronic.parse("12:30 am")) do
+      it 'does send error emails in the midnight hour\'s first run' do
+        Timecop.freeze(Chronic.parse("12:09 am")) do
           expect(::UpdateUserSalesforceInfo).to receive(:call).with(allow_error_email: true)
+          schedule.jobs[:runner].each { |job| eval job[:task] }
+        end
+      end
+
+      it 'does not send error emails in the midnight hour after the first run' do
+        Timecop.freeze(Chronic.parse("12:11 am")) do
+          expect(::UpdateUserSalesforceInfo).to receive(:call).with(allow_error_email: false)
           schedule.jobs[:runner].each { |job| eval job[:task] }
         end
       end


### PR DESCRIPTION
instead of just once an hour; also have first run be closer to top of hour so that we are more certain to not have run out of API calls.