### PR TITLE
Setting and returning role and UUID as req'd in API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - master
     - 2016-accounts-flow
+dist: trusty
 sudo: false
 env: DISPLAY=:99.0 OXA_DB_USER=postgres OXA_TEST_DB=travis_ci_test PARALLEL_TEST_PROCESSORS=2
 language: ruby
@@ -10,7 +11,13 @@ cache: bundler
 bundler_args: --without=production --retry=6
 addons:
   postgresql: "9.4"
-before_install: sh -e /etc/init.d/xvfb start
+before_install:
+  - sh -e /etc/init.d/xvfb start
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
 before_script: bundle exec rake --trace parallel:create parallel:load_schema parallel:seed
 script: bundle exec rake parallel:spec
 notifications:

--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -7,6 +7,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :uuid,
+             type: String,
+             readable: true,
+             writeable: false
+
     property :email,
              type: String,
              readable: false,
@@ -86,6 +91,16 @@ module Api::V1
                description: "Faculty status to assign to newly created user, one of #{
                  User.faculty_statuses.keys.map(&:to_s).inspect
                }"
+             }
+
+    property :role,
+             type: String,
+             readable: false,
+             writeable: true,
+             schema_info: {
+                description: "The role to assign to the newly created user, one of #{
+                  User.roles.keys.map(&:to_s).inspect
+                }"
              }
 
   end

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -6,13 +6,13 @@
 # that will cause this routine to fail
 class CreateUser
 
-  lev_routine
+  lev_routine express_output: :user
 
   protected
 
   def exec(state:, username: nil,
            title: nil, first_name: nil, last_name: nil, suffix: nil,
-           salesforce_contact_id: nil, faculty_status: nil,
+           salesforce_contact_id: nil, faculty_status: nil, role: nil,
            ensure_no_errors: false)
 
     username = generate_unique_valid_username(username) if ensure_no_errors
@@ -27,6 +27,7 @@ class CreateUser
       user.suffix = suffix
       user.salesforce_contact_id = salesforce_contact_id
       user.faculty_status = faculty_status || :no_faculty_info
+      user.role = role || :unknown_role
     end
 
     transfer_errors_from(outputs[:user], {type: :verbatim})

--- a/app/routines/find_or_create_unclaimed_user.rb
+++ b/app/routines/find_or_create_unclaimed_user.rb
@@ -35,6 +35,7 @@ class FindOrCreateUnclaimedUser
                last_name: options[:last_name],
                salesforce_contact_id: options[:salesforce_contact_id],
                faculty_status: options[:faculty_status],
+               role: options[:role],
                ensure_no_errors: true).outputs.user
 
     # routine is smart and gracefully handles case of missing options[:email]

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -228,8 +228,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
                  raw_post_data: {email: 'a-new-email@test.com', first_name: 'Ezekiel', last_name: 'Jones'}
       }.to change{User.count}.by(1)
       expect(response.code).to eq('201')
-      new_user_id = User.order(:id).last.id
-      expect(response.body).to eq({id: new_user_id}.to_json)
+      new_user = User.order(:id).last
+      expect(response.body_as_hash).to eq({id: new_user.id, uuid: new_user.uuid})
     end
 
     it 'creates a new user with first name, last name and full name if given' do
@@ -239,7 +239,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
                  raw_post_data: {
                    email: 'a-new-email@test.com',
                    first_name: 'Sarah',
-                   last_name: 'Test'
+                   last_name: 'Test',
+                   role: 'instructor'
                  }
       }.to change { User.count }.by(1)
       expect(response.code).to eq('201')
@@ -247,6 +248,8 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
       expect(new_user.first_name).to eq 'Sarah'
       expect(new_user.last_name).to eq 'Test'
       expect(new_user.full_name).to eq 'Sarah Test'
+      expect(new_user.role).to eq 'instructor'
+      expect(new_user.uuid).not_to be_blank
     end
 
     it "should not create a new user for anonymous" do
@@ -267,19 +270,19 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
       expect(User.count).to eq user_count
     end
 
-    context "should return only an id for an user" do
+    context "should return only IDs for a user" do
       it "does so for unclaimed users" do
         api_post :find_or_create, trusted_application_token,
                  raw_post_data: {email: unclaimed_user.contact_infos.first.value}
         expect(response.code).to eq('201')
-        expect(response.body).to eq({id: unclaimed_user.id}.to_json)
+        expect(response.body_as_hash).to eq({id: unclaimed_user.id, uuid: unclaimed_user.uuid})
       end
       it "does so for claimed users" do
         api_post :find_or_create,
                  trusted_application_token,
                  raw_post_data: {email: user_2.contact_infos.first.value}
         expect(response.code).to eq('201')
-        expect(response.body).to eq({id: user_2.id}.to_json)
+        expect(response.body_as_hash).to eq({id: user_2.id, uuid: user_2.uuid})
       end
     end
 

--- a/spec/features/add_password_spec.rb
+++ b/spec/features/add_password_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+require_relative './add_reset_password_shared_examples'
+
+feature 'User adds password', js: true do
+
+  it_behaves_like "add_reset_password_shared_examples", :add
+
+  scenario 'without identity gets redirected to add password' do
+    @user = create_user 'user'
+    @login_token = generate_login_token_for 'user'
+    @user.identity.destroy
+    visit password_reset_path(token: @login_token)
+    expect(page).to have_current_path password_add_path
+  end
+
+end

--- a/spec/features/add_reset_password_shared_examples.rb
+++ b/spec/features/add_reset_password_shared_examples.rb
@@ -87,6 +87,7 @@ RSpec.shared_examples "add_reset_password_shared_examples" do |parameter|
     expect_profile_page
 
     click_link (t :"users.edit.sign_out")
+    visit '/'
     expect(page).to have_current_path login_path
 
     # try logging in with the old password

--- a/spec/features/add_reset_password_shared_examples.rb
+++ b/spec/features/add_reset_password_shared_examples.rb
@@ -1,0 +1,135 @@
+RSpec.shared_examples "add_reset_password_shared_examples" do |parameter|
+  let(:type) { parameter }
+
+  before(:each) do
+    @user = create_user 'user'
+    @login_token = generate_login_token_for 'user'
+
+    if :add == type
+      identity_authentication = @user.authentications.first
+      FactoryGirl.create :authentication, user: @user, provider: 'facebook'
+      @user.identity.destroy!
+      identity_authentication.destroy!
+    end
+  end
+
+  scenario 'using a link without a code' do
+    visit start_path(type: type)
+    screenshot!
+    expect(page).to have_no_missing_translations
+    expect(page).to have_content(t :"identities.set.there_was_a_problem_with_password_link")
+    expect(page).to have_current_path start_path(type: type)
+  end
+
+  scenario 'using a link with an invalid code' do
+    visit start_path(type: type, token: '1234')
+    screenshot!
+    expect(page).to have_no_missing_translations
+    expect(page).to have_content(t :"identities.set.there_was_a_problem_with_password_link")
+    expect_page(type: type, token: '1234')
+  end
+
+  scenario 'using a link with an expired code' do
+    @login_token = generate_expired_login_token_for 'user'
+    visit start_path(type: type, token: @login_token)
+    screenshot!
+    expect(page).to have_no_missing_translations
+    expect(page).to have_content(t :"identities.set.expired_password_link")
+    expect_page(type: type)
+  end
+
+  scenario 'using a link with a valid code' do
+    visit start_path(type: type, token: @login_token)
+    expect(page).to have_no_missing_translations
+    expect(page.first('#set_password_password_confirmation')["placeholder"]).to eq t :"identities.set.confirm_password"
+    expect_page(type: type)
+  end
+
+  scenario 'with a blank password' do
+    visit start_path(type: type, token: @login_token)
+    expect_page(type: type)
+    click_button (t :"identities.#{type}.submit")
+    expect(page).to have_content(error_msg Identity, :password, :blank)
+    screenshot!
+  end
+
+  scenario 'password is too short' do
+    visit start_path(type: type, token: @login_token)
+    expect(page).to have_no_missing_translations
+    expect_page(type: type)
+    fill_in (t :"identities.set.password"), with: 'pass'
+    fill_in (t :"identities.set.confirm_password"), with: 'pass'
+    click_button (t :"identities.#{type}.submit")
+    expect(page).to have_content(error_msg Identity, :password, :too_short, count: 8)
+    screenshot!
+  end
+
+  scenario "password and password confirmation don't match" do
+    visit start_path(type: type, token: @login_token)
+    expect(page).to have_no_missing_translations
+    expect_page(type: type)
+    fill_in (t :"identities.set.password"), with: 'password!'
+    fill_in (t :"identities.set.confirm_password"), with: 'password!!'
+    click_button (t :"identities.#{type}.submit")
+    expect(page).to have_content(error_msg Identity, :password_confirmation, :confirmation)
+    screenshot!
+  end
+
+  scenario 'successful' do
+    visit start_path(type: type, token: @login_token)
+    expect(page).to have_no_missing_translations
+    fill_in (t :"identities.set.password"), with: '1234abcd'
+    fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
+    click_button (t :"identities.#{type}.submit")
+    expect(page).to have_content(t :"identities.#{type}_success.message")
+    click_button (t :"identities.#{type}_success.continue")
+
+    expect_profile_page
+
+    click_link (t :"users.edit.sign_out")
+    expect(page).to have_current_path login_path
+
+    # try logging in with the old password
+    complete_login_username_or_email_screen 'user'
+    complete_login_password_screen 'password'
+    expect(page).to have_content(t :"controllers.sessions.incorrect_password")
+
+    # try logging in with the new password
+    complete_login_password_screen '1234abcd'
+
+    expect_profile_page
+    expect(page).to have_no_missing_translations
+    expect(page).to have_content(@user.full_name)
+  end
+
+  scenario 'cancels reset' do
+    visit start_path(type: type, token: @login_token)
+    expect(page).to have_no_missing_translations
+    fill_in (t :"identities.set.password"), with: '1234abcd'
+    fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
+    fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
+    click_link (t :"identities.set.cancel")
+    expect_profile_page
+    expect(@user.identity.authenticate '1234abcd').to eq(false)
+  end
+
+  def expect_reset_password_page(code = @login_token)
+    expect(page).to have_current_path password_reset_path(token: code)
+    expect(page).to have_no_missing_translations
+  end
+
+  def expect_page(type:, token: @login_token)
+    expect(page).to have_current_path start_path(type: type, token: token)
+    expect(page).to have_no_missing_translations
+  end
+
+  def start_path(type:, token: nil)
+    case type
+    when :reset
+      token.present? ? password_reset_path(token: token) : password_reset_path
+    when :add
+      token.present? ? password_add_path(token: token) : password_add_path
+    end
+  end
+
+end

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -1,134 +1,10 @@
 require 'rails_helper'
 
+require_relative './add_reset_password_shared_examples'
+
 feature 'User resets password', js: true do
 
-  [:reset, :add].each do |type|
-
-    context type.to_s do
-
-      before(:each) do
-        @user = create_user 'user'
-        @login_token = generate_login_token_for 'user'
-
-        if :add == type
-          identity_authentication = @user.authentications.first
-          FactoryGirl.create :authentication, user: @user, provider: 'facebook'
-          @user.identity.destroy!
-          identity_authentication.destroy!
-        end
-      end
-
-      scenario 'using a link without a code' do
-        visit start_path(type: type)
-        screenshot!
-        expect(page).to have_no_missing_translations
-        expect(page).to have_content(t :"identities.set.there_was_a_problem_with_password_link")
-        expect(page).to have_current_path start_path(type: type)
-      end
-
-      scenario 'using a link with an invalid code' do
-        visit start_path(type: type, token: '1234')
-        screenshot!
-        expect(page).to have_no_missing_translations
-        expect(page).to have_content(t :"identities.set.there_was_a_problem_with_password_link")
-        expect_page(type: type, token: '1234')
-      end
-
-      scenario 'using a link with an expired code' do
-        @login_token = generate_expired_login_token_for 'user'
-        visit start_path(type: type, token: @login_token)
-        screenshot!
-        expect(page).to have_no_missing_translations
-        expect(page).to have_content(t :"identities.set.expired_password_link")
-        expect_page(type: type)
-      end
-
-      scenario 'using a link with a valid code' do
-        visit start_path(type: type, token: @login_token)
-        expect(page).to have_no_missing_translations
-        expect(page.first('#set_password_password_confirmation')["placeholder"]).to eq t :"identities.set.confirm_password"
-        expect_page(type: type)
-      end
-
-      scenario 'with a blank password' do
-        visit start_path(type: type, token: @login_token)
-        expect_page(type: type)
-        click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content(error_msg Identity, :password, :blank)
-        screenshot!
-      end
-
-      scenario 'password is too short' do
-        visit start_path(type: type, token: @login_token)
-        expect(page).to have_no_missing_translations
-        expect_page(type: type)
-        fill_in (t :"identities.set.password"), with: 'pass'
-        fill_in (t :"identities.set.confirm_password"), with: 'pass'
-        click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content(error_msg Identity, :password, :too_short, count: 8)
-        screenshot!
-      end
-
-      scenario "password and password confirmation don't match" do
-        visit start_path(type: type, token: @login_token)
-        expect(page).to have_no_missing_translations
-        expect_page(type: type)
-        fill_in (t :"identities.set.password"), with: 'password!'
-        fill_in (t :"identities.set.confirm_password"), with: 'password!!'
-        click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content(error_msg Identity, :password_confirmation, :confirmation)
-        screenshot!
-      end
-
-      scenario 'successful' do
-        visit start_path(type: type, token: @login_token)
-        expect(page).to have_no_missing_translations
-        fill_in (t :"identities.set.password"), with: '1234abcd'
-        fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
-        click_button (t :"identities.#{type}.submit")
-        expect(page).to have_content(t :"identities.#{type}_success.message")
-        click_button (t :"identities.#{type}_success.continue")
-
-        expect_profile_page
-
-        click_link (t :"users.edit.sign_out")
-        expect(page).to have_current_path login_path
-
-        # try logging in with the old password
-        complete_login_username_or_email_screen 'user'
-        complete_login_password_screen 'password'
-        expect(page).to have_content(t :"controllers.sessions.incorrect_password")
-
-        # try logging in with the new password
-        complete_login_password_screen '1234abcd'
-
-        expect_profile_page
-        expect(page).to have_no_missing_translations
-        expect(page).to have_content(@user.full_name)
-      end
-
-      scenario 'cancels reset' do
-        visit start_path(type: type, token: @login_token)
-        expect(page).to have_no_missing_translations
-        fill_in (t :"identities.set.password"), with: '1234abcd'
-        fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
-        fill_in (t :"identities.set.confirm_password"), with: '1234abcd'
-        click_link (t :"identities.set.cancel")
-        expect_profile_page
-        expect(@user.identity.authenticate '1234abcd').to eq(false)
-      end
-
-    end
-
-  end
-
-  scenario 'without identity gets redirected to add password' do
-    @user = create_user 'user'
-    @login_token = generate_login_token_for 'user'
-    @user.identity.destroy
-    visit password_reset_path(token: @login_token)
-    expect(page).to have_current_path password_add_path
-  end
+  it_behaves_like "add_reset_password_shared_examples", :reset
 
   scenario 'with identity gets redirected to reset password' do
     @user = create_user 'user'
@@ -199,25 +75,6 @@ feature 'User resets password', js: true do
     click_link(t :"sessions.authenticate_options.reset_password")
 
     expect_authenticate_page
-  end
-
-  def expect_reset_password_page(code = @login_token)
-    expect(page).to have_current_path password_reset_path(token: code)
-    expect(page).to have_no_missing_translations
-  end
-
-  def expect_page(type:, token: @login_token)
-    expect(page).to have_current_path start_path(type: type, token: token)
-    expect(page).to have_no_missing_translations
-  end
-
-  def start_path(type:, token: nil)
-    case type
-    when :reset
-      token.present? ? password_reset_path(token: token) : password_reset_path
-    when :add
-      token.present? ? password_add_path(token: token) : password_add_path
-    end
   end
 
 end

--- a/spec/routines/create_user_spec.rb
+++ b/spec/routines/create_user_spec.rb
@@ -17,6 +17,10 @@ describe CreateUser do
           CreateUser.call(username: "unclebob", first_name: "Robert", last_name: "Martin", ensure_no_errors: true, state: "activated")
         }.to change{User.count}.by 1
       end
+
+      it 'sets a specified role' do
+        expect(CreateUser[role: :instructor, ensure_no_errors: true, state: "activated"].role).to eq 'instructor'
+      end
     end
   end
 


### PR DESCRIPTION
* Allow `role` to be set when creating an unclaimed user
* Allow `uuid` to be read after creating an unclaimed user

Also includes some commits to fix random capybara broken specs.  I upgraded to trusty on travis, and switched to PhantomJS 2.1.1.  The switch to 2.1.1 let me make the failures reproducible between travis and my machine.  The failure happened on the second run through of the same spec (it is repeated once for reset password, once for add password).  I split the specs into shared examples thinking that would help deal with the failure on the 2nd loop.  But, in the end I don't think that had much to do with the solution.  The main change was to explicitly visit the root path after signing out. 