### PR TITLE
Remove 'piloting the book' adoption status on leads

### DIFF
--- a/app/views/faculty_access/apply.html.erb
+++ b/app/views/faculty_access/apply.html.erb
@@ -77,7 +77,6 @@
                         [t('.instructor_use.how'), ""],
                         [t('.instructor_use.fully'), 'Confirmed Adoption Won'],
                         [t('.instructor_use.recommended'), 'Confirmed Will Recommend'],
-                        [t('.instructor_use.piloting'), 'Piloting book this semester'],
                         [t('.instructor_use.interested'), 'High Interest in Adopting'],
                         [t('.instructor_use.nope'), 'Not using']
                       ],

--- a/app/views/signup/profile.html.erb
+++ b/app/views/signup/profile.html.erb
@@ -32,7 +32,6 @@
                     [t('.instructor_use.how'), ""],
                     [t('.instructor_use.fully'), 'Confirmed Adoption Won'],
                     [t('.instructor_use.recommended'), 'Confirmed Will Recommend'],
-                    [t('.instructor_use.piloting'), 'Piloting book this semester'],
                     [t('.instructor_use.interested'), 'High Interest in Adopting'],
                     [t('.instructor_use.nope'), 'Not using']
                    ],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,7 +490,6 @@ en:
         how: How are you using OpenStax?
         fully: Fully adopted and using it as the primary textbook
         recommended: Recommending the book – my students buy a different book
-        piloting: Piloting the book
         interested: Interested in using OpenStax in the future
         nope: Not using OpenStax
       # %{terms_of_use}     a hyperlink to text of the Terms of Use.
@@ -551,7 +550,6 @@ en:
         how: How are you using OpenStax?
         fully: Fully adopted and using it as the primary textbook
         recommended: Recommending the book – my students buy a different book
-        piloting: Piloting the book
         interested: Interested in using OpenStax in the future
         nope: Not using OpenStax
       phone_number: Phone number

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -445,7 +445,6 @@ pl:
         fully: Używam OpenStax jako mojego głównego podręcznika.
         recommended: >-
           Polecam podręcznik OpenStax, ale moi uczniowie kupują inny.
-        piloting: Testuję podręcznik.
         interested: Jestem zainteresowany/a używaniem podręcznika OpenStax.
         nope: Nie używam OpenStax.
       have_read_terms_and_agree_html: >-
@@ -507,7 +506,6 @@ pl:
         fully: Używam OpenStax jako mojego głównego podręcznika.
         recommended: >-
           Polecam podręcznik OpenStax, ale moi uczniowie kupują inny.
-        piloting: Testuję podręcznik OpenStax.
         interested: Jestem zainteresowany/a używaniem podręcznika OpenStax.
         nope: Nie używam OpenStax.
       phone_number: Numer telefonu


### PR DESCRIPTION
@denvergreene says this status is no longer needed / desired.