### PR TITLE
fix prod exception where params not set

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -31,8 +31,8 @@ class SignupController < ApplicationController
                     redirect_to action: :verify_email
                   end,
                   failure: lambda do
-                    @role = params[:signup][:role]
-                    @signup_email = params[:signup][:email]
+                    @role = params[:signup].try(:[],:role)
+                    @signup_email = params[:signup].try(:[],:email)
                     render :start
                   end)
     else


### PR DESCRIPTION
Some prod users got into the signup/start failure block, and they didn't have params set for some reason and kaboom.