### PR TITLE
set password from inside CC iframe

### DIFF
--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -31,7 +31,7 @@ class IdentitiesController < ApplicationController
   def sent_add; end
 
   def continue
-    redirect_back
+    redirect_to profile_url
   end
 
   protected

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -31,7 +31,7 @@ class IdentitiesController < ApplicationController
   def sent_add; end
 
   def continue
-    redirect_to profile_url
+    redirect_back
   end
 
   protected

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -9,6 +9,8 @@ class IdentitiesController < ApplicationController
                   only: [:reset, :send_reset, :sent_reset, :add, :send_add, :sent_add,
                          :reset_success, :add_success]
 
+  before_filter :allow_iframe_access
+
   def reset
     set_password(kind: :reset)
   end

--- a/app/controllers/remote_controller.rb
+++ b/app/controllers/remote_controller.rb
@@ -12,7 +12,7 @@ class RemoteController < ApplicationController
 
   # contains a bare-bones HTML file with an iframe proxy
   def iframe
-    store_url
+
   end
 
   # A bare page that's "displayed" inside an iframe after a logout has completed

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,6 +16,9 @@ class SessionsController < ApplicationController
   before_filter :store_authorization_url_as_fallback, only: [:new, :create]
   before_filter :maybe_skip_to_sign_up, only: [:new]
 
+  before_filter :allow_iframe_access, only: :reauthenticate
+
+
   # If the user arrives to :new already logged in, this means they got linked to
   # the login page somehow; attempt to redirect to the authorization url stored
   # earlier


### PR DESCRIPTION
Not sure about the redirect change, we need to figure out a better solution there.  Before the change, it would redirect back to tutor, which doesn't know what to do so it would display a blank page.