### PR TITLE
fix badly formatted event_data in some SecurityLogs

### DIFF
--- a/lib/tasks/fix_bad_security_log_event_data.rake
+++ b/lib/tasks/fix_bad_security_log_event_data.rake
@@ -1,0 +1,16 @@
+desc "Find possible duplicate acccounts"
+task fix_bad_security_log_event_data: [:environment] do
+
+  bad_to_fixed_event_data = {
+    "---\n:reason: cannot_find_user\n" =>        "{\"reason\":\"cannot_find_user\"}",
+    "---\n:reason: bad_password\n" =>            "{\"reason\":\"bad_password\"}",
+    "---\n:reason: multiple_users\n" =>          "{\"reason\":\"multiple_users\"}",
+    "---\n:reason: too_many_login_attempts\n" => "{\"reason\":\"too_many_login_attempts\"}"
+  }
+
+  bad_to_fixed_event_data.each do |bad, fix|
+    ActiveRecord::Base.connection.execute(
+      "update security_logs set event_data='#{fix}' where event_data='#{bad}'"
+    )
+  end
+end

--- a/spec/lib/tasks/fix_bad_security_log_event_data_spec.rb
+++ b/spec/lib/tasks/fix_bad_security_log_event_data_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "fix_bad_security_log_event_data" do
+  include_context "rake"
+
+  before(:each) do
+    @goods = {}
+    @bads = {}
+
+    @goods[:cannot_find_user], @bads[:cannot_find_user] = good_and_bad(reason: :cannot_find_user)
+    @goods[:bad_password], @bads[:bad_password] = good_and_bad(reason: :bad_password)
+    @goods[:multiple_users], @bads[:multiple_users] = good_and_bad(reason: :multiple_users)
+    @goods[:too_many_login_attempts], @bads[:too_many_login_attempts] = good_and_bad(reason: :too_many_login_attempts)
+  end
+
+  it "works" do
+    # Check that the goods are good and the bads are bad in the way we see on production
+    @goods.each { |_, good| expect{good.reload}.not_to raise_error }
+    @bads.each  { |_, bad|  expect{bad.reload}.to raise_error(JSON::ParserError) }
+
+    call
+
+    # Check that goods are unchanged and still load
+    @goods.each do |reason, good|
+      expect{good.reload}.not_to raise_error
+      expect(good.event_data).to eq({ "reason" => reason.to_s })
+    end
+
+    # Check that bads load now and have the right event_data
+    @bads.each do |reason, bad|
+      expect{bad.reload}.not_to raise_error
+      expect(bad.event_data).to eq({ "reason" => reason.to_s })
+    end
+  end
+
+
+  def good_and_bad(reason:)
+    good = FactoryGirl.create :security_log, event_data: { reason: reason.to_s }
+
+    bad = FactoryGirl.create :security_log
+    ActiveRecord::Base.connection.execute(
+      "update security_logs set event_data='---\n:reason: #{reason}\n' where id=#{bad.id}"
+    )
+
+    [good, bad]
+  end
+
+end


### PR DESCRIPTION
A larger number of `SecurityLog` records on production have badly-formatted `event_data`, e.g. it looks like:

```
"---\n:reason: cannot_find_user\n"
```

When these logs are loaded, the deserialization code raises a `JSON::ParserError` exception.  This prevents CS from looking at security logs for impacted users.

This PR adds a rake task that fixes the bad cases.