### PR TITLE
search by UUID

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -50,6 +50,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     * `name` &ndash; Matches Users' first, last, or full names, case insensitive. (uses wildcard matching)
     * `id` &ndash; Matches Users' IDs exactly.
     * `email` &ndash; Matches Users' emails exactly.
+    * `uuid` &ndash; Mathces Users' UUIDs exactly.
 
     You can also add search terms without prefixes, separated by spaces.
 
@@ -92,7 +93,9 @@ class Api::V1::UsersController < Api::V1::ApiController
     outputs = SearchUsers.call(params[:q], options).outputs
     respond_with outputs, represent_with: Api::V1::UserSearchRepresenter,
                           location: nil,
-                          user_options: { include_private_data: current_application.trusted? }
+                          user_options: {
+                            include_private_data: current_application.try(:trusted?)
+                          }
   end
 
   ###############################################################

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -82,6 +82,10 @@ class SearchUsers
         end
       end
 
+      with.keyword :uuid do |uuids|
+        users = users.where(uuid: uuids)
+      end
+
       with.keyword :id do |ids|
         users = users.where(id: ids)
       end

--- a/spec/routines/search_users_spec.rb
+++ b/spec/routines/search_users_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe SearchUsers, type: :routine do
     expect(outcome).to eq [user_1] # Not user_2 even though his first name is John
   end
 
+  it 'should match by UUID' do
+    outcome = described_class.call("uuid:#{user_3.uuid}").outputs.items.to_a
+    expect(outcome).to eq [user_3]
+  end
+
   context "sorting" do
 
     let!(:bob_brown) { FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb" }


### PR DESCRIPTION
Lets users/apps do a search by UUID, e.g.

`http://localhost:2999/api/users?q=uuid:2901997a-4d12-4ebf-9f0e-ffcc83850009`