### PR TITLE
Make security log search from user admin screen more specific

### DIFF
--- a/app/routines/admin/search_security_log.rb
+++ b/app/routines/admin/search_security_log.rb
@@ -79,9 +79,16 @@ module Admin
           end
         end
 
+        with.keyword :user_id do |user_ids_array|
+          user_ids_array.each do |user_ids|
+            sanitized_ids = to_number_array(user_ids)
+
+            @items = @items.where { user.id.in sanitized_ids }
+          end
+        end
+
         with.keyword :user do |users_array|
           users_array.each do |users|
-            sanitized_ids = to_number_array(users)
             sanitized_names = to_string_array(users, prepend_wildcard: true, append_wildcard: true)
             has_anonymous = sanitized_names.any? do |name|
               'anonymous'.include?(name.downcase.gsub('%', ''))
@@ -91,8 +98,7 @@ module Admin
             end
 
             @items = @items.where do
-              query = (        user.id.in       sanitized_ids  ) |
-                      (  user.username.like_any sanitized_names) |
+              query = (  user.username.like_any sanitized_names) |
                       (user.first_name.like_any sanitized_names) |
                       ( user.last_name.like_any sanitized_names)
               query = query | ((user.id.eq nil) & (application.id.eq     nil)) if has_anonymous

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -164,7 +164,7 @@
     <%= f.label :security_log, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <p class="form-control-static">
-        <%= link_to "Security Log", admin_security_log_path(search: { query: "user:#{@user.id}" }) %>
+        <%= link_to "Security Log", admin_security_log_path(search: { query: "user_id:#{@user.id}" }) %>
       </p>
     </div>
   </div>

--- a/spec/routines/admin/search_security_log_spec.rb
+++ b/spec/routines/admin/search_security_log_spec.rb
@@ -21,6 +21,11 @@ describe Admin::SearchSecurityLog, type: :routine do
     @type_sl = FactoryGirl.create :security_log, user: @another_user,
                                                  application: @another_app,
                                                  event_type: :admin_created
+
+    @user_with_name_like_other_id = FactoryGirl.create :user, first_name: @user.id
+    @user_with_name_like_other_id_sl = FactoryGirl.create :security_log,
+                                                          user: @user_with_name_like_other_id,
+                                                          application: @another_app
   end
 
   it "matches based on id" do
@@ -28,8 +33,8 @@ describe Admin::SearchSecurityLog, type: :routine do
     expect(items).to match_array [@anon_sl]
   end
 
-  it "matches based on user id" do
-    items = described_class.call(query: "user:\"#{@user.id}\"").outputs.items.to_a
+  it "matches based on user id only" do
+    items = described_class.call(query: "user_id:#{@user.id}").outputs.items.to_a
     expect(items).to match_array [@app_and_user_sl, @user_sl]
   end
 
@@ -80,7 +85,8 @@ describe Admin::SearchSecurityLog, type: :routine do
 
   it "matches based on time" do
     items = described_class.call(query: "time:\"today\"").outputs.items.to_a
-    expect(items).to match_array [@type_sl, @ip_sl, @app_and_user_sl, @app_sl, @user_sl, @anon_sl]
+    expect(items).to match_array [@type_sl, @ip_sl, @app_and_user_sl, @app_sl, @user_sl, @anon_sl,
+                                  @user_with_name_like_other_id_sl]
   end
 
   it "matches any fields when no prefix given" do
@@ -90,7 +96,8 @@ describe Admin::SearchSecurityLog, type: :routine do
 
   it "returns all results in reverse creation order if the query is empty" do
     items = described_class.call(query: '').outputs.items.to_a
-    expect(items).to match_array [@type_sl, @ip_sl, @app_and_user_sl, @app_sl, @user_sl, @anon_sl]
+    expect(items).to match_array [@user_with_name_like_other_id_sl, @type_sl, @ip_sl,
+                                  @app_and_user_sl, @app_sl, @user_sl, @anon_sl]
   end
 
 end


### PR DESCRIPTION
In the old way if we were looking at the admin user edit page for user with ID 9, the "Security Log" link would use a search query with `user:9` -- this would match all users who have a "9" in their username.  

This PR changes the link to just search by user ID.