### PR TITLE
Fix bug where signed params weren't removed after use

### DIFF
--- a/lib/authenticate_methods.rb
+++ b/lib/authenticate_methods.rb
@@ -108,7 +108,7 @@ module AuthenticateMethods
     uri = Addressable::URI.parse(request.url || "")
 
     params = uri.query_values
-    params.try(:delete, 'sp')
+    params.delete_if{|key, _| key.starts_with?("sp[")} if params.present?
     uri.query_values = params
 
     uri.to_s

--- a/spec/features/trusted_login_flow_spec.rb
+++ b/spec/features/trusted_login_flow_spec.rb
@@ -52,6 +52,26 @@ feature 'Sign in using trusted parameters', js: true do
       expect_validated_records(params: payload)
     end
 
+    it 'does not give an error if the user takes a longish time to sign up' do
+      arrive_from_app(params: signed_params)
+      click_sign_up
+
+      click_button(t :"signup.start.next")
+      wait_for_animations
+      click_button(t :"signup.start.next")
+      complete_signup_password_screen('password')
+      expect_signup_profile_screen
+      expect(page).to have_field('profile_first_name', with: 'Tester')
+      expect(page).to have_field('profile_last_name', with: 'McTesterson')
+      expect(page).to have_field('profile_school', with: payload[:school])
+
+      Timecop.travel(6.minutes.from_now) do
+        complete_signup_profile_screen_with_whatever
+        expect(page.status_code).to eq 200
+        expect_back_at_app # note, no "verification pending" step
+      end
+    end
+
     it 'requires email validation when modified' do
       arrive_from_app(params: signed_params)
       expect_sign_in_page

--- a/spec/lib/authenticate_methods_spec.rb
+++ b/spec/lib/authenticate_methods_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe AuthenticateMethods, type: :lib do
     allow(controller).to receive(:session).and_return(session)
   end
 
+  it 'can remove signed params from a URL' do
+    request.url = "http://blah.com/oauth/authorize?redirect_uri=http://127.0.0.1:51873//" \
+                  "external_app_for_specs&response_type=code&client_id=blah&sp%5Bemail%5D=test%40test.com&" \
+                  "sp%5Bexternal_user_uuid%5D=blah&sp%5Bname%5D=Tester+McTesterson&sp%5Brole%5D=instructor&" \
+                  "sp%5Bschool%5D=Testing+U&sp%5Bsignature%5D=something&sp%5Btimestamp%5D=1507839964"
+    processed_url = controller.send(:request_url_without_signed_params)
+    query_hash = Rack::Utils.parse_nested_query(URI.parse(processed_url).query)
+    expect(query_hash.has_key?("sp")).to eq false
+  end
+
   context 'anonymous user' do
     it 'authenticate_user! redirects to the login page' do
       expect(controller).to receive(:store_url)


### PR DESCRIPTION
Our current method of removing signed params after use was assuming that parsing of params converted nested params to be contained under an "sp" key, but the params were still in "sp[blah]" format.  This PR fixes this, which means signed params are only processed once, which fixes a problem where slow sign ups failed with a 400.