### PR TITLE
placeholder PL translations for "submitting" disabled button state; submitting state for add/reset PW

### DIFF
--- a/app/views/identities/_set.html.erb
+++ b/app/views/identities/_set.html.erb
@@ -1,4 +1,6 @@
 <%
+  submitting_text ||= submit_text
+
   error_codes = @handler_result.errors.map(&:code)
 
   big_time_error_message =
@@ -32,7 +34,7 @@
 
     <section class="footer">
       <%= link_to(t('.cancel'), profile_path, class: 'btn cancel') %>
-      <%= submit_tag submit_text, class: 'primary' %>
+      <%= f.submit submit_text, data: { disable_with: submitting_text }, class: 'primary' %>
     </section>
   <% end %>
 

--- a/app/views/identities/add.html.erb
+++ b/app/views/identities/add.html.erb
@@ -2,7 +2,8 @@
 
   <%= render partial: 'set', locals: {
     message: (t :".use_form_below_to_add_password"),
-    submit_text: (t :"identities.add.submit")
+    submit_text: (t :"identities.add.submit"),
+    submitting_text: (t :"identities.add.submitting"),
   } %>
 
 <% end %>

--- a/app/views/identities/reset.html.erb
+++ b/app/views/identities/reset.html.erb
@@ -2,7 +2,8 @@
 
   <%= render partial: 'set', locals: {
     message: (t :".use_form_below_to_reset_password"),
-    submit_text: (t :"identities.reset.submit")
+    submit_text: (t :"identities.reset.submit"),
+    submitting_text: (t :"identities.reset.submitting")
   } %>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,7 +267,7 @@ en:
         contact_customer_support: contact Support
       page_heading: Get help logging in
       submit: Submit
-      submitting: Submitting...
+      submitting: Submitting…
       username_or_email: Username or Email
 
     start:
@@ -287,8 +287,8 @@ en:
       email: Email
       email_placeholder: Email or username
       username_placeholder: Username
-      submitting: Continuing…
       next: Next
+      submitting: Continuing…
       cannot_find_user: Cannot find user
       unknown_username: We don’t recognize this username.  Please try again or use your email address instead.
       unknown_email: We don’t recognize this email.  Please try again.
@@ -439,9 +439,9 @@ en:
       page_heading: Choose your password
       password_requirements: Password must be at least 8 characters.
       password: Password
-      submitting: Submitting…
       password_confirmation: Confirm Password
       create_password: Submit
+      submitting: Submitting…
       dont_want_to_remember: Don’t want to remember another password?
       use_social: Sign up with Google or Facebook instead
       separator_or: or
@@ -475,7 +475,6 @@ en:
         I agree to the %{terms_of_use} and the %{privacy_policy}.
       first_name: First Name
       last_name: Last Name
-      submitting: Creating Account…
       suffix: Suffix
       more_things_heading: And a few more things...
       phone_number: Phone number
@@ -484,6 +483,7 @@ en:
       num_students: Number of students per semester
       using_openstax: Already using OpenStax?
       create_account: Create Account
+      submitting: Creating Account…
       titles_interested: Select all OpenStax subjects that interest you
       keep_me_informed: Send me the OpenStax newsletter.
       timeout: Please log in again to complete your sign up

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,11 +200,13 @@ en:
       use_form_below_to_reset_password: >-
         Use the form below to reset your password.
       submit: Reset Password
+      submitting: Resetting…
     add:
       page_heading: Add a password
       use_form_below_to_add_password: >-
         Use the form below to add a password to your account.
       submit: Add Password
+      submitting: Adding…
     add_success:
       page_heading: Success!
       message: Your password was added to your account.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -255,10 +255,10 @@ pl:
         contact_customer_support: skontaktuj się z działem pomocy
       page_heading: Uzyskaj pomoc z logowaniem
       submit: Wyślij
-      submitting: Wysyłanie...
+      submitting: Wysyłanie…
       username_or_email: Nazwa użytkownika albo adres e-mail
 
-    new:
+    start:
       cant_sign_in: Nie możesz się zalogować?
       logout_reminder_html: >-
         Jeżeli używasz publicznego komputera, <b>pamiętaj, aby wylogować się</b>,
@@ -277,6 +277,7 @@ pl:
       email_placeholder: Adres e-mail lub nazwa użytkownika
       username_placeholder: Nazwa użytkownika
       next: Przejdź dalej
+      submitting: Przejdź dalej
       cannot_find_user: Nie znaleziono użytkownika
       unknown_username: >-
         Nie znaleziono użytkownika o takiej nazwie. Spróbuj ponownie albo użyj
@@ -317,6 +318,7 @@ pl:
       sign_in_with_google: Zaloguj się przez Google
       sign_in_with_twitter: Zaloguj się przez Twittera
       login: Zaloguj
+      submitting: Zaloguj
       password: Hasło
       forgot_password: Zapomniałeś/aś hasła?
       trouble_logging_in: Problemy z logowaniem?
@@ -403,6 +405,7 @@ pl:
       page_heading_token: Sprawdź skrzynkę e-mail
       pin: Wprowadź PIN
       confirm: Potwierdź
+      submitting: Potwierdź
       used_wrong_email: Źle wpisałeś/aś adres e-mail?
       edit_email_address: Zmień adres e-mail
       check_your_email: Sprawdź skrzynkę e-mail dla adresu %{email}!
@@ -424,6 +427,7 @@ pl:
       password: Hasło
       password_confirmation: Potwierdź hasło
       create_password: Zapisz
+      submitting: Zapisz
       dont_want_to_remember: Nie chcesz zapamiętywać kolejnego hasła?
       use_social: Zarejestruj się używając konta w serwisie społecznościowym
       separator_or: albo
@@ -463,6 +467,7 @@ pl:
       num_students: Ilu masz uczniów w semestrze?
       using_openstax: Czy używasz OpenStax?
       create_account: Utwórz konto
+      submitting: Utwórz konto
       titles_interested: Zaznacz wszystkie interesujące Cię podręczniki OpenStax
       keep_me_informed: >-
         Proszę o wysyłanie do mnie informacji o nowych podręcznikach, zasobach

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -183,12 +183,14 @@ pl:
     reset:
       page_heading: Zmień hasło
       submit: Ustaw hasło
+      submitting: Ustaw hasło
       use_form_below_to_reset_password: >-
         Aby zmienić swoje hasło, wypełnij poniższe pola.
     add:
       page_heading: Dodaj hasło
       use_form_below_to_add_password: Aby dodać hasło, wypełnij poniższe pola.
       submit: Dodaj hasło
+      submitting: Dodaj hasło
     add_success:
       page_heading: Sukces!
       message: Hasło zostało dowiązane do Twojego konta.


### PR DESCRIPTION
With LMS Accounts work, we changed one locale heading from `new` to `start` that didn't make it into the Polish locale.

* Gets a locale heading change (`new` to `start`) from the LMS PR into the Polish locale
* Adds `submitting` translations to the Polish translation that just copy the text from the button that is being disabled
* Move the `submitting` translations in the English translation next to the translations in the button that are being disabled with the submitting message.
* Add button disabling and translations for adding and resetting passwords