### PR TITLE
Direct link to full admin console

### DIFF
--- a/app/assets/stylesheets/application_layout.scss
+++ b/app/assets/stylesheets/application_layout.scss
@@ -136,13 +136,15 @@ body, p, ol, ul, td, a {
   top: 0;
   left: 0;
   color: white;
+  padding: 4px;
 
   a {
     text-decoration: underline;
+    color: white;
   }
 
   #clock.highlight {
-    color: #ff00ff;
+    color: rgba(255,255,255,0.5);
   }
 }
 

--- a/app/views/shared/_upper_corner_console.html.erb
+++ b/app/views/shared/_upper_corner_console.html.erb
@@ -5,9 +5,11 @@
 
     <% if !Rails.env.production? %>
       Current user: <%= current_user.username %><br/>
-      <%= link_to "Dev Console", main_app.admin_path, remote: true %><br/>
+      <%= link_to "Popup Console", main_app.admin_path, remote: true %><br/>
+      <%= link_to "Full Console", main_app.admin_console_path %><br/>
     <% elsif current_user.is_administrator? %>
-      <%= link_to "Admin Console", main_app.admin_path, remote: true %><br/>
+      <%= link_to "Popup Console", main_app.admin_path, remote: true %><br/>
+      <%= link_to "Full Console", main_app.admin_console_path %><br/>
     <% end %>
 
     <% clock_is_normally_enabled = @clock_enabled && signed_in? %>


### PR DESCRIPTION
Change old admin console link to "Popup console" and add a direct link to full admin console.

![image](https://cloud.githubusercontent.com/assets/1001691/23725825/ea2cc01c-0406-11e7-9b39-b1bc12bedef2.png)

clock and current user not shown in production