### PR TITLE
Let admins manually set SF contact IDs

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -81,7 +81,7 @@ module Admin
 
       return true if new_id.blank? || new_id == @user.salesforce_contact_id
 
-      new_id = nil if new_id == "remove"
+      new_id = nil if new_id.downcase == "remove"
 
       check_really_exists = new_id.present?
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -55,6 +55,14 @@
   </div>
 
   <div class="form-group">
+    <%= f.label "New Salesforce contact", class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <%= f.text_field :salesforce_contact_id, class: "form-control" %>
+      <span class="help-block">Enter 'remove' to get rid of an existing SF contact ID.</span>
+    </div>
+  </div>
+
+  <div class="form-group">
     <%= f.label :faculty_status, class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <% if sf_id.nil? %>
@@ -63,7 +71,7 @@
       <% else %>
         <p class="form-control-static">
           <%= @user.faculty_status.humanize %>
-          <span class="help-block">This is a Salesforce user. You must change this setting in Salesforce.</span>
+          <span class="help-block">This is a Salesforce user. You must change this setting in Salesforce.  If you just changed the Salesforce contact ID, this field will update within 20 minutes.</span>
         </p>
       <% end %>
     </div>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -30,8 +30,8 @@ development:
 
   # Salesforce settings
   salesforce:
-    consumer_key: my_salesforce_key
-    consumer_secret: my_salesforce_secret
+    consumer_key: <%= ENV["SALESFORCE_CONSUMER_KEY"] || 'my_salesforce_key' %>
+    consumer_secret: <%= ENV["SALESFORCE_CONSUMER_SECRET"] || 'my_salesforce_secret' %>
     login_site: <%= ENV["SALESFORCE_LOGIN_SITE"] || 'https://test.salesforce.com' %>
     mail_recipients: 'recipients@example.org'
 
@@ -106,7 +106,7 @@ test:
     login_site: <%= ENV["SALESFORCE_LOGIN_SITE"] || 'https://test.salesforce.com' %>
     tutor_specs_oauth_token: <%= ENV["SALESFORCE_TUTORSPECS_USER_OAUTH_TOKEN"] || 'tutor_specs_oauth_token' %>
     tutor_specs_refresh_token: <%= ENV["SALESFORCE_TUTORSPECS_USER_REFRESH_TOKEN"] || 'tutor_specs_refresh_token' %>
-    tutor_specs_instance_url: <%= ENV["SALESFORCE_TUTORSPECS_USER_INSTANCE_URL"] || 'https://cs50.salesforce.com' %>
+    tutor_specs_instance_url: <%= ENV["SALESFORCE_TUTORSPECS_USER_INSTANCE_URL"] || 'https://cs51.salesforce.com' %>
 
   # Valid urls for loading inside an iframe
   valid_iframe_origins:

--- a/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name%20FROM%20Account"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 15 Apr 2017 22:33:45 GMT
+      Content-Security-Policy-Report-Only:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
+        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
+        ''self'' https:; report-uri /_/ContentDomainCSPNoAuth?type=login; base-uri
+        http://cs51.salesforce.com/services/data/v37.0/query'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=mT2D9a-uSZ6d4veUNhuROA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:33:45 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=24/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0014B00000DaY04QAF"},"Id":"0014B00000DaY04QAF","Name":"JP
+        University"}]}'
+    http_version: 
+  recorded_at: Sat, 15 Apr 2017 22:33:46 GMT
+- request:
+    method: post
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
+    body:
+      encoding: UTF-8
+      string: '{"FirstName":"Joshuah","LastName":"Witting","AccountId":"0014B00000DaY04QAF"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Sat, 15 Apr 2017 22:33:46 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=8SeYxZiGSNGb2NVWpJqh8g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:33:46 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=24/48000
+      Location:
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMl6QAF"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0034B00000FjMl6QAF","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Sat, 15 Apr 2017 22:33:47 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270034B00000FjMl6QAF%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 15 Apr 2017 22:33:47 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=pqNBtLQLTza4KJLkHw1KQQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:33:47 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=25/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMl6QAF"},"Id":"0034B00000FjMl6QAF","Name":"Joshuah
+        Witting","FirstName":"Joshuah","LastName":"Witting","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-04-15T22:33:47.000+0000","AccountId":"0014B00000DaY04QAF"}]}'
+    http_version: 
+  recorded_at: Sat, 15 Apr 2017 22:33:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%27somethingNewNotInSF%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sat, 15 Apr 2017 22:33:48 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=ug1qldYuQMC4VaEwfbC67g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:33:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=24/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"message":"\nAccountId FROM Contact WHERE (Id = ''somethingNewNotInSF'')
+        LIMIT\n                              ^\nERROR at Row:1:Column:156\ninvalid
+        ID field: somethingNewNotInSF","errorCode":"INVALID_QUERY_FILTER_OPERATOR"}]'
+    http_version: 
+  recorded_at: Sat, 15 Apr 2017 22:33:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/works_on_the_happy_path.yml
+++ b/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/works_on_the_happy_path.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Logan","LastName":"Lakin","Subject__c":"","Company":"JP
+      string: '{"FirstName":"Ruben","LastName":"Ritchie","Subject__c":"","Company":"JP
         University","Website":"http://www.rice.edu","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
         Adoption Won","Number_of_Students__c":0,"OS_Accounts_ID__c":1}'
@@ -26,25 +26,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Feb 2017 21:54:17 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; font-src https:
-        data:; connect-src ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Sat, 15 Apr 2017 22:37:47 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=wEgFkyMRTW69gFOCDnZvuA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        25-Apr-2017 21:54:17 GMT
+      - BrowserId=BsxyyKm3Sl2239rn2gVBig;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:37:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/48000
+      - api-usage=66/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EQUbUAO"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cPDUAY"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -53,12 +51,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EQUbUAO","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cPDUAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 21:54:19 GMT
+  recorded_at: Sat, 15 Apr 2017 22:37:49 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q3B000004EQUbUAO%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q4B0000047cPDUAY%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,23 +75,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Feb 2017 21:54:19 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; font-src https:
-        data:; connect-src ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Sat, 15 Apr 2017 22:37:49 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2CZYOykuRSCPJfY3w6h57w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        25-Apr-2017 21:54:19 GMT
+      - BrowserId=IczOVN9gQN6CxbygnIVWmQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:37:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/48000
+      - api-usage=67/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -102,11 +98,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EQUbUAO"},"Id":"00Q3B000004EQUbUAO","Name":"Logan
-        Lakin","FirstName":"Logan","LastName":"Lakin","Salutation":null,"Subject__c":null,"Company":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cPDUAY"},"Id":"00Q4B0000047cPDUAY","Name":"Ruben
+        Ritchie","FirstName":"Ruben","LastName":"Ritchie","Salutation":null,"Subject__c":null,"Company":"JP
         University","Phone":null,"Website":"http://www.rice.edu","Status":"Needs Opportunity","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
         Adoption Won","Number_of_Students__c":0.0,"OS_Accounts_ID__c":"1"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 21:54:19 GMT
+  recorded_at: Sat, 15 Apr 2017 22:37:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_three_contacts_with_same_primary_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_three_contacts_with_same_primary_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jeramie","LastName":"Green_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Abigail","LastName":"King_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:08 GMT
+      - Sat, 15 Apr 2017 22:36:25 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=uWIxg0elRoaoh0yP1KsH2Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:08 GMT
+      - BrowserId=OcDsJTATStCzUPNOLZ_osw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/48000
+      - api-usage=37/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLL8QAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlzQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLL8QAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlzQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:09 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:26 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Aurelia","LastName":"Schneider_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Vicente","LastName":"Rice_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,21 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:09 GMT
+      - Sat, 15 Apr 2017 22:36:26 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=A_UWtpAsTOOCyq0lJ9XkrQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:09 GMT
+      - BrowserId=vhWAlHlaTper0tZC8uwtJw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=39/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLORQA3"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMm4QAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -95,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLORQA3","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMm4QAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:10 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:27 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Nat","LastName":"Senger_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Candida","LastName":"Brekke_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -121,21 +125,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:11 GMT
+      - Sat, 15 Apr 2017 22:36:28 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6UDqSPiIRVafz1GuLdRgDQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:11 GMT
+      - BrowserId=gFfycg8WRp2tLclfFsTzgA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/48000
+      - api-usage=41/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLOWQA3"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMm0QAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -144,12 +150,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLOWQA3","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMm0QAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:12 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:29 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -168,19 +174,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:12 GMT
+      - Sat, 15 Apr 2017 22:36:29 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=qFEI7kxxRWav86g6jRyVkg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:12 GMT
+      - BrowserId=zk-ai6M4TIe8k8YbMoEegQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/48000
+      - api-usage=40/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -189,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLL8QAN"},"Id":"0033B00000AgLL8QAN","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLORQA3"},"Id":"0033B00000AgLORQA3","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLOWQA3"},"Id":"0033B00000AgLOWQA3","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMm0QAF"},"Id":"0034B00000FjMm0QAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlzQAF"},"Id":"0034B00000FjMlzQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMm4QAF"},"Id":"0034B00000FjMm4QAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:12 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:29 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -213,19 +221,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:13 GMT
+      - Sat, 15 Apr 2017 22:36:29 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=D1cNpp4mRN-z8JjkUjhgCw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:13 GMT
+      - BrowserId=e9uPrylgRgOU1ugV8Z4SdQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=45/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -236,5 +246,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:13 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_alt_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_alt_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Allan","LastName":"Kunze_unique_token","Email_alt__c":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Genevieve","LastName":"Huels_unique_token","Email_alt__c":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:18 GMT
+      - Sat, 15 Apr 2017 22:36:30 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=wUK0C5C6RGi1Ht3H4sA96Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:18 GMT
+      - BrowserId=TK874zVsQe24Y4_iUZgYtw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=71/48000
+      - api-usage=42/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLVDQA3"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMm9QAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLVDQA3","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMm9QAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:19 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:31 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Al","LastName":"Schimmel_unique_token","Email_alt__c":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Freida","LastName":"Hessel_unique_token","Email_alt__c":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,21 +74,26 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:19 GMT
+      - Sat, 15 Apr 2017 22:36:31 GMT
+      Content-Security-Policy-Report-Only:
+      - frame-ancestors 'self' *.salesforce.com *.force.com; report-uri /_/ContentDomainCSPNoAuth?type=mydomain;
+        base-uri http://cs51.salesforce.com/services/data/v37.0/sobjects/Contact
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=LiykzhS3TSu_a5VijYPRJQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:19 GMT
+      - BrowserId=0Nm4UVgNRGSrgtKLW6q0VQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=68/48000
+      - api-usage=45/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLL9QAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMmEQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -95,12 +102,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLL9QAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMmEQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:20 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:32 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,19 +126,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:21 GMT
+      - Sat, 15 Apr 2017 22:36:32 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4oIVtYWaSTWAzMgeQKf9Rw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:21 GMT
+      - BrowserId=oI7r2_6USEWmojq7jJBZ3g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=69/48000
+      - api-usage=43/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -140,12 +149,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLVDQA3"},"Id":"0033B00000AgLVDQA3","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLL9QAN"},"Id":"0033B00000AgLL9QAN","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMmEQAV"},"Id":"0034B00000FjMmEQAV","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMm9QAF"},"Id":"0034B00000FjMm9QAF","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:21 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:32 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -164,19 +173,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:21 GMT
+      - Sat, 15 Apr 2017 22:36:33 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=LNy06BHfRAuO9-NUCJcwtw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:21 GMT
+      - BrowserId=7scM2JN5RZKdv_1KrISU-w;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=70/48000
+      - api-usage=49/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -187,5 +198,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:21 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:33 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_and_alt_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_and_alt_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Reed","LastName":"Kuphal_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Dax","LastName":"Hilpert_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:04 GMT
+      - Sat, 15 Apr 2017 22:36:37 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ZSaZuXgxTDiZUavfOFZ9Uw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:04 GMT
+      - BrowserId=TM0PMZ-mS7OkugZlSTEqUA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=68/48000
+      - api-usage=46/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLKyQAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMmOQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLKyQAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMmOQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:05 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:38 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Emory","LastName":"Keebler_unique_token","Email_alt__c":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Miracle","LastName":"McGlynn_unique_token","Email_alt__c":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,21 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:05 GMT
+      - Sat, 15 Apr 2017 22:36:38 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=JBhOe2q2Tf-2nN9rirZsIg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:05 GMT
+      - BrowserId=xKOKutuqSze0XjYrCn5n8g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=65/48000
+      - api-usage=55/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLL3QAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlvQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -95,12 +99,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLL3QAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlvQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:06 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:39 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,19 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:07 GMT
+      - Sat, 15 Apr 2017 22:36:39 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=S1VJoJQFQuKF-mD8T9MKBA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:07 GMT
+      - BrowserId=YJIkEpFqSk6I8jj5cmmfkA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=69/48000
+      - api-usage=54/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -140,12 +146,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLL3QAN"},"Id":"0033B00000AgLL3QAN","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLKyQAN"},"Id":"0033B00000AgLKyQAN","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMmOQAV"},"Id":"0034B00000FjMmOQAV","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlvQAF"},"Id":"0034B00000FjMlvQAF","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:07 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:39 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -164,19 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:07 GMT
+      - Sat, 15 Apr 2017 22:36:39 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=hkq_TVz9QYSPW_3V6ogKMA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:07 GMT
+      - BrowserId=eLAEDJJ5R5quUjf9yYKpVw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=65/48000
+      - api-usage=54/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -187,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:07 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_email.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Kolby","LastName":"Mueller_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Joesph","LastName":"Batz_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:13 GMT
+      - Sat, 15 Apr 2017 22:36:33 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ww1-Jc_oSz2p_2nSZDeT5A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:13 GMT
+      - BrowserId=oh7OhQzhTpO3vdaY235obg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=43/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLRpQAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMf9QAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLRpQAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMf9QAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:14 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:34 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Brant","LastName":"Stanton_unique_token","Email":"f@f.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Joana","LastName":"Mitchell_unique_token","Email":"f@f.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,21 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:15 GMT
+      - Sat, 15 Apr 2017 22:36:34 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=nmzmGkXKTAOu1cKJzc1rGg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:15 GMT
+      - BrowserId=08HB5hgmQQaxNavCwMiiFw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=70/48000
+      - api-usage=49/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLRuQAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMmJQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -95,12 +99,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLRuQAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMmJQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:16 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:35 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,19 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:17 GMT
+      - Sat, 15 Apr 2017 22:36:36 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=aCVm5NslSUasLMsdQVZMEg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:17 GMT
+      - BrowserId=iHis5Dr_T2SlrJu51St58Q;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=69/48000
+      - api-usage=44/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -140,12 +146,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLRpQAN"},"Id":"0033B00000AgLRpQAN","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLRuQAN"},"Id":"0033B00000AgLRuQAN","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMf9QAF"},"Id":"0034B00000FjMf9QAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMmJQAV"},"Id":"0034B00000FjMmJQAV","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:17 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:36 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -164,19 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:17 GMT
+      - Sat, 15 Apr 2017 22:36:36 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=j8oioTGwTRWU6qu3sGyyng;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:17 GMT
+      - BrowserId=TO3_eXwjRjW4H3PAzk_pQg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/48000
+      - api-usage=45/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -187,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:17 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/errors_when_multiple_SF_contacts_exist_for_one_user.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/errors_when_multiple_SF_contacts_exist_for_one_user.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Alexzander","LastName":"Daniel_unique_token","Email":"a@a.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Madge","LastName":"Jaskolski_unique_token","Email":"a@a.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:44 GMT
+      - Sat, 15 Apr 2017 22:35:49 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6A8UcXQsSkKnMpDHuJ7pEg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:44 GMT
+      - BrowserId=zvzdWmI-RJm-66GqP1QlrA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=30/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgL4RQAV"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlLQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgL4RQAV","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlLQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:45 GMT
+  recorded_at: Sat, 15 Apr 2017 22:35:52 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Neoma","LastName":"Nikolaus_unique_token","Email":"b@b.com","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Coralie","LastName":"Ondricka_unique_token","Email":"b@b.com","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,21 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:45 GMT
+      - Sat, 15 Apr 2017 22:35:52 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=qtKSsUirQyqZCl65Zan60g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:45 GMT
+      - BrowserId=84yciCF-SfuRuPKGZ_jcxA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=30/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgL7kQAF"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlQQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -95,12 +99,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgL7kQAF","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlQQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:47 GMT
+  recorded_at: Sat, 15 Apr 2017 22:35:53 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -119,19 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:48 GMT
+      - Sat, 15 Apr 2017 22:35:54 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=rzP3Z7ONQUaZe_2QnjX_aw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:48 GMT
+      - BrowserId=vTKIDOXcSBGtDfcF7taasQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -140,12 +146,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgL4RQAV"},"Id":"0033B00000AgL4RQAV","Email":"a@a.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgL7kQAF"},"Id":"0033B00000AgL7kQAF","Email":"b@b.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlLQAV"},"Id":"0034B00000FjMlLQAV","Email":"a@a.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlQQAV"},"Id":"0034B00000FjMlQQAV","Email":"b@b.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:48 GMT
+  recorded_at: Sat, 15 Apr 2017 22:35:54 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -164,19 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:48 GMT
+      - Sat, 15 Apr 2017 22:35:54 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=mMrN74IPQ7uZn8MmeKnB2A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:48 GMT
+      - BrowserId=AZi8XSEISDaBsHucHDhy7w;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -187,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:48 GMT
+  recorded_at: Sat, 15 Apr 2017 22:35:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/sf_setup.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/sf_setup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Name%20FROM%20Account
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name%20FROM%20Account"
     body:
       encoding: US-ASCII
       string: ''
@@ -21,19 +21,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:43 GMT
+      - Sat, 15 Apr 2017 22:35:49 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8KR49OSHQ4KknQsITKXdTA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:43 GMT
+      - BrowserId=REBRrxZOS9-b6jwvkRnqIA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=30/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -42,8 +44,8 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0013B000009vJrCQAU"},"Id":"0013B000009vJrCQAU","Name":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0014B00000DaY04QAF"},"Id":"0014B00000DaY04QAF","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:44 GMT
+  recorded_at: Sat, 15 Apr 2017 22:35:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_not_cache_info_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_not_cache_info_when_not_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Elissa","LastName":"Yundt_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Julianne","LastName":"Pagac_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:24 GMT
+      - Sat, 15 Apr 2017 22:36:07 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=O-4J5oq5TeC5b4tBCnFQCg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:24 GMT
+      - BrowserId=dsf4XfP7SgeGgU53JpCYkA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=68/48000
+      - api-usage=32/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLYbQAN"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlaQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLYbQAN","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlaQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:25 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:08 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -70,19 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:26 GMT
+      - Sat, 15 Apr 2017 22:36:08 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=sWLOqq9sTYu9MultZckufA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:26 GMT
+      - BrowserId=N-xfGunNR3CrrI5IDjJq1g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=73/48000
+      - api-usage=32/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -91,12 +95,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLYbQAN"},"Id":"0033B00000AgLYbQAN","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlaQAF"},"Id":"0034B00000FjMlaQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:26 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:08 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -115,19 +119,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:26 GMT
+      - Sat, 15 Apr 2017 22:36:09 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jVxmClBqTLqw3D5uj6w5og;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:26 GMT
+      - BrowserId=nc0VSEz3T8yyBD2LjRg1wQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=70/48000
+      - api-usage=30/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -138,5 +144,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:26 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_update_info_when_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_update_info_when_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Lawrence","LastName":"Dare_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Kaleigh","LastName":"Marvin_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:22 GMT
+      - Sat, 15 Apr 2017 22:36:05 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=xgqGy5l6T0iaLfP5qJ-z1A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:22 GMT
+      - BrowserId=TbyZUIL-T62MOkhwcZzdQw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=72/48000
+      - api-usage=32/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLYWQA3"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlVQAV"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLYWQA3","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlVQAV","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:23 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:06 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -70,19 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:23 GMT
+      - Sat, 15 Apr 2017 22:36:06 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=PQ4ShxLGSqGvafUdT2LC1Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:23 GMT
+      - BrowserId=xaPV09PiQHCYO8JiiZdBIw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=30/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -91,12 +95,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLYWQA3"},"Id":"0033B00000AgLYWQA3","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlVQAV"},"Id":"0034B00000FjMlVQAV","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:23 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:06 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -115,19 +119,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:24 GMT
+      - Sat, 15 Apr 2017 22:36:06 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=HuJU8Y-fTOS6s7mBskEZHg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:24 GMT
+      - BrowserId=zQ1eBK3yRWC2ApQ52HDJaA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=71/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -138,5 +144,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:24 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/lead_exists/does_not_cache_info_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/lead_exists/does_not_cache_info_when_not_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Green_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Howe_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,21 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:26 GMT
+      - Sat, 15 Apr 2017 22:35:55 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Y8t1285bSMuc-NQOqnQ9LA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:26 GMT
+      - BrowserId=7CgzVjRJQ0m3nx6_loTkPQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:35:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=69/48000
+      - api-usage=30/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EJkBUAW"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cOoUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -47,12 +49,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EJkBUAW","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cOoUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:28 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:03 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -71,19 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:28 GMT
+      - Sat, 15 Apr 2017 22:36:04 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=F65pM-HcTXudcum5kBwOgw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:28 GMT
+      - BrowserId=dKzB19vFTnyz28octeVnFg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=70/48000
+      - api-usage=30/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -94,10 +98,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:28 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:04 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -116,19 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:29 GMT
+      - Sat, 15 Apr 2017 22:36:04 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=GBdwZs4qRme-csyEtUWWlQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:29 GMT
+      - BrowserId=uO7KUUYnRLGYbg7cF2WmbQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=68/48000
+      - api-usage=30/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -137,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EJkBUAW"},"Id":"00Q3B000004EJkBUAW","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cOoUAI"},"Id":"00Q4B0000047cOoUAI","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:29 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/caches_info_in_user_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/caches_info_in_user_when_not_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Simeon","LastName":"Hauck_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Dax","LastName":"Ferry_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:49 GMT
+      - Sat, 15 Apr 2017 22:36:21 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=zSwoNsAASZCc_adXn_uNwA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:49 GMT
+      - BrowserId=R83lMNJMQIaux32BsSWTRQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/48000
+      - api-usage=33/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgL7pQAF"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlkQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgL7pQAF","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlkQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:50 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:22 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -70,19 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:50 GMT
+      - Sat, 15 Apr 2017 22:36:22 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5OTsY7QxRCqcCFePSytOYg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:50 GMT
+      - BrowserId=HUepHy2HQfCLAgIVwC9F1g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=32/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -91,12 +95,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgL7pQAF"},"Id":"0033B00000AgL7pQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlkQAF"},"Id":"0034B00000FjMlkQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:50 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:22 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -115,19 +119,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:51 GMT
+      - Sat, 15 Apr 2017 22:36:23 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=iV0g3S4ATVqi52K-4G97og;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:51 GMT
+      - BrowserId=_ehWMuOzTQibmYJ7nKV6SA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/48000
+      - api-usage=32/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -138,5 +144,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:51 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/updates_info_in_user_when_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/updates_info_in_user_when_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Alejandra","LastName":"Dooley_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Jacynthe","LastName":"Wuckert_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,21 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:51 GMT
+      - Sat, 15 Apr 2017 22:36:23 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=cLYTrPtTRSCzGR-eStevLw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:51 GMT
+      - BrowserId=wAXAUZc5R2WgSNa5gDOgGg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/48000
+      - api-usage=32/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgL4SQAV"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlpQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -46,12 +48,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgL4SQAV","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlpQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:52 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:24 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -70,19 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:53 GMT
+      - Sat, 15 Apr 2017 22:36:24 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4VVv1hoWSEKSjA3p59DSkA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:53 GMT
+      - BrowserId=AjRoa2HrTzi4IaQKd_469A;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=33/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -91,12 +95,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgL4SQAV"},"Id":"0033B00000AgL4SQAV","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlpQAF"},"Id":"0034B00000FjMlpQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:53 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:25 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -115,19 +119,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:53 GMT
+      - Sat, 15 Apr 2017 22:36:25 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=iHQbDZIORb-5OZnc0r_Pag;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:53 GMT
+      - BrowserId=77Rv9q0nRLaP7hEyjDoI6g;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/48000
+      - api-usage=33/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -138,5 +144,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:53 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_if_email_doesn_t_match.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_if_email_doesn_t_match.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Okuneva_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Leuschke_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,21 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:58 GMT
+      - Sat, 15 Apr 2017 22:36:09 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=bG7t9ZAdS_2YLy3XfP555w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:58 GMT
+      - BrowserId=6ysyBXCaRCC-IO7uwWLJTg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=65/48000
+      - api-usage=30/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EJk1UAG"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cOtUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -47,12 +49,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EJk1UAG","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cOtUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:00 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:11 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -71,19 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:00 GMT
+      - Sat, 15 Apr 2017 22:36:11 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=tdYnG2RqSSicBUhz7TT42A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:00 GMT
+      - BrowserId=moubR3BBS8WKhbUwGlhvGg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=65/48000
+      - api-usage=33/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -94,10 +98,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:00 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:11 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -116,19 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:00 GMT
+      - Sat, 15 Apr 2017 22:36:12 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pZpXd4YfTCuBnA4PBCU-tw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:00 GMT
+      - BrowserId=3kJZI2rbQtasZ3AwhTO0OA;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -137,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EJk1UAG"},"Id":"00Q3B000004EJk1UAG","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cOtUAI"},"Id":"00Q4B0000047cOtUAI","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:00 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_user_to_lead_status_if_user_already_has_SF_contact_ID.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_user_to_lead_status_if_user_already_has_SF_contact_ID.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Yundt_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Boehm_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,21 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:54 GMT
+      - Sat, 15 Apr 2017 22:36:15 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2D06eGT9S2ibkhRFWvB7eA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:54 GMT
+      - BrowserId=KeLJDEvLRZazfkdrLQhgww;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/48000
+      - api-usage=32/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EJjxUAG"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cP3UAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -47,15 +49,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EJjxUAG","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cP3UAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:55 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:18 GMT
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Contact
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jada","LastName":"Dicki_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0013B000009vJrCQAU"}'
+      string: '{"FirstName":"Enoch","LastName":"Batz_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0014B00000DaY04QAF"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -73,21 +75,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:55 GMT
+      - Sat, 15 Apr 2017 22:36:19 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Q38NqTt8QWCQXv0uAfRtmw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:55 GMT
+      - BrowserId=AW4dvMxwQpC_gsL4FGR9nQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/48000
+      - api-usage=34/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0033B00000AgLEMQA3"
+      - "/services/data/v37.0/sobjects/Contact/0034B00000FjMlfQAF"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -96,12 +100,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0033B00000AgLEMQA3","success":true,"errors":[]}'
+      string: '{"id":"0034B00000FjMlfQAF","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:57 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:20 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -120,19 +124,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:57 GMT
+      - Sat, 15 Apr 2017 22:36:20 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=bF9ZoWWEQtqItTBnFy_yOw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:57 GMT
+      - BrowserId=25ZipMkQTmGSuNieQgFuVw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -141,12 +147,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0033B00000AgLEMQA3"},"Id":"0033B00000AgLEMQA3","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0034B00000FjMlfQAF"},"Id":"0034B00000FjMlfQAF","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:57 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:20 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -165,19 +171,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:31:58 GMT
+      - Sat, 15 Apr 2017 22:36:20 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2jhq9UnKTo-MbXaWHKJeSw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:31:58 GMT
+      - BrowserId=RFVWHNzySMSX81MRIfPlmw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=33/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -186,7 +194,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EJjxUAG"},"Id":"00Q3B000004EJjxUAG","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cP3UAI"},"Id":"00Q4B0000047cP3UAI","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:31:58 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/updates_user_status_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/updates_user_status_when_not_previously_linked.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Lesch_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Waters_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,21 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:01 GMT
+      - Sat, 15 Apr 2017 22:36:12 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=txuU8UI4RGicIGSLBWBwqw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:01 GMT
+      - BrowserId=_FqZHkp4QJSqU6bL-ZsYMg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/48000
+      - api-usage=33/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EJk6UAG"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cOyUAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -47,12 +49,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EJk6UAG","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cOyUAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:02 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:13 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -71,19 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:03 GMT
+      - Sat, 15 Apr 2017 22:36:14 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=OdFUoLHUTauPe1q_2FkDfg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:03 GMT
+      - BrowserId=kFpLE_bPQVWLHbh1xzIj5Q;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=68/48000
+      - api-usage=31/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -94,10 +98,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:03 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:14 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
     body:
       encoding: US-ASCII
       string: ''
@@ -116,19 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Feb 2017 01:32:03 GMT
+      - Sat, 15 Apr 2017 22:36:14 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Q9uq20eoSduc4SNsDcjZ4Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        23-Apr-2017 01:32:03 GMT
+      - BrowserId=kMyrB-b_Rn6ZZgwMK55Wcw;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:36:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=67/48000
+      - api-usage=32/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -137,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EJk6UAG"},"Id":"00Q3B000004EJk6UAG","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cOyUAI"},"Id":"00Q4B0000047cOyUAI","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 22 Feb 2017 01:32:03 GMT
+  recorded_at: Sat, 15 Apr 2017 22:36:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
+++ b/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://cs50.salesforce.com/services/data/v37.0/sobjects/Lead
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
       string: '{"FirstName":"Bob","LastName":"Armstrong","Subject__c":"Biology;Macro
@@ -26,25 +26,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Feb 2017 22:25:12 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; font-src https:
-        data:; connect-src ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Sat, 15 Apr 2017 22:37:33 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=4io69w9XTL26NRCPxpSgzg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        25-Apr-2017 22:25:12 GMT
+      - BrowserId=sFJksSFDS1S08-bNDDm5LQ;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:37:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/48000
+      - api-usage=66/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q3B000004EQVtUAO"
+      - "/services/data/v37.0/sobjects/Lead/00Q4B0000047cP8UAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -53,12 +51,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q3B000004EQVtUAO","success":true,"errors":[]}'
+      string: '{"id":"00Q4B0000047cP8UAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 22:25:13 GMT
+  recorded_at: Sat, 15 Apr 2017 22:37:34 GMT
 - request:
     method: get
-    uri: https://cs50.salesforce.com/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q3B000004EQVtUAO%27)%20LIMIT%201
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q4B0000047cP8UAI%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -77,23 +75,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Feb 2017 22:25:13 GMT
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; font-src https:
-        data:; connect-src ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Sat, 15 Apr 2017 22:37:35 GMT
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
       - referrer origin-when-cross-origin
       - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2ANRRAzYQ5OtTWKZ6n4D5g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        25-Apr-2017 22:25:13 GMT
+      - BrowserId=pKTk3Ee0SFGP8Sh9HJVslg;Path=/;Domain=.salesforce.com;Expires=Wed,
+        14-Jun-2017 22:37:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/48000
+      - api-usage=65/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -102,11 +98,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q3B000004EQVtUAO"},"Id":"00Q3B000004EQVtUAO","Name":"Bob
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q4B0000047cP8UAI"},"Id":"00Q4B0000047cP8UAI","Name":"Bob
         Armstrong","FirstName":"Bob","LastName":"Armstrong","Salutation":null,"Subject__c":"Biology;Macro
         Econ","Company":"Rice University","Phone":"634-5789","Website":"http://www.ece.rice.edu/boba","Status":"Needs
         School","Email":"bob@bob.edu","LeadSource":"OSC Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
         Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"1"}]}'
     http_version: 
-  recorded_at: Fri, 24 Feb 2017 22:25:13 GMT
+  recorded_at: Sat, 15 Apr 2017 22:37:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/admin/change_salesforce_contact_manually_spec.rb
+++ b/spec/features/admin/change_salesforce_contact_manually_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'vcr_helper'
+
+RSpec.describe "Change Salesforce contact manually", vcr: VCR_OPTS do
+
+  before(:all) do
+    @proxy = SalesforceProxy.new
+  end
+
+  before(:each) do
+    load_salesforce_user
+
+    @admin_user = create_admin_user
+    visit '/'
+    complete_login_username_or_email_screen('admin')
+    complete_login_password_screen('password')
+
+    @target_user = FactoryGirl.create(:user)
+
+    visit "/admin/users/#{@target_user.id}/edit"
+  end
+
+  it 'can be removed' do
+    @target_user.update_attribute(:salesforce_contact_id, 'something')
+    fill_in 'user_salesforce_contact_id', with: 'remove'
+    click_button 'Save'
+    @target_user.reload
+    expect(@target_user.salesforce_contact_id).to be_nil
+  end
+
+  it 'can be set if the Contact exists in SF' do
+    contact = @proxy.new_contact
+    fill_in 'user_salesforce_contact_id', with: contact.id
+    click_button 'Save'
+    @target_user.reload
+    expect(@target_user.salesforce_contact_id).to eq contact.id
+  end
+
+  it 'cannot be set if the Contact does not exist in SF' do
+    @target_user.update_attribute(:salesforce_contact_id, 'original')
+    fill_in 'user_salesforce_contact_id', with: 'somethingNewNotInSF'
+    click_button 'Save'
+    @target_user.reload
+    expect(@target_user.salesforce_contact_id).to eq "original"
+  end
+
+end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -10,6 +10,7 @@ VCR.configure do |c|
   %w(
     tutor_specs_oauth_token
     tutor_specs_refresh_token
+    tutor_specs_instance_url
   ).each do |salesforce_secret_name|
     Rails.application.secrets['salesforce'][salesforce_secret_name].tap do |value|
       c.filter_sensitive_data("<#{salesforce_secret_name}>") { value } if value.present?


### PR DESCRIPTION
Now admins can manually set SF contact IDs.  Before the new ID is saved on the User, the code checks to verify that the ID is that of a SF Contact.  If there is an existing ID that we want to remove, the admin can set the new ID as `remove` and this special string will cause the ID to be removed.  This code does not simultaneously update the faculty status -- we'll just have to wait < 20 mins for the next run of the SF update code to do that.  

![image](https://cloud.githubusercontent.com/assets/1001691/25066542/5b284860-21dd-11e7-862f-8007dad81dee.png)

A lot of the files are cassette reruns
