### PR TITLE
Push email to SF Contact when marked faculty verified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'will_paginate'
 gem 'chronic'
 
 # Salesforce
-gem 'openstax_salesforce', '~> 0.12.0'
+gem 'openstax_salesforce', path: '/Users/jps/dev/openstax/openstax_salesforce' #'~> 0.14.0'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', git: 'https://github.com/openstax/active_force', ref: '9695896f5'
 

--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'will_paginate'
 gem 'chronic'
 
 # Salesforce
-gem 'openstax_salesforce', path: '/Users/jps/dev/openstax/openstax_salesforce' #'~> 0.14.0'
+gem 'openstax_salesforce', '~> 0.15.0'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', git: 'https://github.com/openstax/active_force', ref: '9695896f5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,6 @@ GIT
       active_attr (~> 0.8)
       restforce (~> 2.1.0)
 
-PATH
-  remote: /Users/jps/dev/openstax/openstax_salesforce
-  specs:
-    openstax_salesforce (0.14.0)
-      active_force
-      omniauth-salesforce (~> 1.0.5)
-      rails (~> 4.2.0)
-      restforce (~> 2.1.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -358,6 +349,11 @@ GEM
     openstax_rescue_from (1.8.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
+    openstax_salesforce (0.15.0)
+      active_force
+      omniauth-salesforce (~> 1.0.5)
+      rails (~> 4.2.0)
+      restforce (~> 2.1.3)
     openstax_utilities (4.2.3)
       keyword_search
       lev
@@ -654,7 +650,7 @@ DEPENDENCIES
   omniauth-twitter
   openstax_api (~> 8.1.0)
   openstax_rescue_from (~> 1.8.0)
-  openstax_salesforce!
+  openstax_salesforce (~> 0.15.0)
   openstax_utilities (~> 4.2.0)
   p3p
   parallel_tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,15 @@ GIT
       active_attr (~> 0.8)
       restforce (~> 2.1.0)
 
+PATH
+  remote: /Users/jps/dev/openstax/openstax_salesforce
+  specs:
+    openstax_salesforce (0.14.0)
+      active_force
+      omniauth-salesforce (~> 1.0.5)
+      rails (~> 4.2.0)
+      restforce (~> 2.1.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -349,11 +358,6 @@ GEM
     openstax_rescue_from (1.8.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 5.0)
-    openstax_salesforce (0.12.0)
-      active_force
-      omniauth-salesforce (~> 1.0.5)
-      rails (~> 4.2.0)
-      restforce (~> 2.1.3)
     openstax_utilities (4.2.3)
       keyword_search
       lev
@@ -650,7 +654,7 @@ DEPENDENCIES
   omniauth-twitter
   openstax_api (~> 8.1.0)
   openstax_rescue_from (~> 1.8.0)
-  openstax_salesforce (~> 0.12.0)
+  openstax_salesforce!
   openstax_utilities (~> 4.2.0)
   p3p
   parallel_tests

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -97,10 +97,15 @@ module Admin
 
       begin
         contact = OpenStax::Salesforce::Remote::Contact.find(new_id) if check_really_exists
-        # if didn't explode, we found it, let cron job update other info
-        @user.salesforce_contact_id = new_id
-        return @user.save
+
+        if contact.present? || new_id.nil?
+          @user.salesforce_contact_id = new_id
+          return @user.save
+        end
       rescue
+        # exploded, probably due to badly formed SF ID
+      ensure
+        # either exploded or contact was `nil`
         flash[:alert] = "Can't find a Salesforce contact with ID #{new_id}"
         return false
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,7 +219,7 @@ class User < ActiveRecord::Base
     (
       email_addresses.verified
                      .where{confirmation_sent_at != nil} # manually verified
-                     .order{created_at.asc}
+                     .order{created_at.desc}
                      .first ||
       email_addresses.verified
                      .order{created_at.asc}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,6 +210,23 @@ class User < ActiveRecord::Base
     known_roles - ["student"]
   end
 
+  def guessed_preferred_confirmed_email
+    # A heuristic for guessing the user's preferred confirmed email.  Assumes that
+    # emails that were manually entered are more preferred than those that were
+    # added via a social login. Manually-entered emails trigger confirmation emails,
+    # so those emails have the confirmation sent at timestamp.
+
+    (
+      email_addresses.verified
+                     .where{confirmation_sent_at != nil} # manually verified
+                     .order{created_at.asc}
+                     .first ||
+      email_addresses.verified
+                     .order{created_at.asc}
+                     .first
+    ).try(:value)
+  end
+
   protected
 
   def generate_uuid

--- a/app/representers/api/v1/contact_info_representer.rb
+++ b/app/representers/api/v1/contact_info_representer.rb
@@ -40,5 +40,10 @@ module Api::V1
              if: ->(*) { !verified },
              getter: ->(*) { ConfirmByPin.sequential_failure_for(self).attempts_remaining }
 
+    property :is_guessed_preferred,
+             readable: true,
+             writeable: false,
+             getter: ->(*) { guessed_preferred_confirmed_email == value }
+
   end
 end

--- a/app/representers/api/v1/contact_info_representer.rb
+++ b/app/representers/api/v1/contact_info_representer.rb
@@ -43,7 +43,7 @@ module Api::V1
     property :is_guessed_preferred,
              readable: true,
              writeable: false,
-             getter: ->(*) { guessed_preferred_confirmed_email == value }
+             getter: ->(*) { user.guessed_preferred_confirmed_email == value }
 
   end
 end

--- a/app/routines/add_email_to_user.rb
+++ b/app/routines/add_email_to_user.rb
@@ -1,6 +1,6 @@
 class AddEmailToUser
 
-  lev_routine
+  lev_routine express_output: :email
 
   uses_routine SendContactInfoConfirmation
 

--- a/config/initializers/openstax_salesforce.rb
+++ b/config/initializers/openstax_salesforce.rb
@@ -24,8 +24,15 @@ OpenStax::Salesforce.configure do |config|
 
   if Rails.env.test?
     config.sandbox_oauth_token = secrets['tutor_specs_oauth_token']
-    config.sandbox_refresh_token = secrets['tutor_specs_refresh_token']
     config.sandbox_instance_url = secrets['tutor_specs_instance_url']
+
+    # DO NOT set the refresh token, because if the oauth token has expired the
+    # specs will use the refresh token to get a new oauth token, but then recorded
+    # cassettes will contain that unfiltered token and future spec runs may end up
+    # having the "unused interactions" messages because they don't expect the refresh
+    # token interactions.
+    #
+    #config.sandbox_refresh_token = secrets['tutor_specs_refresh_token']
   end
 
   config.page_heading_proc = ->(view, text) { view.content_for(:page_header, text) }

--- a/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
@@ -21,22 +21,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:12 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:56:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=bRYJ4xuRTCeti-AgZOJM1A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:12 GMT
+      - BrowserId=v4xIUGyPR7SxND50EUOZZA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:56:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/48000
+      - api-usage=224/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -45,16 +44,16 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0010S0000057qMUQAY"},"Id":"0010S0000057qMUQAY","Name":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0010v000002Wo0qAAC"},"Id":"0010v000002Wo0qAAC","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:12 GMT
+  recorded_at: Wed, 24 May 2017 04:56:08 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Aniya","LastName":"Effertz","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Alex","LastName":"Hauck","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -72,24 +71,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:12 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:56:08 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=X1ami1tgTeWMPq4DBjrcuw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:12 GMT
+      - BrowserId=haRCuaCQS-aH-2FqWmw4WA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:56:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/48000
+      - api-usage=224/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2l0QAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001a9YuAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -98,12 +96,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2l0QAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001a9YuAAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:22 GMT
+  recorded_at: Wed, 24 May 2017 04:56:09 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId%20FROM%20Contact%20WHERE%20(Id%20=%20%270030S000005P2l0QAC%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Confirmed_Emails__c%20FROM%20Contact%20WHERE%20(Id%20=%20%270030v000001a9YuAAI%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -122,27 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:23 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Wed, 24 May 2017 04:56:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=AT44PhhYTN-mw0UALWXeSQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:23 GMT
+      - BrowserId=UitWY1l1SaWyc14rg922LA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:56:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=224/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -151,8 +143,8 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2l0QAC"},"Id":"0030S000005P2l0QAC","Name":"Aniya
-        Effertz","FirstName":"Aniya","LastName":"Effertz","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-05-17T17:38:22.000+0000","AccountId":"0010S0000057qMUQAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001a9YuAAI"},"Id":"0030v000001a9YuAAI","Name":"Alex
+        Hauck","FirstName":"Alex","LastName":"Hauck","Email":null,"Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":null,"LastModifiedDate":"2017-05-24T04:56:08.000+0000","AccountId":"0010v000002Wo0qAAC","SendFacultyVerificationTo__c":null,"All_Emails__c":null,"Confirmed_Emails__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:23 GMT
+  recorded_at: Wed, 24 May 2017 04:56:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Confirmed_Emails__c%20FROM%20Contact%20WHERE%20(Id%20=%20%270010v000002Wo0qAAC%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 May 2017 04:56:06 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=VaXbatTGQ0Gzf6NJtkOyQQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:56:06 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=224/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Wed, 24 May 2017 04:56:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_of_malformed.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_of_malformed.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Confirmed_Emails__c%20FROM%20Contact%20WHERE%20(Id%20=%20%27somethingwonky%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Wed, 24 May 2017 04:56:07 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=GAEZjmZBS5CnyQAejr3NeQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:56:07 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=225/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"message":"\nConfirmed_Emails__c FROM Contact WHERE (Id = ''somethingwonky'')
+        LIMIT 1\n                                        ^\nERROR at Row:1:Column:222\ninvalid
+        ID field: somethingwonky","errorCode":"INVALID_QUERY_FILTER_OPERATOR"}]'
+    http_version: 
+  recorded_at: Wed, 24 May 2017 04:56:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/works_on_the_happy_path.yml
+++ b/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/works_on_the_happy_path.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Mya","LastName":"Ebert","Subject__c":"","Company":"JP
+      string: '{"FirstName":"Jacinthe","LastName":"Hills","Subject__c":"","Company":"JP
         University","Website":"http://www.rice.edu","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":0,"OS_Accounts_ID__c":16}'
+        Adoption Won","Number_of_Students__c":0,"OS_Accounts_ID__c":1}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -26,24 +26,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:55 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:31:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=bywxHKX0TfiJXuT5quhBmQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:55 GMT
+      - BrowserId=9dwyEiTRQWi3NUpeMZ2w9Q;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:31:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/48000
+      - api-usage=211/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001OphBUAS"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010SqVEAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -52,12 +51,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001OphBUAS","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010SqVEAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:56 GMT
+  recorded_at: Wed, 24 May 2017 04:32:00 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0S000001OphBUAS%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0v0000010SqVEAU%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -76,22 +75,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:57 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:32:00 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=AcV-V9ZUTLSjdsDVJbNihw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:57 GMT
+      - BrowserId=_Rc6qz71Rs-JDZ96F6bRIA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:32:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=19/48000
+      - api-usage=212/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,11 +98,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001OphBUAS"},"Id":"00Q0S000001OphBUAS","Name":"Mya
-        Ebert","FirstName":"Mya","LastName":"Ebert","Salutation":null,"Subject__c":null,"Company":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010SqVEAU"},"Id":"00Q0v0000010SqVEAU","Name":"Jacinthe
+        Hills","FirstName":"Jacinthe","LastName":"Hills","Salutation":null,"Subject__c":null,"Company":"JP
         University","Phone":null,"Website":"http://www.rice.edu","Status":"Needs Opportunity","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"16"}]}'
+        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"1","accounts_uuid__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:57 GMT
+  recorded_at: Wed, 24 May 2017 04:32:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_three_contacts_with_same_primary_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_three_contacts_with_same_primary_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Elta","LastName":"Kunde_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Demario","LastName":"Schowalter_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,29 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:32 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Content-Security-Policy-Report-Only:
-      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
-        style-src https: ''unsafe-inline''; img-src https: data:; frame-ancestors
-        ''self'' *.salesforce.com *.force.com; font-src https: data:; connect-src
-        ''self'' https:; report-uri /_/ContentDomainCSP?type=appserver'
+      - Tue, 23 May 2017 20:28:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=5iFeYb0ITka43pw29u8wQg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:32 GMT
+      - BrowserId=-jsKfVfKRUyedz-ZMAlHjA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=87/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lZQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXclAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -54,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lZQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXclAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:33 GMT
+  recorded_at: Tue, 23 May 2017 20:29:00 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Adolfo","LastName":"Harvey_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Abelardo","LastName":"Bednar_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -80,24 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:33 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:01 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=6cussJJlRM-TUy6B3aeJvQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:33 GMT
+      - BrowserId=BFevBCuQT86xgpQZ5zhrkg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=85/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2leQAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcqAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -106,15 +99,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2leQAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcqAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:34 GMT
+  recorded_at: Tue, 23 May 2017 20:29:01 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Joshua","LastName":"Brakus_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Khalil","LastName":"Feest_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -132,24 +125,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:34 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:02 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=VMognnWjSUCESXRHzdVd0w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:34 GMT
+      - BrowserId=4mPbN4WyRdu2auUCG2M9Zw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=86/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2ljQAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcvAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -158,9 +150,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2ljQAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcvAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:35 GMT
+  recorded_at: Tue, 23 May 2017 20:29:02 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -182,22 +174,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:35 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=x5GkmtQdSM2Ho22Ld-04Tg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:35 GMT
+      - BrowserId=zmxQCa2PTYCJYa8n6NUCWw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -206,9 +197,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2ljQAC"},"Id":"0030S000005P2ljQAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2leQAC"},"Id":"0030S000005P2leQAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lZQAS"},"Id":"0030S000005P2lZQAS","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcqAAG"},"Id":"0030v000001ZXcqAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcvAAG"},"Id":"0030v000001ZXcvAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXclAAG"},"Id":"0030v000001ZXclAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:35 GMT
+  recorded_at: Tue, 23 May 2017 20:29:03 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -230,22 +221,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:35 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:03 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=HojF8ZyxSs2a0nvf-wqHaw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:35 GMT
+      - BrowserId=sZRoFWURSDabPk9rldVCVg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=86/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -256,5 +246,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:35 GMT
+  recorded_at: Tue, 23 May 2017 20:29:03 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_alt_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_alt_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Eleanore","LastName":"Reilly_unique_token","Email_alt__c":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Nicola","LastName":"Rogahn_unique_token","Email_alt__c":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:29 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2vuzH2UgR_6Ufvshu-EGzw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:29 GMT
+      - BrowserId=APseNbbhR8-CuaRX0kluyA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=89/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lQQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdFAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lQQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdFAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:30 GMT
+  recorded_at: Tue, 23 May 2017 20:29:11 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Zelda","LastName":"Medhurst_unique_token","Email_alt__c":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Zion","LastName":"Volkman_unique_token","Email_alt__c":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,24 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:30 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:11 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=RxPRIWQ8TmaMnXNVuTRPPw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:30 GMT
+      - BrowserId=hByklNekSJSJlhfkh2PDog;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=90/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lUQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdGAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -101,9 +99,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lUQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdGAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:31 GMT
+  recorded_at: Tue, 23 May 2017 20:29:12 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -125,22 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:31 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:12 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=_7XYloSBSGOoKZRKcftkaA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:31 GMT
+      - BrowserId=_EUQj88gRuSCcF8sAo5RhQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=85/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -149,9 +146,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lUQAS"},"Id":"0030S000005P2lUQAS","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lQQAS"},"Id":"0030S000005P2lQQAS","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdFAAW"},"Id":"0030v000001ZXdFAAW","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdGAAW"},"Id":"0030v000001ZXdGAAW","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:31 GMT
+  recorded_at: Tue, 23 May 2017 20:29:12 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -173,22 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:31 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Hsuuzy9XS1iwyOjzasKBmA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:31 GMT
+      - BrowserId=oIFnTJvISreIx5PJw2NNGQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -199,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:31 GMT
+  recorded_at: Tue, 23 May 2017 20:29:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_and_alt_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_and_alt_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Retta","LastName":"Rohan_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Neva","LastName":"Schneider_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:27 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:04 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Oo7Te-bSRzOE9lJ5wnCThg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:27 GMT
+      - BrowserId=y2a77Y6RRgy9Xa4oOsZbbA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=88/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lKQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXd0AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lKQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXd0AAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:27 GMT
+  recorded_at: Tue, 23 May 2017 20:29:04 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Jordane","LastName":"Corwin_unique_token","Email_alt__c":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Jakayla","LastName":"Jenkins_unique_token","Email_alt__c":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,24 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:28 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:05 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=VpnwKK3gQKytsc40Iu6hZw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:28 GMT
+      - BrowserId=AFJxpu47Sv62KtN864tcUQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=87/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lPQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXd5AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -101,9 +99,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lPQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXd5AAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:28 GMT
+  recorded_at: Tue, 23 May 2017 20:29:06 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -125,22 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:29 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=3hsnX6lKTPeQxHB3UdiAvQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:29 GMT
+      - BrowserId=_Gy17LNcQWeW2fBpi8b-Iw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=89/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -149,9 +146,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lPQAS"},"Id":"0030S000005P2lPQAS","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lKQAS"},"Id":"0030S000005P2lKQAS","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXd5AAG"},"Id":"0030v000001ZXd5AAG","Email":null,"Email_alt__c":"f@f.com","Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXd0AAG"},"Id":"0030v000001ZXd0AAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:29 GMT
+  recorded_at: Tue, 23 May 2017 20:29:06 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -173,22 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:29 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:06 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=gtJi76VASBW78QWdcgxvMg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:29 GMT
+      - BrowserId=8IDAEapeS1OzUSC8I8btSQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=86/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -199,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:29 GMT
+  recorded_at: Tue, 23 May 2017 20:29:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_email.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/email_collisions/errors_and_doesn_t_link_when_two_contacts_with_same_primary_email.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Kelton","LastName":"Gislason_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Laurianne","LastName":"Buckridge_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:36 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:07 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=h3e9mJLBSKObfOP9lryKHw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:36 GMT
+      - BrowserId=wD_QEwU9R9Sbqb8_iYYI3Q;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:07 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=88/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lkQAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXchAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lkQAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXchAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:36 GMT
+  recorded_at: Tue, 23 May 2017 20:29:08 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Gardner","LastName":"Batz_unique_token","Email":"f@f.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Carleton","LastName":"Kub_unique_token","Email":"f@f.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,24 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:36 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:08 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=40IQgqhvQHmwfR9dsaXiKw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:36 GMT
+      - BrowserId=I-8KRNVlR7mXN6u9jQFsUA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=88/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2loQAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdAAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -101,9 +99,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2loQAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdAAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:37 GMT
+  recorded_at: Tue, 23 May 2017 20:29:09 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -125,22 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:37 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:09 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=CHI5GA4CTOyhYQhmX5xU0w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:37 GMT
+      - BrowserId=uExFtVJNSo653JohePOzCQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=88/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -149,9 +146,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2loQAC"},"Id":"0030S000005P2loQAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lkQAC"},"Id":"0030S000005P2lkQAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXchAAG"},"Id":"0030v000001ZXchAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdAAAW"},"Id":"0030v000001ZXdAAAW","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:37 GMT
+  recorded_at: Tue, 23 May 2017 20:29:09 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -173,22 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:38 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:10 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=aLyfUXT9Q7eUexvuxVCJfg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:38 GMT
+      - BrowserId=F8iDxqICRD-xtflBneUbtw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=86/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -199,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:38 GMT
+  recorded_at: Tue, 23 May 2017 20:29:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/errors_when_multiple_SF_contacts_exist_for_one_user.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/errors_when_multiple_SF_contacts_exist_for_one_user.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Merle","LastName":"McKenzie_unique_token","Email":"a@a.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Rene","LastName":"Larson_unique_token","Email":"a@a.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:23 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:48 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jnJ_GxXyQaGdg6l0sPPCaA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:23 GMT
+      - BrowserId=4k-eIsgvRqG2zhLa4Dl42w;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=84/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lAQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcRAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,15 +48,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lAQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcRAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:24 GMT
+  recorded_at: Tue, 23 May 2017 20:28:49 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Johnathon","LastName":"Jast_unique_token","Email":"b@b.com","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Nigel","LastName":"Bosco_unique_token","Email":"b@b.com","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -75,24 +74,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:24 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:49 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Xx7HYX_RSpiaI-8gp1VEug;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:24 GMT
+      - BrowserId=O9n6Iws9TrWc7GvcxY8akQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=83/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lFQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcWAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -101,9 +99,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lFQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcWAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:25 GMT
+  recorded_at: Tue, 23 May 2017 20:28:50 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -125,22 +123,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:26 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:50 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=v8s8CsTHR_-_QzCUCaPmCQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:26 GMT
+      - BrowserId=c-cFk2hhSKihTsG8aXd59Q;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=83/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -149,9 +146,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lFQAS"},"Id":"0030S000005P2lFQAS","Email":"b@b.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lAQAS"},"Id":"0030S000005P2lAQAS","Email":"a@a.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcWAAW"},"Id":"0030v000001ZXcWAAW","Email":"b@b.com","Email_alt__c":null,"Faculty_Verified__c":null},{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcRAAW"},"Id":"0030v000001ZXcRAAW","Email":"a@a.com","Email_alt__c":null,"Faculty_Verified__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:26 GMT
+  recorded_at: Tue, 23 May 2017 20:28:50 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -173,22 +170,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:26 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:51 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=FvtgkOKXSfuZ4W67_It1_A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:26 GMT
+      - BrowserId=PVcM6m9iR5WBgwVdhOSwog;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=83/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -199,5 +195,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:26 GMT
+  recorded_at: Tue, 23 May 2017 20:28:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/sf_setup.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/sf_setup.yml
@@ -21,22 +21,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:23 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:48 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=BZANd_h7RiWoZywPP6He4g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:23 GMT
+      - BrowserId=dHYjump9T_-a7Ld3xNYbtw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=83/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -45,8 +44,8 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0010S0000057qMUQAY"},"Id":"0010S0000057qMUQAY","Name":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Account","url":"/services/data/v37.0/sobjects/Account/0010v000002Wo0qAAC"},"Id":"0010v000002Wo0qAAC","Name":"JP
         University"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:23 GMT
+  recorded_at: Tue, 23 May 2017 20:28:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_not_cache_info_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_not_cache_info_when_not_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Nico","LastName":"Abbott_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Quentin","LastName":"Labadie_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:38 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=pq0Xvn6vRluK5XxBrtzsTA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:38 GMT
+      - BrowserId=R6CTqOUeQ1ivigtQ7iEKRA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/48000
+      - api-usage=86/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2lGQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcgAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,9 +48,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2lGQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcgAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:39 GMT
+  recorded_at: Tue, 23 May 2017 20:28:58 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -73,22 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:39 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:58 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=Hn1hC2LYRo-Y5kNDt7Fv3g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:39 GMT
+      - BrowserId=nh3vxvABR2-A9waTWR9fiw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,9 +95,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2lGQAS"},"Id":"0030S000005P2lGQAS","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcgAAG"},"Id":"0030v000001ZXcgAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:39 GMT
+  recorded_at: Tue, 23 May 2017 20:28:58 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -121,22 +119,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:39 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:59 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=9-DmPDJJSz-7oebv_fYtHQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:39 GMT
+      - BrowserId=O2LngPOHS1KrSxgyGIbg-Q;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/48000
+      - api-usage=86/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,5 +144,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:39 GMT
+  recorded_at: Tue, 23 May 2017 20:28:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_update_info_when_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/contact_exists/does_update_info_when_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Drew","LastName":"Sanford_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Margret","LastName":"Pollich_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:39 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=OdqP9eRMRbKVaidI0y2fbQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:39 GMT
+      - BrowserId=vTRNGD1nR1SiT1bIRarB_A;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/48000
+      - api-usage=85/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2ltQAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXcbAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,9 +48,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2ltQAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXcbAAG","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:40 GMT
+  recorded_at: Tue, 23 May 2017 20:28:55 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -73,22 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:41 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:55 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=-3LZqYThQAGRZEA4Uq7tJw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:41 GMT
+      - BrowserId=DF_xsc7NQrG6pjQXAMELVQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=85/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,9 +95,52 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2ltQAC"},"Id":"0030S000005P2ltQAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXcbAAG"},"Id":"0030v000001ZXcbAAG","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:41 GMT
+  recorded_at: Tue, 23 May 2017 20:28:55 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact/0030v000001ZXcbAAG"
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:28:56 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=gclTMtWKTRm1oIm9BoF_kw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:56 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=86/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:28:56 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -121,22 +162,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:41 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:57 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=ilb2GFlaSrWuuGxo-9VZ-g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:41 GMT
+      - BrowserId=hJ8EEKUrQpGO62izHVs3nA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=85/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,5 +187,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:41 GMT
+  recorded_at: Tue, 23 May 2017 20:28:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/lead_exists/does_not_cache_info_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_unverified_email/lead_exists/does_not_cache_info_when_not_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Glover_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Hansen_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,24 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:41 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:52 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2QKvAInjTriDKfA2BfKJiQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:41 GMT
+      - BrowserId=d4oNy5pBRKqSOuriNf1jAg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/48000
+      - api-usage=84/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001OpgrUAC"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010Sa3EAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -50,9 +49,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001OpgrUAC","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010Sa3EAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:45 GMT
+  recorded_at: Tue, 23 May 2017 20:28:53 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -74,22 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:45 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:53 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=PpJU6_g6QuKVuwmmNQL1sA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:45 GMT
+      - BrowserId=Kl3ey-S1TsapoW_AmVk5og;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=85/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,7 +98,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:45 GMT
+  recorded_at: Tue, 23 May 2017 20:28:53 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -122,22 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:45 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:28:54 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=XsYPBC1iR4WZ2Y4ZktthBw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:45 GMT
+      - BrowserId=8Wls7-06Tt2n6tPyXMucSQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:28:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/48000
+      - api-usage=85/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001OpgrUAC"},"Id":"00Q0S000001OpgrUAC","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010Sa3EAE"},"Id":"00Q0v0000010Sa3EAE","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:45 GMT
+  recorded_at: Tue, 23 May 2017 20:28:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/caches_info_in_user_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/caches_info_in_user_when_not_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Elfrieda","LastName":"Effertz_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Jillian","LastName":"Waelchi_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:52 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:22 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=limnku0sTQmizOC5N_HRkg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:52 GMT
+      - BrowserId=_Cj_VoXjQBqfDU3opLHQEQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/48000
+      - api-usage=93/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2m8QAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdKAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,9 +48,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2m8QAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdKAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:53 GMT
+  recorded_at: Tue, 23 May 2017 20:29:23 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -73,22 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:53 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:23 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=7_kAIst_QeO_w7ExeW8tGw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:53 GMT
+      - BrowserId=QuE45GRISaW4B8NFAafl7A;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/48000
+      - api-usage=88/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,9 +95,52 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2m8QAC"},"Id":"0030S000005P2m8QAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdKAAW"},"Id":"0030v000001ZXdKAAW","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:53 GMT
+  recorded_at: Tue, 23 May 2017 20:29:23 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact/0030v000001ZXdKAAW"
+    body:
+      encoding: UTF-8
+      string: '{"SendFacultyVerificationTo__c":"f@f.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:29:24 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=7PO3HMIySvO2B1LnYn2umQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=88/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:29:24 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -121,22 +162,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:53 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:25 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=jrPopAeFRMGbMDHbE-vU9A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:54 GMT
+      - BrowserId=pJSeh_ltTGqdT6mq-K77Qg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=16/48000
+      - api-usage=90/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,5 +187,53 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:54 GMT
+  recorded_at: Tue, 23 May 2017 20:29:25 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Confirmed_Emails__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(Id%20=%20%270030v000001ZXdKAAW%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:29:25 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=6-pt7FHdS0qZvZyXazlR7w;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:25 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=89/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdKAAW"},"Id":"0030v000001ZXdKAAW","Name":"Jillian
+        Waelchi_unique_token","FirstName":"Jillian","LastName":"Waelchi_unique_token","Email":"f@f.com","Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":"Confirmed","LastModifiedDate":"2017-05-23T20:29:24.000+0000","AccountId":"0010v000002Wo0qAAC","SendFacultyVerificationTo__c":"f@f.com","All_Emails__c":null,"Confirmed_Emails__c":null}]}'
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:29:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/updates_info_in_user_when_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/contact_exists/updates_info_in_user_when_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Mia","LastName":"Roob_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Alanis","LastName":"Jakubowski_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -23,24 +23,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:54 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:26 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=tKBD55sWRoeQADd2zMWF_A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:54 GMT
+      - BrowserId=Z7-L9MuLQaekOJHfG0qEOA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=12/48000
+      - api-usage=90/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2mDQAS"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdPAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,9 +48,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2mDQAS","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdPAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:55 GMT
+  recorded_at: Tue, 23 May 2017 20:29:26 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -73,22 +72,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:55 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:27 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8NpxoN3hRraTNldOm0Oo8g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:55 GMT
+      - BrowserId=nyMcNQDgQDenHkX_CKaQwA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/48000
+      - api-usage=89/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -97,9 +95,52 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2mDQAS"},"Id":"0030S000005P2mDQAS","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdPAAW"},"Id":"0030v000001ZXdPAAW","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:55 GMT
+  recorded_at: Tue, 23 May 2017 20:29:27 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact/0030v000001ZXdPAAW"
+    body:
+      encoding: UTF-8
+      string: '{"SendFacultyVerificationTo__c":"f@f.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:29:27 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=ztckUzKvTWiUbxS7SelIYA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:27 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=89/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:29:28 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -121,22 +162,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:55 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:28 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=8awPPZMPSP-C-QoQB9ODsg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:55 GMT
+      - BrowserId=tzinKLbERpS8mbHSt3Mhkg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/48000
+      - api-usage=88/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -147,5 +187,53 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:55 GMT
+  recorded_at: Tue, 23 May 2017 20:29:28 GMT
+- request:
+    method: get
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20Faculty_Verified__c,%20LastModifiedDate,%20AccountId,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Confirmed_Emails__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(Id%20=%20%270030v000001ZXdPAAW%27)%20LIMIT%201"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:29:29 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=Npln_KstSNCGFWVqqJbcPQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:29 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=87/48000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdPAAW"},"Id":"0030v000001ZXdPAAW","Name":"Alanis
+        Jakubowski_unique_token","FirstName":"Alanis","LastName":"Jakubowski_unique_token","Email":"f@f.com","Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"Faculty_Verified__c":"Confirmed","LastModifiedDate":"2017-05-23T20:29:28.000+0000","AccountId":"0010v000002Wo0qAAC","SendFacultyVerificationTo__c":"f@f.com","All_Emails__c":null,"Confirmed_Emails__c":null}]}'
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:29:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_if_email_doesn_t_match.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_if_email_doesn_t_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Ratke_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Rogahn_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,24 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:50 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=MMkhpnYuThSplIjkKnq0Rg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:50 GMT
+      - BrowserId=wNpGu7NsQaOlqfNjRE4-NA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/48000
+      - api-usage=90/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001Oph6UAC"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010SaIEAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -50,9 +49,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001Oph6UAC","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010SaIEAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:51 GMT
+  recorded_at: Tue, 23 May 2017 20:29:21 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -74,22 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:52 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:22 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=PKe2ho4hRbGIO6rbFzX01g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:52 GMT
+      - BrowserId=xB5hq6pIST64cQvpXRY6Qw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/48000
+      - api-usage=86/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,7 +98,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:52 GMT
+  recorded_at: Tue, 23 May 2017 20:29:22 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -122,22 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:52 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:22 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=7YcSezArTri7IEYe4C3P9w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:52 GMT
+      - BrowserId=6T7yLaTmRv-8uVAPahAR2A;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/48000
+      - api-usage=91/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001Oph6UAC"},"Id":"00Q0S000001Oph6UAC","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010SaIEAU"},"Id":"00Q0v0000010SaIEAU","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:52 GMT
+  recorded_at: Tue, 23 May 2017 20:29:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_user_to_lead_status_if_user_already_has_SF_contact_ID.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/does_not_update_user_to_lead_status_if_user_already_has_SF_contact_ID.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Lynch_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Batz_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,24 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:46 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:16 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=zxHQ0nULQXWuL6O5TW5tZw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:46 GMT
+      - BrowserId=x4DeaLwPT8Ost1fPCqMrAQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/48000
+      - api-usage=86/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001OpgwUAC"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010SaDEAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -50,15 +49,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001OpgwUAC","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010SaDEAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:47 GMT
+  recorded_at: Tue, 23 May 2017 20:29:17 GMT
 - request:
     method: post
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Keegan","LastName":"Green_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010S0000057qMUQAY"}'
+      string: '{"FirstName":"Alexandro","LastName":"Kuphal_unique_token","Email":"f@f.com","Faculty_Verified__c":"Confirmed","AccountId":"0010v000002Wo0qAAC"}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -76,24 +75,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:47 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:17 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=OZIw87F5Qcase4wcqaoNhg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:47 GMT
+      - BrowserId=eNhlAAUITMKnUividR5ERw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=92/48000
       Location:
-      - "/services/data/v37.0/sobjects/Contact/0030S000005P2m3QAC"
+      - "/services/data/v37.0/sobjects/Contact/0030v000001ZXdBAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -102,9 +100,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0030S000005P2m3QAC","success":true,"errors":[]}'
+      string: '{"id":"0030v000001ZXdBAAW","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:48 GMT
+  recorded_at: Tue, 23 May 2017 20:29:18 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -126,22 +124,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:48 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:18 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=yrrbCpgfSuO9KHIlNJnxkA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:48 GMT
+      - BrowserId=XaTt-NUZRhqUHXKz1qGFGw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -150,9 +147,52 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030S000005P2m3QAC"},"Id":"0030S000005P2m3QAC","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v37.0/sobjects/Contact/0030v000001ZXdBAAW"},"Id":"0030v000001ZXdBAAW","Email":"f@f.com","Email_alt__c":null,"Faculty_Verified__c":"Confirmed"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:48 GMT
+  recorded_at: Tue, 23 May 2017 20:29:18 GMT
+- request:
+    method: patch
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Contact/0030v000001ZXdBAAW"
+    body:
+      encoding: UTF-8
+      string: '{"SendFacultyVerificationTo__c":"f@f.com"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <tutor_specs_oauth_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 23 May 2017 20:29:19 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
+      Set-Cookie:
+      - BrowserId=7Ep4MkQ8RPqojuWyZmXSiA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:19 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=88/48000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 23 May 2017 20:29:19 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -174,22 +214,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:48 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:20 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=tPwDLWgTQDuh25vs0Rvr2Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:48 GMT
+      - BrowserId=Vdc2OSY9RI2r7-mXqUSFdw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -198,7 +237,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001OpgwUAC"},"Id":"00Q0S000001OpgwUAC","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010SaDEAU"},"Id":"00Q0v0000010SaDEAU","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:48 GMT
+  recorded_at: Tue, 23 May 2017 20:29:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/updates_user_status_when_not_previously_linked.yml
+++ b/spec/cassettes/UpdateUserSalesforceInfo/user_with_verified_email/lead_exists/updates_user_status_when_not_previously_linked.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"LastName":"Pouros_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
+      string: '{"LastName":"Lubowitz_unique_token","Company":"JP University","Email":"f@f.com","LeadSource":"OSC
         Faculty"}'
     headers:
       User-Agent:
@@ -24,24 +24,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:48 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:13 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=dzBBIvuuQ2GA9aEwlXv2Mw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:48 GMT
+      - BrowserId=luvYQYWwQLqkSKYstLdq5g;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/48000
+      - api-usage=89/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001Oph1UAC"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010Sa8EAE"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -50,9 +49,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001Oph1UAC","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010Sa8EAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:49 GMT
+  recorded_at: Tue, 23 May 2017 20:29:14 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email,%20Email_alt__c,%20Faculty_Verified__c%20FROM%20Contact%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)"
@@ -74,22 +73,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:50 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:15 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=2IsdDm0_Tf2GEA0j6An18g;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:50 GMT
+      - BrowserId=ch3FWLoNRwOeav_6rknnCA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/48000
+      - api-usage=91/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,7 +98,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:50 GMT
+  recorded_at: Tue, 23 May 2017 20:29:15 GMT
 - request:
     method: get
     uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Email%20FROM%20Lead%20WHERE%20(LastName%20LIKE%20%27%25_unique_token%27)%20AND%20(LeadSource%20=%20%27OSC%20Faculty%27)"
@@ -122,22 +120,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:38:50 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Tue, 23 May 2017 20:29:16 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=IiBJDLKJTESfNXFUJeWw4Q;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:38:50 GMT
+      - BrowserId=MRC5I7OxRo2TH5-UbSsXlA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        22-Jul-2017 20:29:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/48000
+      - api-usage=87/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -146,7 +143,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001Oph1UAC"},"Id":"00Q0S000001Oph1UAC","Email":"f@f.com"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010Sa8EAE"},"Id":"00Q0v0000010Sa8EAE","Email":"f@f.com"}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:38:50 GMT
+  recorded_at: Tue, 23 May 2017 20:29:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
+++ b/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"FirstName":"Bob","LastName":"Armstrong","Subject__c":"Biology;Macro
         Econ","Company":"Rice University","Phone":"634-5789","Website":"http://www.ece.rice.edu/boba","Email":"bob@bob.edu","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":30,"OS_Accounts_ID__c":17}'
+        Adoption Won","Number_of_Students__c":30,"OS_Accounts_ID__c":1}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -26,24 +26,23 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 17 May 2017 17:39:03 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:31:40 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=xwCI_s2KReG3savz6rsfow;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:39:03 GMT
+      - BrowserId=FGZFb51jRSqBBiFAfVPAyQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:31:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=23/48000
+      - api-usage=210/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00Q0S000001OphGUAS"
+      - "/services/data/v37.0/sobjects/Lead/00Q0v0000010SqQEAU"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -52,12 +51,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00Q0S000001OphGUAS","success":true,"errors":[]}'
+      string: '{"id":"00Q0v0000010SqQEAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:39:05 GMT
+  recorded_at: Wed, 24 May 2017 04:31:40 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0S000001OphGUAS%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0v0000010SqQEAU%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -76,22 +75,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 May 2017 17:39:05 GMT
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - Wed, 24 May 2017 04:31:41 GMT
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Content-Security-Policy:
-      - referrer origin-when-cross-origin; upgrade-insecure-requests
+      - referrer origin-when-cross-origin
+      - reflected-xss block;report-uri /_/ContentDomainCSPNoAuth?type=xss
       Set-Cookie:
-      - BrowserId=HVlTVaPFQk6dXpp8SiAJhg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        16-Jul-2017 17:39:05 GMT
+      - BrowserId=YeilgILHRO-J-eh5bOk9ZQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        23-Jul-2017 04:31:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=26/48000
+      - api-usage=211/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -100,11 +98,11 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0S000001OphGUAS"},"Id":"00Q0S000001OphGUAS","Name":"Bob
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00Q0v0000010SqQEAU"},"Id":"00Q0v0000010SqQEAU","Name":"Bob
         Armstrong","FirstName":"Bob","LastName":"Armstrong","Salutation":null,"Subject__c":"Biology;Macro
         Econ","Company":"Rice University","Phone":"634-5789","Website":"http://www.ece.rice.edu/boba","Status":"Needs
         School","Email":"bob@bob.edu","LeadSource":"OSC Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"17"}]}'
+        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"1","accounts_uuid__c":null}]}'
     http_version: 
-  recorded_at: Wed, 17 May 2017 17:39:05 GMT
+  recorded_at: Wed, 24 May 2017 04:31:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -132,20 +132,23 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
           type: "EmailAddress",
           value: "unconfirmed@example.com",
           is_verified: false,
-          num_pin_verification_attempts_remaining: ConfirmByPin.max_pin_failures
+          num_pin_verification_attempts_remaining: ConfirmByPin.max_pin_failures,
+          is_guessed_preferred: false
         },
         {
           id: confirmed_email.id,
           type: "EmailAddress",
           value: "confirmed@example.com",
-          is_verified: true
+          is_verified: true,
+          is_guessed_preferred: true
         },
         {
           id: over_pinned_email.id,
           type: "EmailAddress",
           value: "over_pinned@example.com",
           is_verified: false,
-          num_pin_verification_attempts_remaining: 0
+          num_pin_verification_attempts_remaining: 0,
+          is_guessed_preferred: false
         }
       )
     end

--- a/spec/features/admin/change_salesforce_contact_manually_spec.rb
+++ b/spec/features/admin/change_salesforce_contact_manually_spec.rb
@@ -38,7 +38,15 @@ RSpec.describe "Change Salesforce contact manually", vcr: VCR_OPTS do
 
   it 'cannot be set if the Contact does not exist in SF' do
     @target_user.update_attribute(:salesforce_contact_id, 'original')
-    fill_in 'user_salesforce_contact_id', with: 'somethingNewNotInSF'
+    fill_in 'user_salesforce_contact_id', with: '0010v000002Wo0qAAC'
+    click_button 'Save'
+    @target_user.reload
+    expect(@target_user.salesforce_contact_id).to eq "original"
+  end
+
+  it 'cannot be set if the ID is of malformed' do
+    @target_user.update_attribute(:salesforce_contact_id, 'original')
+    fill_in 'user_salesforce_contact_id', with: 'somethingwonky'
     click_button 'Save'
     @target_user.reload
     expect(@target_user.salesforce_contact_id).to eq "original"

--- a/spec/features/salesforce/update_user_salesforce_info_spec.rb
+++ b/spec/features/salesforce/update_user_salesforce_info_spec.rb
@@ -38,18 +38,22 @@ RSpec.describe "UpdateUserSalesforceInfo", vcr: VCR_OPTS do
       let!(:contact) { @proxy.new_contact(email: email_address.value, faculty_verified: "Confirmed") }
 
       it 'caches info in user when not previously linked' do
+        expect(contact.send_faculty_verification_to).to be_blank
         call_expecting_no_errors
         user.reload
         expect(user.salesforce_contact_id).to eq contact.id
         expect(user).to be_confirmed_faculty
+        expect(contact.reload.send_faculty_verification_to).to eq "f@f.com"
       end
 
       it 'updates info in user when previously linked' do
+        expect(contact.send_faculty_verification_to).to be_blank
         user.update_attribute(:salesforce_contact_id, contact.id)
         call_expecting_no_errors
         user.reload
         expect(user.salesforce_contact_id).to eq contact.id
         expect(user).to be_confirmed_faculty
+        expect(contact.reload.send_faculty_verification_to).to eq "f@f.com"
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,12 +257,14 @@ describe User, type: :model do
         @email_a = AddEmailToUser['a@a.com', user]
       }
       Timecop.freeze(0.minutes.ago)  { AddEmailToUser['b@b.com', user, already_verified: true] }
-      Timecop.freeze(-3.minutes.ago) { AddEmailToUser['c@c.com', user, already_verified: true] }
+      Timecop.freeze(-1.minutes.ago) { @email_c = AddEmailToUser['c@c.com', user] }
+      Timecop.freeze(-3.minutes.ago) { AddEmailToUser['d@d.com', user, already_verified: true] }
     }
 
-    it 'chooses earliest manually entered emails' do
+    it 'chooses latest manually entered emails' do
       ConfirmContactInfo[@email_a]
-      expect(user.guessed_preferred_confirmed_email).to eq 'a@a.com'
+      ConfirmContactInfo[@email_c]
+      expect(user.guessed_preferred_confirmed_email).to eq 'c@c.com'
     end
 
     it 'chooses earliest auto confirmed if no manually entered emails' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -248,4 +248,25 @@ describe User, type: :model do
       }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
+
+  context '#guessed_preferred_confirmed_email' do
+    let(:user) { FactoryGirl.create :user }
+
+    before(:each) {
+      Timecop.freeze(3.minutes.ago)  {
+        @email_a = AddEmailToUser['a@a.com', user]
+      }
+      Timecop.freeze(0.minutes.ago)  { AddEmailToUser['b@b.com', user, already_verified: true] }
+      Timecop.freeze(-3.minutes.ago) { AddEmailToUser['c@c.com', user, already_verified: true] }
+    }
+
+    it 'chooses earliest manually entered emails' do
+      ConfirmContactInfo[@email_a]
+      expect(user.guessed_preferred_confirmed_email).to eq 'a@a.com'
+    end
+
+    it 'chooses earliest auto confirmed if no manually entered emails' do
+      expect(user.guessed_preferred_confirmed_email).to eq 'b@b.com'
+    end
+  end
 end

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -293,6 +293,8 @@ describe UpdateUserSalesforceInfo do
     end
 
     stub_salesforce(contacts: contacts)
+    allow_any_instance_of(OpenStax::Salesforce::Remote::Contact).to receive(:update_attributes!) { true }
+
     # The +10 is for getting the guessed preferred email per user
     expect{described_class.call}.to make_database_queries(matching: /^SELECT/, count: 5 + 10)
   end

--- a/spec/routines/update_user_salesforce_info_spec.rb
+++ b/spec/routines/update_user_salesforce_info_spec.rb
@@ -235,37 +235,41 @@ describe UpdateUserSalesforceInfo do
     end
   end
 
-  context '#cache_contact_data_in_user' do
+  context '#cache_contact_data_in_user!' do
+    before(:each) {
+      disable_sfdc_client
+    }
+
     it 'handles nil contacts' do
-      described_class.new(allow_error_email: true).cache_contact_data_in_user(nil, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user!(nil, user)
       expect(user.salesforce_contact_id).to be_nil
       expect(user.faculty_status).to eq 'no_faculty_info'
     end
 
     it 'handles Confirmed faculty status' do
       contact = new_contact(id: 'foo', faculty_verified: "Confirmed")
-      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user!(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'confirmed_faculty'
     end
 
     it 'handles Pending faculty status' do
       contact = new_contact(id: 'foo', faculty_verified: "Pending")
-      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user!(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'pending_faculty'
     end
 
     it 'handles Rejected faculty status' do
       contact = new_contact(id: 'foo', faculty_verified: "Rejected")
-      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user!(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'rejected_faculty'
     end
 
     it 'handles Rejected2 faculty status' do
       contact = new_contact(id: 'foo', faculty_verified: "Rejected2")
-      described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
+      described_class.new(allow_error_email: true).cache_contact_data_in_user!(contact, user)
       expect(user.salesforce_contact_id).to eq 'foo'
       expect(user.faculty_status).to eq 'rejected_faculty'
     end
@@ -273,7 +277,7 @@ describe UpdateUserSalesforceInfo do
     it 'raises for unknown faculty status' do
       contact = new_contact(id: 'foo', faculty_verified: "Diddly")
       expect{
-        described_class.new(allow_error_email: true).cache_contact_data_in_user(contact, user)
+        described_class.new(allow_error_email: true).cache_contact_data_in_user!(contact, user)
       }.to raise_error(RuntimeError)
     end
   end
@@ -289,7 +293,8 @@ describe UpdateUserSalesforceInfo do
     end
 
     stub_salesforce(contacts: contacts)
-    expect{described_class.call}.to make_database_queries(matching: /^SELECT/, count: 5)
+    # The +10 is for getting the guessed preferred email per user
+    expect{described_class.call}.to make_database_queries(matching: /^SELECT/, count: 5 + 10)
   end
 
   it 'logs an error when an email alt is a different contact\'s primary email' do


### PR DESCRIPTION
Pushes an email address to the SF Contact when the user is marked faculty verified in Accounts so that SF can send they "yay you are verified" email.

Also adds a `guessed_preferred_email` method to `User` and to the user JSON -- is a heuristic way to figure out what email address out of many the user may prefer.