### PR TITLE
Prohibit semicolons in email addresses

### DIFF
--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -138,6 +138,7 @@ en:
               contains_tick: An email should not contain a tick (`)
               contains_colon: An email should not contain a colon
               contains_comma: An email should not contain a comma
+              contains_semicolon: An email should not contain a semicolon
 
         identity:
           attributes:

--- a/lib/email_address_validations.rb
+++ b/lib/email_address_validations.rb
@@ -32,6 +32,11 @@ module EmailAddressValidations
           # AWS::SES::ResponseError InvalidParameterValue - Domain contains illegal character
           without: /,/,
           message: :contains_comma
+        },
+        {
+          # AWS::SES::ResponseError InvalidParameterValue - Missing final '@domain'
+          without: /;/,
+          message: :contains_semicolon
         }
       ]
     end

--- a/spec/lib/email_address_validations_spec.rb
+++ b/spec/lib/email_address_validations_spec.rb
@@ -55,6 +55,10 @@ describe EmailAddressValidations do
     expect_invalid('bob,by@gmail.com')
   end
 
+  it 'returns errors when email address contains a semicolon' do
+    expect_invalid('ggg;jsmith@yahoo.com')
+  end
+
   def expect_valid(value)
     email_objects(value).each do |email|
       expect(email).to be_valid


### PR DESCRIPTION
... if there's a semicolon it gets read as two different email addresses and then Amazon issues a "no domain" error for one of the two split addresses.