### PR TITLE
Use 'OSC Faculty' source on all SF Leads

### DIFF
--- a/app/routines/push_salesforce_lead.rb
+++ b/app/routines/push_salesforce_lead.rb
@@ -6,6 +6,8 @@ class PushSalesforceLead
 
   def exec(user:, email: nil, role:, phone_number:, school:, num_students:, using_openstax:, url:, newsletter:, subject:)
 
+    raise(IllegalArgument, "Cannot push SF Leads for student roles") if role.match(/student/i)
+
     status.set_job_name(self.class.name)
     status.set_job_args(user: user.to_global_id.to_s)
 
@@ -15,7 +17,7 @@ class PushSalesforceLead
 
     fatal_error(code: :email_missing) if email.nil?
 
-    source = (role || "").match(/instructor/i) ? "OSC Faculty" : "OSC User"
+    source = "OSC Faculty"
 
     lead = OpenStax::Salesforce::Remote::Lead.new(
       first_name: user.first_name,

--- a/spec/routines/push_salesforce_lead_spec.rb
+++ b/spec/routines/push_salesforce_lead_spec.rb
@@ -25,10 +25,26 @@ RSpec.describe PushSalesforceLead, vcr: VCR_OPTS do
 
       expect(lead.errors).to be_empty
       expect(lead.id).not_to be_nil
+      expect(lead.source).to eq "OSC Faculty"
 
       lead_from_sf = OpenStax::Salesforce::Remote::Lead.where(id: lead.id).first
       expect(lead_from_sf).not_to be_nil
     end
+  end
+
+  it "raises an exception when role is student" do
+    expect{
+      described_class[user: user,
+                      email: email_address.value,
+                      role: "student",
+                      school: "JP University",
+                      using_openstax: "Confirmed Adoption Won",
+                      url: "http://www.rice.edu",
+                      newsletter: true,
+                      phone_number: nil,
+                      num_students: nil,
+                      subject: ""]
+    }.to raise_error(IllegalArgument)
   end
 
 end


### PR DESCRIPTION
Previously was only setting source to "OSC Faculty" for instructor roles.  Now setting it for other non-student roles.