### PR TITLE
Internationalised model validation messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Rails framework
 gem 'rails', '4.2.7.1'
+gem 'rails-i18n', '~> 4'
 
 # Bootstrap front-end framework
 gem 'bootstrap-sass', '~> 3.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,6 +408,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (4.0.9)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     rails-settings-cached (0.6.5)
       rails (>= 4.2.0)
     rails-settings-ui (1.1.0)
@@ -657,6 +660,7 @@ DEPENDENCIES
   protected_attributes
   quiet_assets
   rails (= 4.2.7.1)
+  rails-i18n (~> 4)
   rails-settings-cached
   rails-settings-ui
   redis-rails

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -49,7 +49,7 @@ class SignupController < ApplicationController
                   end,
                   failure: lambda do
                     @handler_result.errors.each do | error |  # TODO move to view?
-                      error.message = I18n.t("signup.verify_email.#{error.code}")
+                      error.message = I18n.t(:"signup.verify_email.#{error.code}", default: error.message)
                     end
                     render :verify_email
                   end)

--- a/app/handlers/signup_profile_instructor.rb
+++ b/app/handlers/signup_profile_instructor.rb
@@ -15,7 +15,7 @@ class SignupProfileInstructor < SignupProfile
     validates :using_openstax, presence: true
     validate :subjects, lambda { |profile|
       unless profile.subjects.detect{|_, checked| checked == '1'}
-        profile.errors.add(:subjects, 'must have at least one selection')
+        profile.errors.add(:subjects, :blank_selection)
       end
     }
   end

--- a/app/handlers/signup_profile_other.rb
+++ b/app/handlers/signup_profile_other.rb
@@ -9,7 +9,7 @@ class SignupProfileOther < SignupProfile
     validates :url, presence: true
     validate :subjects, lambda { |profile|
       unless profile.subjects.detect{|_, checked| checked == '1'}
-        profile.errors.add(:subjects, 'must have at least one selection')
+        profile.errors.add(:subjects, :blank_selection)
       end
     }
   end

--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -58,13 +58,13 @@ class ContactInfo < ActiveRecord::Base
 
   def check_if_last_verified
     if verified? and not user.contact_infos.verified.many? and not destroyed_by_association
-      errors.add(:user, 'unable to delete last verified email address')
+      errors.add(:user, :last_verified)
       return false
     end
   end
 
   def check_for_verified_collision
-    errors.add(:value, 'already confirmed on another account') \
+    errors.add(:value, :already_confirmed) \
       if value.present? &&
          verified? &&
          ContactInfo.verified

--- a/app/models/message_body.rb
+++ b/app/models/message_body.rb
@@ -11,7 +11,7 @@ class MessageBody < ActiveRecord::Base
 
   def not_empty
     return unless [html, text, short_text].all?{|f| f.blank?}
-    errors.add(:base, "can't be blank")
+    errors.add(:base, :blank)
     false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,6 @@ class User < ActiveRecord::Base
                                  maximum: USERNAME_MAX_LENGTH,
                                  allow_blank: true },
                        format: { with: USERNAME_VALID_REGEX,
-                                 message: "can only contain letters, numbers, and underscores.",
                                  allow_blank: true }
 
   validates :username, uniqueness: { case_sensitive: false, allow_nil: true },
@@ -246,7 +245,7 @@ class User < ActiveRecord::Base
       was = change[0]
       is = change[1]
 
-      errors.add(attr.to_sym, "can't be blank") if !was.blank? && is.blank?
+      errors.add(attr.to_sym, :blank) if !was.blank? && is.blank?
     end
   end
 

--- a/app/views/contact_infos/confirm.html.erb
+++ b/app/views/contact_infos/confirm.html.erb
@@ -3,7 +3,7 @@
                         :".page_heading.success")) do %>
 
   <% if @handler_result.errors.any? %>
-    <% if @handler_result.errors.first.code == :"already confirmed on another account" %>
+    <% if @handler_result.errors.first.code == :"already_confirmed" %>
       <p><%= t :".email_already_in_use" %></p>
     <% else %>
       <p><%= t :".verification_code_not_found" %></p>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -1,0 +1,42 @@
+en:
+  errors:
+    # By default all error messages are formatted as “%{attribute} %{message}”,
+    # where “%{attribute}” is name of the attribute having erroneous value, and
+    # “%{message}” is a generic error message. While this format works
+    # for English, it will not work for any language in which “%{message}”
+    # depends on “%{attribute}” (one example of such dependency is gender
+    # agreement). We therefore change message format to “%{message}” and
+    # redefine all default messages.
+    format: "%{message}"
+
+    messages:
+      accepted: "%{attribute} must be accepted"
+      blank: "%{attribute} can't be blank"
+      confirmation: "%{attribute} doesn't match %{attribute}"
+      empty: "%{attribute} can't be empty"
+      equal_to: "%{attribute} must be equal to %{count}"
+      even: "%{attribute} must be even"
+      exclusion: "%{attribute} is reserved"
+      greater_than: "%{attribute} must be greater than %{count}"
+      greater_than_or_equal_to: "%{attribute} must be greater than or equal to %{count}"
+      inclusion: "%{attribute} is not included in the list"
+      invalid: "%{attribute} is invalid"
+      less_than: "%{attribute} must be less than %{count}"
+      less_than_or_equal_to: "%{attribute} must be less than or equal to %{count}"
+      model_invalid: "%{attribute} Validation failed: %{errors}"
+      not_a_number: "%{attribute} is not a number"
+      not_an_integer: "%{attribute} must be an integer"
+      odd: "%{attribute} must be odd"
+      other_than: "%{attribute} must be other than %{count}"
+      present: "%{attribute} must be blank"
+      required: "%{attribute} must exist"
+      taken: "%{attribute} has already been taken"
+      too_long:
+        one: "%{attribute} is too long (maximum is 1 character)"
+        other: "%{attribute} is too long (maximum is %{count} characters)"
+      too_short:
+        one: "%{attribute} is too short (minimum is 1 character)"
+        other: "%{attribute} is too short (minimum is %{count} characters)"
+      wrong_length:
+        one: "%{attribute} is the wrong length (should be 1 character)"
+        other: "%{attribute} is the wrong length (should be %{count} characters)"

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -41,6 +41,82 @@ en:
         one: "%{attribute} is the wrong length (should be 1 character)"
         other: "%{attribute} is the wrong length (should be %{count} characters)"
 
+  activemodel:
+    errors:
+      models:
+        faculty_access_apply/apply_paramifier: &faculty_access_apply
+          attributes:
+            first_name:
+              blank: This field can't be blank
+            last_name:
+              blank: This field can't be blank
+            email:
+              blank: This field can't be blank
+            school:
+              blank: This field can't be blank
+            phone_number:
+              blank: This field can't be blank
+            url:
+              blank: This field can't be blank
+            num_students:
+              blank: This field can't be blank
+              not_a_number: This field is not a number
+              greater_than_or_equal_to: This field must be greater than or equal to %{count}
+            using_openstax:
+              blank: Subjects must have at least one selection
+        faculty_access_apply_instructor/apply_paramifier:
+          <<: *faculty_access_apply
+        identities_set_password/set_password_paramifier:
+          attributes:
+            password:
+              blank: Password can't be blank
+            password_confirmation:
+              blank: Password confirmation can't be blank
+        sessions_lookup_login/login_paramifier:
+          attributes:
+            username_or_email:
+              blank: Username or email can't be blank
+        signup_password/signup_paramifier:
+          attributes:
+            password:
+              blank: Password can't be blank
+            password_confirmation:
+              blank: Password confirmation can't be blank
+        signup_profile/profile_paramifier: &signup_profile
+          attributes:
+            first_name:
+              blank: This field can't be blank
+            last_name:
+              blank: This field can't be blank
+            school:
+              blank: This field can't be blank
+            phone_number:
+              blank: This field can't be blank
+            url:
+              blank: This field can't be blank
+            num_students:
+              blank: This field can't be blank
+              not_a_number: This field is not a number
+              greater_than_or_equal_to: This field must be greater than or equal to %{count}
+            using_openstax:
+              blank: Subjects must have at least one selection
+            subjects:
+              blank_selection: Subjects must have at least one selection
+        signup_profile_instructor/profile_paramifier:
+          <<: *signup_profile
+        signup_profile_other/profile_paramifier:
+          <<: *signup_profile
+        signup_start/signup_paramifier:
+          attributes:
+            email:
+              blank: Email can't be blank
+            role:
+              blank: Role can't be blank
+        signup_verify_email/pin_paramifier:
+          attributes:
+            pin:
+              blank: Pin can't be blank
+
   activerecord:
     errors:
       models:
@@ -55,7 +131,7 @@ en:
         email_address:
           attributes:
             # Marking &email_address for reference later.
-            value: &email_address
+            value: &email_addres_validations
               invalid: “%{value}” is not a valid email address
               too_many_dots: This email has too many dots in a row
               ends_with_dot: An email cannot end with a dot
@@ -82,7 +158,7 @@ en:
               # This is a virtual field corresponding to EmailAddress#value.
               # To avoid redefining messages for that field we include them from
               # activerecord.errors.models.email_address.attributes.value
-              <<: *email_address
+              <<: *email_addres_validations
 
         user:
           attributes:

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -40,3 +40,59 @@ en:
       wrong_length:
         one: "%{attribute} is the wrong length (should be 1 character)"
         other: "%{attribute} is the wrong length (should be %{count} characters)"
+
+  activerecord:
+    errors:
+      models:
+        contact_info:
+          attributes:
+            user:
+              last_verified: Unable to delete last verified email address
+            value:
+              already_confirmed: Value already confirmed on another account
+              blank: Value can't be blank
+
+        email_address:
+          attributes:
+            # Marking &email_address for reference later.
+            value: &email_address
+              invalid: “%{value}” is not a valid email address
+              too_many_dots: This email has too many dots in a row
+              ends_with_dot: An email cannot end with a dot
+              contains_tick: An email should not contain a tick (`)
+              contains_colon: An email should not contain a colon
+              contains_comma: An email should not contain a comma
+
+        identity:
+          attributes:
+            password:
+              blank: Password can't be blank
+              too_short:
+                one: Password is too short (minimum is 1 character)
+                other: Password is too short (minimum is %{count} characters)
+              too_long:
+                one: Password is too long (maximum is 1 character)
+                other: Password is too short (minimum is %{count} characters)
+            password_confirmation:
+              confirmation: Password confirmation doesn't match password
+
+        signup_state:
+          attributes:
+            contact_info_value:
+              # This is a virtual field corresponding to EmailAddress#value.
+              # To avoid redefining messages for that field we include them from
+              # activerecord.errors.models.email_address.attributes.value
+              <<: *email_address
+
+        user:
+          attributes:
+            username:
+              too_short: Username is too short (minimum is %{count} characters)
+              too_long: Username is too long (maximum is %{count} characters)
+              invalid: >-
+                Username can only contain letters, numbers, and underscores.
+              taken: Username has already been taken
+            first_name:
+              blank: First name can't be blank
+            last_name:
+              blank: Last name can't be blank

--- a/config/locales/activerecord.pl.yml
+++ b/config/locales/activerecord.pl.yml
@@ -1,0 +1,200 @@
+pl:
+  errors:
+    format: "%{message}"
+
+    messages:
+      accepted: "Pole %{attribute} musi być zaakceptowane"
+      blank: "Pole %{attribute} nie może być puste"
+      confirmation: "Pola %{attribute} i %{attribute} nie są zgodne"
+      empty: "Pole %{attribute} nie może być puste"
+      equal_to: "Wartość pola %{attribute} musi równać się %{count}"
+      even: "Wartość pola %{attribute} musi być parzysta"
+      exclusion: "Wartość pola %{attribute} jest zastrzeżona"
+      greater_than: "Wartość pola %{attribute} musi być większa niż %{count}"
+      greater_than_or_equal_to: >-
+        Wartość pola %{attribute} musi wynosić co najmniej %{count}
+      inclusion: "Wartość pola %{attribute} nie zawiera się w liście"
+      invalid: "Wartość pola %{attribute} jest nieprawidłowa"
+      less_than: "Wartość pola %{attribute} musi być mniejsza niż %{count}"
+      less_than_or_equal_to: >-
+        Wartość pola %{attribute} nie może przekraczać %{count}
+      model_invalid: "Wprowadzone dane są niepoprawne: %{errors}"
+      not_a_number: "Wartość pola %{attribute} nie jest liczbą"
+      not_an_integer: "Wartość pola %{attribute} musi być liczbą całkowitą"
+      odd: Wartość pola "%{attribute} musi być nieparzysta"
+      other_than: "Wartość pola %{attribute} nie może wynosić %{count}"
+      present: "Pole %{attribute} musi być puste"
+      required: "Wartość pola %{attribute} musi istnieć"
+      taken: "Wartość pola %{attribute} jest już zajęta"
+      too_long:
+        one: "Wartość pola %{attribute} jest za długa (najwyżej 1 znak)"
+        few: "Wartość pola %{attribute} jest za długa (najwyżej %{count} znaki)"
+        many: "Wartość pola %{attribute} jest za długa (najwyżej %{count} znaków)"
+        other: "Wartość pola %{attribute} jest za długa (najwyżej %{count} znaku)"
+      too_short:
+        one: "Wartość pola %{attribute} jest za krótka (co najmniej 1 znak)"
+        few: "Wartość pola %{attribute} jest za krótka (co najmniej %{count} znaki)"
+        many: "Wartość pola %{attribute} jest za krótka (co najmniej %{count} znaków)"
+        other: "Wartość pola %{attribute} jest za krótka (co najmniej %{count} znaku)"
+      wrong_length:
+        one: "Wartość pola %{attribute} ma nieprawidłową długość (powinien być 1 znak)"
+        few: "Wartość pola %{attribute} ma nieprawidłową długość (powinny być %{count} znaki)"
+        many: "Wartość pola %{attribute} ma nieprawidłową długość (powinno być %{count} znaków)"
+        other: "Wartość pola %{attribute} ma nieprawidłową długość (powinno być %{count} znaku)"
+
+  activemodel:
+    errors:
+      models:
+        faculty_access_apply/apply_paramifier: &faculty_access_apply
+          attributes:
+            first_name:
+              blank: Wpisz imię
+            last_name:
+              blank: Wpisz nazwisko
+            email:
+              blank: Wpisz adres e-mail
+            school:
+              blank: Wpisz nazwę szkoły
+            phone_number:
+              blank: Wpisz numer telefonu
+            url:
+              blank: Wpisz adres strony
+            num_students:
+              blank: Podaj liczbę uczniów
+              not_a_number: Podana wartość nie jest liczbą
+              greater_than_or_equal_to: >-
+                Liczba uczniów musi wynosić co najmniej %{count}
+            using_openstax:
+              blank: Proszę wybrać jedną z opcji
+        faculty_access_apply_instructor/apply_paramifier:
+          <<: *faculty_access_apply
+        identities_set_password/set_password_paramifier:
+          attributes:
+            password:
+              blank: Wpisz hasło
+            password_confirmation:
+              blank: Wpisz hasło ponownie
+        sessions_lookup_login/login_paramifier:
+          attributes:
+            username_or_email:
+              blank: Wpisz adres e-mail lub nazwę użytkownika
+        signup_password/signup_paramifier:
+          attributes:
+            password:
+              blank: Wpisz hasło
+            password_confirmation:
+              blank: Wpisz hasło ponownie
+        signup_profile/profile_paramifier: &signup_profile
+          attributes:
+            first_name:
+              blank: Wpisz imię
+            last_name:
+              blank: Wpisz nazwisko
+            school:
+              blank: Wpisz nazwę szkoły
+            phone_number:
+              blank: Wpisz numer telefonu
+            url:
+              blank: Wpisz adres strony
+            num_students:
+              blank: Podaj liczbę uczniów
+              not_a_number: Podana wartość nie jest liczbą
+              greater_than_or_equal_to: >-
+                Liczba uczniów musi wynosić co najmniej %{count}
+            using_openstax:
+              blank: Proszę wybrać jedną z opcji
+            subjects:
+              blank_selection: Zaznacz co najmniej jedną opcję
+        signup_profile_instructor/profile_paramifier:
+          <<: *signup_profile
+        signup_profile_other/profile_paramifier:
+          <<: *signup_profile
+        signup_start/signup_paramifier:
+          attributes:
+            email:
+              blank: Wpisz adres e-mail
+            role:
+              blank: Wybierz funkcję
+        signup_verify_email/pin_paramifier:
+          attributes:
+            pin:
+              blank: Wpisz PIN
+
+  activerecord:
+    errors:
+      models:
+        contact_info:
+          attributes:
+            user:
+              last_verified: >-
+                Nie można usunąć ostatniego zweryfikowanego adresu e-mail
+            value:
+              already_confirmed: Wartość jest już zatwierdzona dla innego konta
+              blank: Pole nie może być puste
+
+        email_address:
+          attributes:
+            value: &email_address_validations
+              invalid: „%{value}” nie jest poprawnym adresem e-mail
+              too_many_dots: Adres e-mail ma zbyt wiele kropek pod rząd
+              ends_with_dot: Adres e-mail nie może kończyć się kropką
+              contains_tick: Adres e-mail nie może zawierać znaku „`”
+              contains_colon: Adres e-mail nie może zawierać dwukropka
+              contains_comma: Adres e-mail nie może zawierać przecinka
+
+        identity:
+          attributes:
+            password:
+              blank: Wpisz hasło
+              too_short:
+                one: Hasło jest za krótkie (wymagany co najmniej jeden znak)
+                few: Hasło jest za krótkie (wymagane co najmniej %{count} znaki)
+                many: >-
+                  Hasło jest za krótkie (wymaganych co najmniej %{count} znaków)
+              too_long:
+                one: Hasło jest za długie (wymagany co najwyżej jeden znak)
+                few: >-
+                  Hasło jest za długie (wymagane co najwyżej %{count} znaki)
+                many: >-
+                  Hasło jest za długie (wymaganych co najwyżej %{count} znaków)
+            password_confirmation:
+              confirmation: Weryfikacja hasła nie powiodła się
+
+        signup_state:
+          attributes:
+            contact_info_value:
+              <<: *email_address_validations
+
+        user:
+          attributes:
+            username:
+              too_short:
+                one: >-
+                  Nazwa użytkownika jest za krótka
+                  (wymagany co najmniej jeden znak).
+                few: >-
+                  Nazwa użytkownika jest za krótka
+                  (wymagane co najmniej %{count} znaki)
+                many: >-
+                  Nazwa użytkownika jest za krótka
+                  (wymaganych co najmniej %{count} znaków)
+                other:
+              too_long:
+                one: >-
+                  Nazwa użytkownika jest zbyt długa
+                  (wymagany co najwyżej jeden znak).
+                few: >-
+                  Nazwa użytkownika jest zbyt długa
+                  (wymagane co najwyżej %{count} znaki).
+                many: >-
+                  Nazwa użytkownika jest zbyt długa
+                  (wymaganych co najwyżej %{count} znaków).
+                other:
+              invalid: >-
+                Nazwa użytkownika może składać się jedynie z liter, cyfr oraz
+                podkreślników.
+              taken: Ta nazwa użytkownika jest już zajęta.
+            first_name:
+              blank: Wpisz imię
+            last_name:
+              blank: Wpisz nazwisko

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,7 +272,6 @@ en:
       used_this_method_last_time: >-
         It looks like you used this the last time you signed in.
       email: Email
-      blank: Email or username can't be blank.
       email_placeholder: Email or username
       username_placeholder: Username
       next: Next
@@ -412,7 +411,6 @@ en:
       check_your_email: Check your inbox for %{email}!
       you_will_have_received: We sent you a six-digit PIN. Enter it below.
       pin_not_correct: This PIN is incorrect.  Please enter the correct PIN.
-      blank: cannot be blank.
       no_pin_confirmation_attempts_remaining:
         content_html: >-
           You have run out of attempts at confirming this email using a PIN.  Please

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,45 +1,4 @@
 en:
-  activemodel:
-    attributes:
-      sessions_lookup_login/login_paramifier:
-        username_or_email: Email or username
-      signup_profile_instructor/profile_paramifier:
-        first_name: This field
-        last_name: This field
-        phone_number: This field
-        school: This field
-        num_students: This field
-        url: This field
-        using_openstax: This field
-      signup_profile_other/profile_paramifier:
-        first_name: This field
-        last_name: This field
-        phone_number: This field
-        school: This field
-        url: This field
-      signup_profile_student/profile_paramifier:
-        first_name: This field
-        last_name: This field
-        school: This field
-      faculty_access_apply_instructor/apply_paramifier:
-        first_name: This field
-        last_name: This field
-        phone_number: This field
-        school: This field
-        num_students: This field
-        url: This field
-        using_openstax: This field
-      faculty_access_apply_other/apply_paramifier:
-        first_name: This field
-        last_name: This field
-        phone_number: This field
-        school: This field
-        url: This field
-  activerecord:
-    attributes:
-      signup_state:
-        contact_info_value: Email address
-
   # Strings in this section are intended for use from within JavaScript files.
   # They are reproduced as a global `window.OX.I18n`. For example the key
   # `javascript.alert.close` would be accessible as `window.OX.I18n.alert.close`.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -65,9 +65,13 @@ pl:
           Limit nieudanych prób logowania na Twoje konto został przekroczony.
           %{reset_password} albo spróbuj ponownie później.
         reset_password: Zmień hasło
+      too_many_lookup_attempts: >-
+        Wyczerpany limit prób logowania do konta. Spróbuj ponownie później
       way_to_login_cannot_be_added: >-
         Ta metoda logowania nie może zostać użyta, ponieważ jest powiązana
         z już wykorzystanym adresem e-mail.
+      mismatched_authentication: >-
+        Nie rozpoznano tej tożsamości; przedstaw się jeszcze raz
 
     signup:
       already_have_username_and_password: >-
@@ -175,6 +179,7 @@ pl:
         Niestety wystąpił problem z użytym przez Ciebie linkiem. Jeżeli problem
         będzie się powtarzał, skontaktuj się z działem pomocy.
       expired_password_link: Użyty przez ciebie link wygasł.
+      cancel: Anuluj
     reset:
       page_heading: Zmień hasło
       submit: Ustaw hasło
@@ -269,7 +274,6 @@ pl:
       no_account_q: Nie masz konta?
       used_this_method_last_time: Tej metody użyłeś/aś poprzednim razem.
       email: Adres e-mail
-      blank: Musisz podać adres e-mail lub nazwę użytkownika
       email_placeholder: Adres e-mail lub nazwa użytkownika
       username_placeholder: Nazwa użytkownika
       next: Przejdź dalej

--- a/lib/email_address_validations.rb
+++ b/lib/email_address_validations.rb
@@ -6,32 +6,32 @@ module EmailAddressValidations
       [
         {
           with: /\A[^@ ]+@[^@. ]+\.[^@ ]+\z/,
-          message: "\"%{value}\" is not a valid email address"
+          message: :invalid
         },
         {
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains dot-dot
           without: /.*\.{2,}.*/,
-          message: "This email has too many dots in a row"
+          message: :too_many_dots
         },
         {
           # AWS::SES::ResponseError InvalidParameterValue - Domain ends with dot
           without: /.*\.\z/,
-          message: "An email cannot end with a dot"
+          message: :ends_with_dot
         },
         {
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
           without: /`/,
-          message: "An email should not contain a tick (`)"
+          message: :contains_tick
         },
         {
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
           without: /:/,
-          message: "An email should not contain a colon"
+          message: :contains_colon
         },
         {
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
           without: /,/,
-          message: "An email should not contain a comma"
+          message: :contains_comma
         }
       ]
     end

--- a/spec/controllers/identities_controller_spec.rb
+++ b/spec/controllers/identities_controller_spec.rb
@@ -58,7 +58,7 @@ describe IdentitiesController, type: :controller do
           expect(response.code).to eq('400')
           expect(response.body).to have_no_missing_translations
           expect(response.body).not_to include(t :"identities.set.there_was_a_problem_with_password_link")
-          expect(response.body).to include("Password can't be blank")
+          expect(response.body).to include(error_msg IdentitiesSetPassword, :password, :blank) # TODO: get error message from activemodel
           expect(response.body).to include(t :"identities.reset.submit")
           identity.reload
           expect(identity.authenticate('password')).to be_truthy

--- a/spec/controllers/identities_controller_spec.rb
+++ b/spec/controllers/identities_controller_spec.rb
@@ -68,7 +68,7 @@ describe IdentitiesController, type: :controller do
           reset_password('pass','pass')
           expect(response.code).to eq('400')
           expect(response.body).to have_no_missing_translations
-          expect(response.body).to include('Password is too short')
+          expect(response.body).to include(error_msg Identity, :password, :too_short, count: 8)
           expect(response.body).to include(t :"identities.reset.submit")
           identity.reload
           expect(identity.authenticate('password')).to be_truthy
@@ -78,7 +78,7 @@ describe IdentitiesController, type: :controller do
           reset_password('password', 'passwordd')
           expect(response.code).to eq('400')
           expect(response.body).to have_no_missing_translations
-          expect(response.body).to include("Password confirmation doesn't match Password")
+          expect(response.body).to include(error_msg Identity, :password_confirmation, :confirmation)
           expect(response.body).to include(t :"identities.reset.submit")
           identity.reload
           expect(identity.authenticate('password')).to be_truthy

--- a/spec/features/apply_for_faculty_access.rb
+++ b/spec/features/apply_for_faculty_access.rb
@@ -61,10 +61,12 @@ describe 'Apply for faculty access', type: :feature, js: true do
 
       screenshot!
       expect(page).to have_content(t :"faculty_access.apply.page_heading")
-      expect(page).to have_content("can't be blank", count: 7)
+      [:first_name, :last_name, :email, :phone_number, :school, :url, :using_openstax].each do |var|
+        expect(pag).to have_content(error_msg FacultyAccessApply, var, :blank, scope: :activemodel)
+      end
       expect(find('#apply_first_name').value).not_to eq @user.first_name
       expect(find('#apply_last_name').value).not_to eq @user.last_name
-      expect(page).to have_content("is not a number")
+      expect(page).to have_content(error_msg FacultyAccessApply, :num_students, :not_a_number, scope: :activemodel)
     end
 
     scenario "email taken" do
@@ -148,8 +150,10 @@ describe 'Apply for faculty access', type: :feature, js: true do
 
       screenshot!
       expect(page).to have_content(t :"faculty_access.apply.page_heading")
-      expect(page).to have_content("can't be blank", count: 6)
-      expect(page).not_to have_content("is not a number")
+      [:first_name, :last_name, :email, :phone_number, :school, :url].each do |var|
+        expect(page).to have_content(error_msg FacultyAccessApply, var, :blank, scope: :activemodel)
+      end
+      expect(page).not_to have_content(error_msg FacultyAccessApply, :num_students, :not_a_number)
     end
 
     scenario "email taken" do

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -54,7 +54,7 @@ feature 'User resets password', js: true do
         visit start_path(type: type, token: @login_token)
         expect_page(type: type)
         click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content("Password can't be blank")
+        expect(page).to have_content(error_msg Identity, :password, :blank)
         screenshot!
       end
 
@@ -65,7 +65,7 @@ feature 'User resets password', js: true do
         fill_in (t :"identities.set.password"), with: 'pass'
         fill_in (t :"identities.set.confirm_password"), with: 'pass'
         click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content('Password is too short')
+        expect(page).to have_content(error_msg Identity, :password, :too_short, count: 8)
         screenshot!
       end
 
@@ -76,7 +76,7 @@ feature 'User resets password', js: true do
         fill_in (t :"identities.set.password"), with: 'password!'
         fill_in (t :"identities.set.confirm_password"), with: 'password!!'
         click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content("Password confirmation doesn't match Password")
+        expect(page).to have_content(error_msg Identity, :password_confirmation, :confirmation)
         screenshot!
       end
 

--- a/spec/features/user_cant_sign_in_spec.rb
+++ b/spec/features/user_cant_sign_in_spec.rb
@@ -21,7 +21,7 @@ feature "User can't sign in", js: true do
 
     scenario "username or email blank" do
       complete_login_username_or_email_screen('')
-      expect(page).to have_content("Email or username can't be blank") # TODO put in en.yml and reverse username/email
+      expect(page).to have_content(error_msg SessionsLookupLogin, :username_or_email, :blank)
       screenshot!
     end
 

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -71,7 +71,7 @@ feature 'User manages emails', js: true do
         find('input').set('user')
         find('.glyphicon-ok').click
       }
-      expect(page).to have_content('Value "user" is not a valid email address')
+      expect(page).to have_content(error_msg EmailAddress, :value, :invalid, value: 'user')
     end
 
     scenario 'toggles searchable field' do

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -327,7 +327,9 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     scenario 'fields blank' do
       complete_signup_password_screen('', '')
       expect(page).to have_no_missing_translations
-      expect(page).to have_content("can't be blank")
+      [:password, :password_confirmation].each do |var|
+        expect(page).to have_content(error_msg SignupPassword, var, :blank)
+      end
       screenshot!
     end
 
@@ -391,9 +393,11 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
         agree: true
       )
 
-      expect(page).to have_content("can't be blank", count: 6)
-      expect(page).to have_content("is not a number")
-      expect(page).to have_content("Subjects must have at least one selection")
+      [:first_name, :last_name, :phone_number, :school, :url, :using_openstax].each do |var|
+        expect(page).to have_content(error_msg SignupProfileInstructor, var, :blank)
+      end
+      expect(page).to have_content(error_msg SignupProfileInstructor, :num_students, :not_a_number)
+      expect(page).to have_content(error_msg SignupProfileInstructor, :subjects, :blank_selection)
 
       screenshot!
     end
@@ -415,7 +419,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
           agree: true,
         )
       )
-      expect(page).to have_content("must be greater than or equal to 0")
+      expect(page).to have_content(error_msg SignupProfileInstructor, :num_students, :greater_than_or_equal_to, count: 0)
       attrs.each do |key, value|
         expect(page).to have_field(t("signup.profile.#{key}"), with: value)
       end
@@ -467,7 +471,9 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
         agree: true
       )
 
-      expect(page).to have_content("can't be blank", count: 3)
+      [:first_name, :last_name, :school].each do |var|
+        expect(page).to have_content(error_msg SignupProfileStudent, var, :blank)
+      end
 
       screenshot!
     end
@@ -509,7 +515,9 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       )
 
       screenshot!
-      expect(page).to have_content("can't be blank", count: 5)
+      [:first_name, :last_name, :phone_number, :school, :url].each do |var|
+        expect(page).to have_content(error_msg SignupProfileOther, var, :blank)
+      end
     end
   end
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -320,7 +320,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     scenario 'passwords do not match' do
       complete_signup_password_screen('password', 'blah')
       expect(page).to have_no_missing_translations
-      expect(page).to have_content('confirmation doesn\'t match')
+      expect(page).to have_content(error_msg Identity, :password_confirmation, :confirmation)
       screenshot!
     end
 
@@ -334,7 +334,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     scenario 'password too short' do
       complete_signup_password_screen('p', 'p')
       expect(page).to have_no_missing_translations
-      expect(page).to have_content('too short')
+      expect(page).to have_content(error_msg Identity, :password, :too_short, count: 8)
       screenshot!
     end
 

--- a/spec/models/application_group_spec.rb
+++ b/spec/models/application_group_spec.rb
@@ -11,14 +11,14 @@ describe ApplicationGroup do
       expect(application_group).to be_valid
       application_group.application = nil
       expect(application_group).not_to be_valid
-      expect(application_group.errors.messages[:application]).to eq(["can't be blank"])
+      expect(application_group).to have_error(:application, :blank)
 
       application_group.application = application
 
       expect(application_group).to be_valid
       application_group.group = nil
       expect(application_group).not_to be_valid
-      expect(application_group.errors.messages[:group]).to eq(["can't be blank"])
+      expect(application_group).to have_error(:group, :blank)
     end
 
     it 'cannot have the same application and group' do
@@ -28,7 +28,7 @@ describe ApplicationGroup do
       expect(application_group2).to be_valid
       application_group2.group = application_group.group
       expect(application_group2).not_to be_valid
-      expect(application_group2.errors.messages[:group_id]).to eq(["has already been taken"])
+      expect(application_group2).to have_error(:group_id, :taken)
     end
   end
 

--- a/spec/models/application_user_spec.rb
+++ b/spec/models/application_user_spec.rb
@@ -22,14 +22,14 @@ describe ApplicationUser do
       expect(application_user).to be_valid
       application_user.application = nil
       expect(application_user).not_to be_valid
-      expect(application_user.errors.messages[:application]).to eq(["can't be blank"])
+      expect(application_user).to have_error(:application, :blank)
 
       application_user.application = application
 
       expect(application_user).to be_valid
       application_user.user = nil
       expect(application_user).not_to be_valid
-      expect(application_user.errors.messages[:user]).to eq(["can't be blank"])
+      expect(application_user).to have_error(:user, :blank)
     end
 
     it 'cannot have the same application and user' do
@@ -39,7 +39,7 @@ describe ApplicationUser do
       expect(application_user2).to be_valid
       application_user2.user = application_user.user
       expect(application_user2).not_to be_valid
-      expect(application_user2.errors.messages[:user_id]).to eq(["has already been taken"])
+      expect(application_user2).to have_error(:user_id, :taken)
     end
   end
 

--- a/spec/models/contact_info_spec.rb
+++ b/spec/models/contact_info_spec.rb
@@ -12,9 +12,8 @@ describe ContactInfo do
     it 'does not accept empty value or type' do
       info = ContactInfo.new
       expect(info).not_to be_valid
-      expect(info.errors.messages[:value]).to eq(["can't be blank"])
-      expect(info.errors.messages[:type]).to eq(
-        ["can't be blank"])
+      expect(info).to have_error(:value, :blank)
+      expect(info).to have_error(:type, :blank)
     end
 
     it 'does not accept invalid types' do
@@ -42,10 +41,10 @@ describe ContactInfo do
       email2.user = email1.user
       email2.value = email1.value.upcase
       expect(email2).not_to be_valid
-      expect(email2.errors.types[:value]).to include(:taken)
+      expect(email2).to have_error(:value, :taken)
       email2.verified = false
       expect(email2).not_to be_valid
-      expect(email2.errors.types[:value]).to include(:taken)
+      expect(email2).to have_error(:value, :taken)
     end
 
     it 'does not allow two users to have the same verified email with different case' do
@@ -63,7 +62,7 @@ describe ContactInfo do
       expect(email1.destroyed?).to be true
       email2.destroy
       expect(email2.destroyed?).to be false
-      expect(email2.errors[:user].to_s).to include('unable to delete')
+      expect(email2).to have_error(:user, :last_verified)
     end
 
     context 'when altering email value' do
@@ -79,7 +78,7 @@ describe ContactInfo do
         expect(newemail.save).to be true
         newemail.verified = true
         expect(newemail.save).to be false
-        expect(newemail.errors[:value].to_s).to include('already confirmed on another account')
+        expect(newemail).to have_error(:value, :already_confirmed)
       end
 
       it 'does allow a user to add an already used unverified email and to verify it' do
@@ -97,7 +96,7 @@ describe ContactInfo do
         email2.save!
         email1.value = email2.value
         expect(email1.save).to be false
-        expect(email1.errors[:value].to_s).to include('already confirmed on another account')
+        expect(email1).to have_error(:value, :already_confirmed)
       end
 
       it 'does allow a user to update their email to be a dupe of an unverified email' do

--- a/spec/models/group_member_spec.rb
+++ b/spec/models/group_member_spec.rb
@@ -7,13 +7,13 @@ describe GroupMember do
     it 'must have a valid group' do
       group_member.group = nil
       expect(group_member).not_to be_valid
-      expect(group_member.errors.messages[:group]).to eq(["can't be blank"])
+      expect(group_member).to have_error(:group, :blank)
     end
 
     it 'must have a valid user' do
       group_member.user = nil
       expect(group_member).not_to be_valid
-      expect(group_member.errors.messages[:user]).to eq(["can't be blank"])
+      expect(group_member).to have_error(:user, :blank)
     end
 
     it 'must have a unique user for each group' do
@@ -21,8 +21,7 @@ describe GroupMember do
       group_member2 = FactoryGirl.build(:group_member, group: group_member.group,
                                                        user: group_member.user)
       expect(group_member2).not_to be_valid
-      expect(group_member2.errors.messages[:user_id]).to(
-        eq(["has already been taken"]))
+      expect(group_member2).to have_error(:user_id, :taken)
 
       group_member2.user = FactoryGirl.build(:user)
       expect(group_member2).to be_valid

--- a/spec/models/group_nesting_spec.rb
+++ b/spec/models/group_nesting_spec.rb
@@ -15,17 +15,17 @@ describe GroupNesting do
 
       group_nesting_2.member_group = nil
       expect(group_nesting_2).not_to be_valid
-      expect(group_nesting_2.errors.messages[:member_group]).to eq(["can't be blank"])
+      expect(group_nesting_2).to have_error(:member_group, :blank)
 
       group_nesting_2.member_group = group_nesting_1.member_group
       expect(group_nesting_2).not_to be_valid
-      expect(group_nesting_2.errors.messages[:member_group_id]).to eq(["has already been taken"])
+      expect(group_nesting_2).to have_error(:member_group_id, :taken)
     end
 
     it 'must have a container_group' do
       group_nesting_2.container_group = nil
       expect(group_nesting_2).not_to be_valid
-      expect(group_nesting_2.errors.messages[:container_group]).to eq(["can't be blank"])
+      expect(group_nesting_2).to have_error(:container_group, :blank)
     end
 
     it 'cannot nest groups in loops' do

--- a/spec/models/group_owner_spec.rb
+++ b/spec/models/group_owner_spec.rb
@@ -7,13 +7,13 @@ describe GroupOwner do
     it 'must have a valid group' do
       group_owner.group = nil
       expect(group_owner).not_to be_valid
-      expect(group_owner.errors.messages[:group]).to eq(["can't be blank"])
+      expect(group_owner).to have_error(:group, :blank)
     end
 
     it 'must have a valid user' do
       group_owner.user = nil
       expect(group_owner).not_to be_valid
-      expect(group_owner.errors.messages[:user]).to eq(["can't be blank"])
+      expect(group_owner).to have_error(:user, :blank)
     end
 
     it 'must have a unique user for each group' do
@@ -21,8 +21,7 @@ describe GroupOwner do
       group_owner2 = FactoryGirl.build(:group_owner, group: group_owner.group,
                                                      user: group_owner.user)
       expect(group_owner2).not_to be_valid
-      expect(group_owner2.errors.messages[:user_id]).to(
-        eq(["has already been taken"]))
+      expect(group_owner2).to have_error(:user_id, :taken)
 
       group_owner2.user = FactoryGirl.build(:user)
       expect(group_owner2).to be_valid

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,7 +17,7 @@ describe Group do
 
       group_3 = FactoryGirl.build(:group, name: group_1.name)
       expect(group_3).not_to be_valid
-      expect(group_3.errors.messages[:name]).to eq(["has already been taken"])
+      expect(group_3).to have_error(:name, :taken)
 
       group_3.name = nil
       expect(group_3).to be_valid

--- a/spec/models/message_body_spec.rb
+++ b/spec/models/message_body_spec.rb
@@ -9,7 +9,7 @@ describe MessageBody do
     it 'must have a valid message' do
       message_body.message = nil
       expect(message_body).not_to be_valid
-      expect(message_body.errors.messages[:message]).to eq(["can't be blank"])
+      expect(message_body).to have_error(:message, :blank)
     end
 
     it 'must not be blank' do
@@ -17,7 +17,7 @@ describe MessageBody do
       message_body.text = ''
       message_body.short_text = ''
       expect(message_body).not_to be_valid
-      expect(message_body.errors.messages[:base]).to eq(["can't be blank"])
+      expect(message_body).to have_error(:base, :blank)
     end
 
     it 'must have a unique message' do
@@ -25,7 +25,7 @@ describe MessageBody do
       message_body2 = FactoryGirl.build(:message_body,
                         message: message_body.message)
       expect(message_body2).not_to be_valid
-      expect(message_body2.errors.messages[:message_id]).to eq(["has already been taken"])
+      expect(message_body2).to have_error(:message_id, :taken)
     end
 
     it 'validates if it has a unique message and is not blank' do

--- a/spec/models/message_recipient_spec.rb
+++ b/spec/models/message_recipient_spec.rb
@@ -9,8 +9,7 @@ describe MessageRecipient do
     it 'must have a valid message' do
       message_recipient.message = nil
       expect(message_recipient).not_to be_valid
-      expect(message_recipient.errors.messages[:message]).to(
-        eq(["can't be blank"]))
+      expect(message_recipient).to have_error(:message, :blank)
     end
 
     it 'must have a unique user' do
@@ -18,8 +17,7 @@ describe MessageRecipient do
       message_recipient2 = FactoryGirl.build(:message_recipient,
         user: message_recipient.user, message: message_recipient.message)
       expect(message_recipient2).not_to be_valid
-      expect(message_recipient2.errors.messages[:user_id]).to(
-        eq(["has already been taken"]))
+      expect(message_recipient2).to have_error(:user_id, :taken)
     end
 
     it 'must have a unique contact_info' do
@@ -28,8 +26,7 @@ describe MessageRecipient do
         contact_info: message_recipient.contact_info,
         message: message_recipient.message)
       expect(message_recipient2).not_to be_valid
-      expect(message_recipient2.errors.messages[:contact_info_id]).to(
-        eq(["has already been taken"]))
+      expect(message_recipient2).to have_error(:contact_info_id, :taken)
     end
 
     it 'validates if it has a message and unique contact_info and user' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -34,32 +34,31 @@ describe Message do
     it 'must have a valid body' do
       message.body = nil
       expect(message).not_to be_valid
-      expect(message.errors.messages[:body]).to eq(["can't be blank"])
+      expect(message).to have_error(:body, :blank)
     end
 
     it 'must have a valid application' do
       message.application = nil
       expect(message).not_to be_valid
-      expect(message.errors.messages[:application]).to eq(["can't be blank"])
+      expect(message).to have_error(:application, :blank)
     end
 
     it 'must have message_recipients' do
       message.message_recipients = []
       expect(message).not_to be_valid
-      expect(message.errors.messages[:message_recipients]).to(
-        eq(["can't be blank"]))
+      expect(message).to have_error(:message_recipients, :blank)
     end
 
     it 'must have a valid subject' do
       message.subject = ''
       expect(message).not_to be_valid
-      expect(message.errors.messages[:subject]).to eq(["can't be blank"])
+      expect(message).to have_error(:subject, :blank)
     end
 
     it 'must have a valid subject_prefix' do
       message.subject_prefix = ''
       expect(message).not_to be_valid
-      expect(message.errors.messages[:subject_prefix]).to eq(["can't be blank"])
+      expect(message).to have_error(:subject_prefix, :blank)
     end
 
     it 'validates if it has all the required fields' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,13 +27,13 @@ describe User, type: :model do
       it 'is invalid for the first name to become blank' do
         user.first_name = "   "
         expect(user).not_to be_valid
-        expect(user.errors[:first_name]).to include("can't be blank")
+        expect(user).to have_error(:first_name, :blank)
       end
 
       it 'is invalid for the last name to become blank' do
         user.last_name = "\t   "
         expect(user).not_to be_valid
-        expect(user.errors[:last_name]).to include("can't be blank")
+        expect(user).to have_error(:last_name, :blank)
       end
     end
   end
@@ -101,7 +101,7 @@ describe User, type: :model do
       user_3 = FactoryGirl.build :user, username: user_1.username
       expect(user_3).not_to be_valid
       expect(user_3.errors).to include(:username)
-      expect(user_3.errors[:username]).to include('has already been taken')
+      expect(user_3).to have_error(:username, :taken)
 
       user_4 = FactoryGirl.build :user, username: user_1.username.upcase
       expect(user_4).not_to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -263,6 +263,88 @@ RSpec::Matchers.define :have_api_error_status do |error_status|
   end
 end
 
+# Matcher checking a model instance for error presence. For example
+#
+#   model = Model.create(id: already_taken_value, name: 'Name')
+#   expect(model).to have_error(:id, :taken)
+#   expect(model).not_to have_error(:name, :blank)
+RSpec::Matchers.define :have_error do |field, message|
+  include RSpec::Matchers::Composable
+
+  match do |actual|
+    actual.errors.types.include? field and actual.errors.types[field].include? message
+  end
+
+  failure_message do |actual|
+    if actual.errors[field].empty?
+      "expected #{actual.model_name} to have errors on #{field}, but it had none"
+    else
+      msg = error_msg actual.class, field, message
+      "expected #{actual.errors[field]} to include #{msg.inspect}"
+    end
+  end
+
+  failure_message_when_negated do |actual|
+    msg = error_msg actual.class, field, message
+    "expected #{actual.errors[field]} not to include #{msg.inspect}"
+  end
+end
+
+# Utility for getting error messages for models. It's intended as a replacement
+# for have_error matcher to be used when there is no model instance. For example
+#
+#   visit '/redefine/model/instance'
+#   expect(page).to have_content(error_msg Model, :id, :taken)
+#
+# There two alternative signatures
+#
+# error_msg model, field, error, options = {}
+# error_msg model, group, field, error, options = {}
+#
+# First form expects model to be an ActiveRecord model, a Lev handler with
+# a single paramify block, or a symbol naming one.
+#
+# Second form expects a Lev handler with a paramify block named group, or
+# a symbol naming one.
+def error_msg model, *args
+  model_or_name = model
+  if model.is_a? Symbol
+    model = Object.const_get model.to_s.camelize
+  end
+
+  if model.include? Lev::Handler
+    if args[-1].is_a? Hash
+      options = args.pop
+    else
+      options = {}
+    end
+
+    if args.length == 3
+      group, field, error = args
+    elsif args.length == 2 and model.paramify_classes.keys.length == 1
+      field, error = args
+      group = model.paramify_classes.keys[0]
+    end
+
+    model = model.paramify_classes[group]
+
+    if model.nil?
+      raise "#{model_or_name} is a Lev handler but is not paramified"
+    end
+  else
+    field, error, options = args
+  end
+  options ||= {}
+
+  instance = model.new
+  if options.has_key? :value
+    instance[field] = options[:value]
+  end
+
+  options[:message] = error
+  Lev::BetterActiveModelErrors.generate_message instance, field, :invalid, options
+end
+
 # Fail on missing translation in a spec.
 I18n.exception_handler = lambda do |exception, locale, key, options|
   raise "Missing translation for #{key} in locale #{locale} with options #{options}"


### PR DESCRIPTION
This PR internationalises validation messages for ActiveRecord models and Lev handlers.

To account for non-SOV and non-SVO languages the default error message format has been changed from `"%{attribute}" "%{message}"` to just `"%{message}"`. While not necessary, this has been done also for English, as this locale will serve as a base for future translations. Default validation messages have also been changed to reflect this new format.

Error messages have been moved from main language files to `activerecord.{lang}.yml`. All error messages which may be returned to the user have been declared in translation files, including cases where the validations are using default messages, so that translation files explicitly list all user-visible messages.