### PR TITLE
Focus first form field on signup page

### DIFF
--- a/app/assets/javascripts/signup/index.js
+++ b/app/assets/javascripts/signup/index.js
@@ -5,6 +5,7 @@
 //= require_self
 
 $(document).ready(function(){
+  $('form:first *:input[type!=hidden]:first').focus();
   OX.Signup.TypeSelector.initialize();
   $('[data-toggle="tooltip"]').tooltip()
 });

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -17,6 +17,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
 
       arrive_from_app
       click_sign_up
+      expect(page.evaluate_script("document.activeElement.id")).to eq "signup_role"
       complete_signup_email_screen("Instructor","bob@bob.edu", screenshot_after_role: true)
       complete_signup_verify_screen(pass: true)
       complete_signup_password_screen('password')


### PR DESCRIPTION
From https://trello.com/c/GnqWNehB/2-bug-account-accessibility-issues
I just wanted to get Accounts up and running and do one PR. :) Feel free to tell me this isn't the correct way to do this.