### PR TITLE
Notify devs when social login gives invalid_credentials

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,11 @@ en:
         address that is already in use!
       mismatched_authentication: >-
         You logged in with a different third-party account than we expected.  Please try again.
+      trouble_with_provider: >-
+        We are having difficulties communicating with the login provider you selected.  Our technical
+        team has been notified and we will get to work fixing this problem.  In the meantime you can
+        log in with a password if you have already set one up, or you can add one if you haven't.
+        If you need help, please contact support.
 
     signup:
       already_have_username_and_password: >-

--- a/spec/features/user_cant_sign_in_spec.rb
+++ b/spec/features/user_cant_sign_in_spec.rb
@@ -180,4 +180,22 @@ feature "User can't sign in", js: true do
     expect(page).to have_content(t(:"controllers.sessions.mismatched_authentication"))
   end
 
+  scenario 'social login fails with invalid_credentials notifies devs' do
+    user = create_user 'user'
+    authentication = FactoryGirl.create :authentication, provider: 'google_oauth2', user: user
+
+    arrive_from_app
+    complete_login_username_or_email_screen('user')
+
+    with_omniauth_failure_message(:invalid_credentials) do
+      click_link('google-login-button')
+    end
+
+    screenshot!
+    expect(page).to have_content(t(:"controllers.sessions.trouble_with_provider"))
+
+    open_email('recipients@example.org')
+    expect(current_email.subject).to eq "[OpenStax] (test) google_oauth2 social login is DOWN!"
+  end
+
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -193,6 +193,21 @@ def with_omniauth_test_mode(options={})
   end
 end
 
+def with_omniauth_failure_message(message)
+  begin
+    OmniAuth.config.test_mode = true
+
+    [:facebook, :google_oauth2, :twitter, :identity].each do |provider|
+      OmniAuth.config.mock_auth[provider] = message
+    end
+
+    yield
+  ensure
+    OmniAuth.config.test_mode = false
+  end
+
+end
+
 def make_new_contract_version(contract = FinePrint::Contract.first)
   new_contract_version = contract.new_version
   raise "New contract version didn't save" unless new_contract_version.save


### PR DESCRIPTION
`invalid_credentials` can come back from Google or Facebook login for any number of reasons, pretty much all of which are our fault (needing to sign new TOS, using deprecated APIs, etc).  Since we need to fix this ASAP so people can log in, this PR and notifies devs with an email.  It also gives a better error message to the user instead of just saying "invalid_credentials":

![image](https://cloud.githubusercontent.com/assets/1001691/25060340/de057ebe-2157-11e7-94f4-905b4f7b5bbd.png)
