### PR TITLE
Reject leading non-ascii chars in email

### DIFF
--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -139,6 +139,7 @@ en:
               contains_colon: An email should not contain a colon
               contains_comma: An email should not contain a comma
               contains_semicolon: An email should not contain a semicolon
+              leading_nonascii: An email address should not have leading non-ASCII characters
 
         identity:
           attributes:

--- a/lib/email_address_validations.rb
+++ b/lib/email_address_validations.rb
@@ -37,6 +37,10 @@ module EmailAddressValidations
           # AWS::SES::ResponseError InvalidParameterValue - Missing final '@domain'
           without: /;/,
           message: :contains_semicolon
+        },
+        {
+          without: /\A[\u007f-\ufeff]+/,
+          message: :leading_nonascii
         }
       ]
     end

--- a/spec/lib/email_address_validations_spec.rb
+++ b/spec/lib/email_address_validations_spec.rb
@@ -59,6 +59,10 @@ describe EmailAddressValidations do
     expect_invalid('ggg;jsmith@yahoo.com')
   end
 
+  it 'returns errors when start with unicode non-breaking space' do
+    expect_invalid("\ufeff\ufeffbob@bob.com")
+  end
+
   def expect_valid(value)
     email_objects(value).each do |email|
       expect(email).to be_valid


### PR DESCRIPTION
An email came in containing some non-breaking spaces `\ufeff` and AWS complained.  This blocks that from happening.  We should probably start using a real email validator gem in our pipeline so we don't have to mess with all the cases ourselves.