### PR TITLE
Add signup states page for support team

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -99,4 +99,27 @@ body.admin {
   }
 }
 
+#signup_states {
+  .searches {
+    float: right;
+    margin-bottom: 10px;
+  }
 
+  .desc {
+    clear: both;
+  }
+
+  .entry {
+    border: 1px solid #ddd;
+    background-color: #eee;
+    margin: 10px 0px;
+    padding: 8px;
+
+    .token {
+      font-size: 9px;
+    }
+  }
+
+
+
+}

--- a/app/controllers/admin/signup_states_controller.rb
+++ b/app/controllers/admin/signup_states_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class SignupStatesController < BaseController
+    layout 'admin'
+
+    def index
+      if params[:since] == "forever"
+        @signup_states = SignupState.all
+      else
+        since = (params[:since] || 1).to_i
+        @signup_states = SignupState.where{created_at.gt since.days.ago}
+      end
+      @signup_states = @signup_states.order(created_at: :desc)
+    end
+  end
+end

--- a/app/views/admin/signup_states/index.html.erb
+++ b/app/views/admin/signup_states/index.html.erb
@@ -1,0 +1,46 @@
+<% @page_header = "Signup States" %>
+
+<div id="signup_states">
+
+  <div class="searches">
+    <%= link_to "1 day", admin_signup_states_path(since: "1") %> &sdot;
+    <%= link_to "1 week", admin_signup_states_path(since: "7") %> &sdot;
+    <%= link_to "2 weeks", admin_signup_states_path(since: "14") %> &sdot;
+    <%= link_to "All", admin_signup_states_path(since: "forever") %>
+  </div>
+
+  <p class="desc">Signup states record transient information users provide as they are going through the sign up process.  These
+    states are deleted once sign up is complete, so the data on this page is only useful for helping a user who is
+    stuck in the middle of the sign up process.</p>
+
+  <h4>Notes</h4>
+
+  <ol>
+    <li><b>UNDER NO CIRCUMSTANCES</b>, on penalty of wearing a frowning Staxly pendant around your neck for a month, release PINs or
+    confirmation codes to users without having manually verified their email address via an approved method.
+    <li>Do not click on the confirmation code URLs -- doing so will launch *you* into the user's sign up flow.</li>
+  </ol>
+
+  <h4 style="margin-top:20px">Records created within last <%= pluralize((params[:since] || 1).to_i, "day") %>, newest records first</h4>
+
+  <% @signup_states.each do |signup_state| %>
+    <div class="entry">
+      <div class="basics">
+        <%= signup_state.contact_info_value || "No email yet" %> |
+        <%= signup_state.verified ? "Verified" : "Not Verified" %> |
+        PIN <b><%= signup_state.confirmation_pin %></b> |
+        reports as <b><%= signup_state.role %></b> |
+        created at <b><%= signup_state.created_at %></b>
+      </div>
+      <div class="token">
+        <%= signup_verify_by_token_url(code: signup_state.confirmation_code) %>
+      </div>
+      <% if signup_state.trusted_data %>
+        <div class="trusted_data">
+          <%= signup_state.trusted_data %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -42,6 +42,7 @@
               <ul class="dropdown-menu">
                 <li><%= link_to 'Search', main_app.admin_users_path %></li>
                 <li><%= link_to 'Actions', main_app.actions_admin_users_path %></li>
+                <li><%= link_to 'Signup States', main_app.admin_signup_states_path %></li>
               </ul>
             </li>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :signup_states, only: [:index]
+
     mount RailsSettingsUi::Engine, at: 'settings'
   end
 

--- a/spec/features/admin/signup_states_spec.rb
+++ b/spec/features/admin/signup_states_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+feature 'Admin signup state page' do
+
+  context 'as an admin user' do
+    before(:each) do
+      @admin_user = create_admin_user
+      visit '/'
+      complete_login_username_or_email_screen('admin')
+      complete_login_password_screen('password')
+    end
+
+    it "works" do
+      Timecop.freeze(4.weeks.ago) { FactoryGirl.create :signup_state, contact_info_value: "a@a.com" }
+      Timecop.freeze(1.9.weeks.ago) { FactoryGirl.create :signup_state, contact_info_value: "b@b.com" }
+      Timecop.freeze(0.9.weeks.ago) { FactoryGirl.create :signup_state, contact_info_value: "c@c.com" }
+      FactoryGirl.create :signup_state, contact_info_value: "d@d.com"
+
+      visit '/admin/signup_states'
+
+      expect(page).to have_content("d@d.com")
+      expect(page).not_to have_content("c@c.com")
+
+      click_link "1 week"
+
+      expect(page).to have_content(/d@d\.com.*c@c\.com/)
+      expect(page).not_to have_content("b@b.com")
+
+      click_link "2 weeks"
+
+      expect(page).to have_content(/d@d\.com.*c@c\.com.*b@b\.com/)
+      expect(page).not_to have_content("a@a.com")
+
+      click_link "All"
+
+      expect(page).to have_content(/d@d\.com.*c@c\.com.*b@b\.com.*a@a\.com/)
+    end
+  end
+
+end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -44,22 +44,6 @@ describe 'whenever schedule' do
         end
       end
     end
-
-    context 'missing SF user email' do
-      it 'is not sent in non-production' do
-        expect{
-          eval_runner_tasks("UpdateUserSalesforceInfo")
-        }.to change { ActionMailer::Base.deliveries.count }.by(0)
-      end
-
-      it 'is sent in production' do
-        allow(Rails.application).to receive(:is_real_production?) { true }
-        allow(OpenStax::Salesforce).to receive(:ready_for_api_usage?) { true }
-        expect{
-          eval_runner_tasks("UpdateUserSalesforceInfo")
-        }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-    end
   end
 
   def use_local_zone(example)


### PR DESCRIPTION
Adds a page so the support team can see helpful information on users who are in the middle of signing up for an account.

![image](https://user-images.githubusercontent.com/1001691/32021189-e99fe040-b98f-11e7-9add-7f72a9d2da7b.png)

Accessible via:

![image](https://user-images.githubusercontent.com/1001691/32021200-f0c1229e-b98f-11e7-899d-3bfcccbec01b.png)
