### PR TITLE
Hide signup when asked to log in from faculty application page

### DIFF
--- a/app/controllers/faculty_access_controller.rb
+++ b/app/controllers/faculty_access_controller.rb
@@ -1,5 +1,7 @@
 class FacultyAccessController < ApplicationController
 
+  prepend_before_filter :disallow_signup, only: :apply
+
   helper_method :instructor_has_selected_subject
 
   def apply
@@ -36,6 +38,11 @@ class FacultyAccessController < ApplicationController
 
   def instructor_has_selected_subject(key)
     params[:apply] && params[:apply][:subjects] && params[:apply][:subjects][key] == '1'
+  end
+
+  def disallow_signup
+    # value doesn't really matter, if set at all, signup hidden
+    params[:no_signup] = 1
   end
 
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -52,8 +52,10 @@
       <section class="footer">
         <input type="submit" value="<%= t '.next' %>" class="primary" />
         <p class="extra-info">
-          <%= t '.no_account_q' %>
-          <%= link_to(t('.sign_up'), get_alternate_signup_url || signup_path) %>.
+          <% if !params.has_key?(:no_signup) %>
+            <%= t '.no_account_q' %>
+            <%= link_to(t('.sign_up'), get_alternate_signup_url || signup_path) %>.
+          <% end %>
         </p>
       </section>
   <% end %>

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -44,7 +44,7 @@ module UserSessionManagement
     return if signed_in?
 
     store_url
-    redirect_to main_app.login_path(params.slice(:client_id, :signup_at, :go))
+    redirect_to main_app.login_path(params.slice(:client_id, :signup_at, :go, :no_signup))
   end
 
   def authenticate_admin!

--- a/spec/features/apply_for_faculty_access.rb
+++ b/spec/features/apply_for_faculty_access.rb
@@ -8,9 +8,33 @@ describe 'Apply for faculty access', type: :feature, js: true do
     @user.save!
   end
 
-  scenario "anonymous user rejected" do
+  scenario "anonymous user asked to log in" do
     visit faculty_access_apply_path(r: capybara_url(external_app_for_specs_path))
+
+    screenshot!
+
     expect_sign_in_page
+    expect(page).not_to have_content("Sign up")
+
+    complete_login_username_or_email_screen('user')
+    complete_login_password_screen('password')
+
+    complete_faculty_access_apply_screen(
+      role: :other,
+      first_name: "Jimmy",
+      last_name: "Tudeski",
+      email: "howdy@ho.com",
+      phone_number: "000-0000",
+      school: "Rice University",
+      url: "http://www.rice.edu",
+      subjects: ["Biology", "Principles of Macroeconomics"],
+      newsletter: true,
+    )
+
+    expect(page).to have_content(t :"faculty_access.pending.page_heading")
+    click_button(t :"faculty_access.pending.ok")
+
+    expect(page.current_url).to eq(capybara_url(external_app_for_specs_path))
   end
 
   context "chooses instructor role" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -468,7 +468,7 @@ def complete_faculty_access_apply_screen(role: nil, first_name: nil, last_name: 
   subjects.each do |subject|
     find_field(subject).set("1")
   end
-  page.check('profile[newsletter]') if newsletter
+  page.check('apply[newsletter]') if newsletter
   click_button (t :"faculty_access.apply.submit")
   expect(page).to have_no_missing_translations
 end


### PR DESCRIPTION
When a user visits the [faculty access application page](https://accounts.openstax.org/faculty_access/apply), they are expected to have an account and be logged in to it.  If for some reason they are not logged in, Accounts redirects them to the login page.  Before this PR, this log in page had a "Sign up" link, which doesn't really make sense because they should already have an account to get to the faculty application page.  Some users would click this link and get down a bad path (it would loop, etc).  

This is what it looked like before:

![image](https://cloud.githubusercontent.com/assets/1001691/23727632/b31be22c-040d-11e7-899e-cc297b46a2d0.png)

With this PR, we now hide the sign up link when users arrive from the faculty access application page:

![image](https://cloud.githubusercontent.com/assets/1001691/23727666/c7b54d86-040d-11e7-8fc5-1d9bfe3e372d.png)
