### PR TITLE
Update FB API calls to current version (HOTFIX)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'doorkeeper', '2.2.2'
 # OAuth clients
 gem 'omniauth'
 gem 'omniauth-identity'
-gem 'omniauth-facebook', '~>3.0.0'
+gem 'omniauth-facebook', '~>4.0.0'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-facebook (3.0.0)
+    omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.4.1)
       jwt (~> 1.5.2)
@@ -641,7 +641,7 @@ DEPENDENCIES
   oj
   oj_mimic_json
   omniauth
-  omniauth-facebook (~> 3.0.0)
+  omniauth-facebook (~> 4.0.0)
   omniauth-google-oauth2
   omniauth-identity
   omniauth-twitter

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -6,8 +6,8 @@ secrets = Rails.application.secrets
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :facebook, secrets[:facebook_app_id], secrets[:facebook_app_secret],
            client_options: {
-             site: 'https://graph.facebook.com/v2.0',
-             authorize_url: "https://www.facebook.com/v2.0/dialog/oauth"
+             site: 'https://graph.facebook.com/v2.8',
+             authorize_url: "https://www.facebook.com/v2.8/dialog/oauth"
            }
   provider :twitter, secrets[:twitter_consumer_key], secrets[:twitter_consumer_secret]
   provider :google_oauth2, secrets[:google_client_id], secrets[:google_client_secret]


### PR DESCRIPTION
We had been using version 2.0 of the FB graph API. On March 27 they deprecated use of that version. This PR upgrades us to the latest FB API.