### PR TITLE
Add support_identifier field to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,15 +57,17 @@ class User < ActiveRecord::Base
 
   validate :ensure_names_continue_to_be_present
 
-  validates :login_token, uniqueness: {allow_nil: true}
+  validates :login_token, uniqueness: { allow_nil: true }
+
+  validates :uuid, :support_identifier, presence: true, uniqueness: true
 
   delegate_to_routine :destroy
 
   attr_accessible :title, :first_name, :last_name, :suffix, :username
 
-  attr_readonly :uuid
+  attr_readonly :uuid, :support_identifier
 
-  before_create :generate_uuid
+  before_validation :generate_uuid, :generate_support_identifier, on: :create
 
   before_create :make_first_user_an_admin
 
@@ -240,11 +242,15 @@ class User < ActiveRecord::Base
     end.try!(:value)
   end
 
-  protected
-
   def generate_uuid
     self.uuid ||= SecureRandom.uuid
   end
+
+  def generate_support_identifier(length: 4)
+    self.support_identifier ||= "cs#{SecureRandom.hex(length)}"
+  end
+
+  protected
 
   def make_first_user_an_admin
     return if Rails.env.production? || Rails.env.test?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,7 +247,7 @@ class User < ActiveRecord::Base
   end
 
   def generate_support_identifier(length: 4)
-    self.support_identifier ||= "cs#{SecureRandom.hex(length)}"
+    self.support_identifier ||= "cs_#{SecureRandom.hex(length)}"
   end
 
   protected

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -40,6 +40,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :support_identifier,
+             type: String,
+             readable: true,
+             writeable: false
+
     property :salesforce_contact_id,
              if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
              type: String,

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -121,7 +121,7 @@ class SearchUsers
 
       with.keyword :any do |terms|
         sanitized_names = sanitize_strings(terms, append_wildcard: true,
-                                           prepend_wildcard: options[:admin])
+                                                  prepend_wildcard: options[:admin])
 
         if sanitized_names.length == 2 # looks like a "firstname lastname" search
           users = users.joins{contact_infos.outer}.where do
@@ -129,18 +129,21 @@ class SearchUsers
           end
         else # otherwise try to match "all the things"
           sanitized_terms = sanitize_strings(terms, append_wildcard: options[:admin],
-                                             prepend_wildcard: options[:admin])
+                                                    prepend_wildcard: options[:admin])
           users = users.joins{contact_infos.outer}.where do
             contact_infos_query = contact_infos.value.like_any sanitized_terms
             contact_infos_query &= (contact_infos.type.eq('EmailAddress') &
                                     contact_infos.verified.eq(true) &
                                     contact_infos.is_searchable.eq(true)) unless options[:admin]
-            username.like_any(sanitized_names) |
+            query = username.like_any(sanitized_names) |
               first_name.like_any(sanitized_names) |
               last_name.like_any(sanitized_names) |
               first_name.op('||', ' ').op('||', last_name).like_any(sanitized_names) |
               contact_infos_query |
               id.in(terms)
+            next query unless options[:admin]
+
+            query | support_identifier.like_any(sanitized_names)
           end
         end
       end

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -92,6 +92,16 @@ class SearchUsers
         users = users.where(uuid: uuids_queries)
       end
 
+      if options[:admin]
+        with.keyword :support_identifier do |identifiers|
+          sanitized_identifiers = sanitize_strings(
+            identifiers, append_wildcard: true, prepend_wildcard: true
+          )
+
+          users = users.where { support_identifier.like_any(sanitized_identifiers) }
+        end
+      end
+
       with.keyword :id do |ids|
         users = users.where(id: ids)
       end

--- a/db/migrate/20171214225648_add_support_identifier_to_users.rb
+++ b/db/migrate/20171214225648_add_support_identifier_to_users.rb
@@ -1,0 +1,16 @@
+class AddSupportIdentifierToUsers < ActiveRecord::Migration
+  def change
+    enable_extension :citext
+
+    add_column :users, :support_identifier, :citext
+
+    add_index :users, :support_identifier, unique: true
+
+    User.find_each do |user|
+      user.generate_support_identifier
+      user.save!
+    end
+
+    change_column_null :users, :support_identifier, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113145312) do
+ActiveRecord::Schema.define(version: 20171214225648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pgcrypto"
+  enable_extension "citext"
 
   create_table "application_groups", force: :cascade do |t|
     t.integer  "application_id", :null=>false, :index=>{:name=>"index_application_groups_on_application_id_and_unread_updates", :with=>["unread_updates"]}
@@ -272,6 +273,7 @@ ActiveRecord::Schema.define(version: 20171113145312) do
     t.datetime "login_token_expires_at"
     t.integer  "role",                   :default=>0, :null=>false, :index=>{:name=>"index_users_on_role"}
     t.jsonb    "trusted_signup_data"
+    t.citext   "support_identifier",     :null=>false, :index=>{:name=>"index_users_on_support_identifier", :unique=>true}
   end
   add_index "users", ["username"], :name=>"index_users_on_username_case_insensitive", :case_sensitive=>false
 

--- a/lib/import_users.rb
+++ b/lib/import_users.rb
@@ -71,6 +71,8 @@ class ImportUsers
     @user.title = title
     @user.first_name = first_name
     @user.last_name = last_name
+    @user.generate_uuid
+    @user.generate_support_identifier
     @user.save(validate: false)
 
     identity = @user.build_identity

--- a/spec/controllers/api/v1/application_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/application_groups_controller_spec.rb
@@ -1,35 +1,38 @@
 require 'rails_helper'
 
-describe Api::V1::ApplicationGroupsController, type: :controller, api: true, version: :v1 do
+RSpec.describe Api::V1::ApplicationGroupsController, type: :controller, api: true, version: :v1 do
 
   let!(:untrusted_application) { FactoryGirl.create :doorkeeper_application }
   let!(:trusted_application)   { FactoryGirl.create :doorkeeper_application, :trusted }
   let!(:user_1) { FactoryGirl.create :user }
-  let!(:user_2) { FactoryGirl.create :user_with_emails,
-                                     first_name: 'Bob',
-                                     last_name: 'Michaels' }
+  let!(:user_2) do
+    FactoryGirl.create :user_with_emails, first_name: 'Bob', last_name: 'Michaels'
+  end
 
-  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: user_2.id }
+  let!(:user_2_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: user_2.id
+  end
 
-  let!(:untrusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: nil }
-  let!(:trusted_application_token)   { FactoryGirl.create :doorkeeper_access_token,
-    application: trusted_application,
-    resource_owner_id: nil }
+  let!(:untrusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: nil
+  end
+  let!(:trusted_application_token)   do
+    FactoryGirl.create :doorkeeper_access_token, application: trusted_application,
+                                                 resource_owner_id: nil
+  end
 
   let!(:group_1) { FactoryGirl.create :group, members_count: 0, owners_count: 0 }
   let!(:group_2) { FactoryGirl.create :group, members_count: 0, owners_count: 0 }
-  let!(:application_group_1) { FactoryGirl.create :application_group,
-                                                  application: untrusted_application,
-                                                  group: group_1 }
-  let!(:application_group_2) { FactoryGirl.create :application_group,
-                                                  application: trusted_application,
-                                                  group: group_2 }
+  let!(:application_group_1) do
+    FactoryGirl.create :application_group, application: untrusted_application, group: group_1
+  end
+  let!(:application_group_2) do
+    FactoryGirl.create :application_group, application: trusted_application, group: group_2
+  end
 
-  describe "updates" do
+  context "updates" do
 
     it "should return no results for an app without updated groups" do
       api_get :updates, untrusted_application_token
@@ -185,7 +188,7 @@ describe Api::V1::ApplicationGroupsController, type: :controller, api: true, ver
 
   end
 
-  describe "updated" do
+  context "updated" do
     it "should properly change unread_updates" do
       group_1.save!
       application_group_1.reload.unread_updates = 2

--- a/spec/controllers/api/v1/application_users_controller_spec.rb
+++ b/spec/controllers/api/v1/application_users_controller_spec.rb
@@ -1,27 +1,26 @@
 require 'rails_helper'
 
-describe Api::V1::ApplicationUsersController, type: :controller, api: true, version: :v1 do
+RSpec.describe Api::V1::ApplicationUsersController, type: :controller, api: true, version: :v1 do
 
-  let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
-  let!(:trusted_application)     { FactoryGirl.create :doorkeeper_application, :trusted }
+  let!(:untrusted_application) { FactoryGirl.create :doorkeeper_application }
+  let!(:trusted_application)   { FactoryGirl.create :doorkeeper_application, :trusted }
+
+  let!(:untrusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: nil
+  end
+  let!(:trusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: trusted_application,
+                                                 resource_owner_id: nil
+  end
+
   let!(:user_1)          { FactoryGirl.create :user }
-  let!(:user_2)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'Bob',
-                                              last_name: 'Michaels' }
-
-  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: user_2.id }
-
-  let!(:untrusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: nil }
-  let!(:trusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-    application: trusted_application,
-    resource_owner_id: nil }
-
-  let!(:billy_users) {
-    (0..45).to_a.collect{|ii|
+  let!(:user_2)          do
+    FactoryGirl.create :user_with_emails,
+                       first_name: 'Bob', last_name: 'Michaels', salesforce_contact_id: "somesfid"
+  end
+  let!(:billy_users) do
+    (0..45).to_a.map do |ii|
       user = FactoryGirl.create :user,
                                 first_name: "Billy#{ii.to_s.rjust(2, '0')}",
                                 last_name: "Fred_#{(45-ii).to_s.rjust(2,'0')}",
@@ -29,12 +28,22 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
       FactoryGirl.create :application_user, user: user,
                                             application: untrusted_application,
                                             unread_updates: 0
-    }
-  }
+    end
+  end
+  let!(:bob_brown) do
+    FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb"
+  end
+  let!(:bob_jones) do
+    FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj"
+  end
+  let!(:tim_jones) do
+    FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj"
+  end
 
-  let!(:bob_brown) { FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb" }
-  let!(:bob_jones) { FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj" }
-  let!(:tim_jones) { FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj" }
+  let!(:user_2_token)    do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: user_2.id
+  end
 
   before(:each) do
     user_2.reload
@@ -45,7 +54,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
     end
   end
 
-  describe "find by username" do
+  context "find by username" do
     it "returns a single result when username matches" do
       api_get :find_by_username, untrusted_application_token, parameters: { username: 'foo_bb' }
       expect(response.code).to eq('200')
@@ -76,7 +85,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
     end
   end
 
-  describe "index" do
+  context "index" do
 
     it "returns a single result well" do
       api_get :index, untrusted_application_token, parameters: {q: 'first_name:bob last_name:Michaels'}
@@ -162,7 +171,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
 
   end
 
-  describe "updates" do
+  context "updates" do
 
     it "should return no results for an app without updated users" do
       app_user = user_2.application_users.first
@@ -195,7 +204,7 @@ describe Api::V1::ApplicationUsersController, type: :controller, api: true, vers
 
   end
 
-  describe "updated" do
+  context "updated" do
 
     it "should not let an app mark another app's updates as read" do
       app_user = user_2.application_users.first

--- a/spec/controllers/api/v1/contact_infos_controller_spec.rb
+++ b/spec/controllers/api/v1/contact_infos_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Api::V1::ContactInfosController, type: :controller, api: true, version: :v1 do
+RSpec.describe Api::V1::ContactInfosController, type: :controller, api: true, version: :v1 do
 
   let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,51 +1,58 @@
 require 'rails_helper'
 
-describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
+RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
 
-  let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
-  let!(:trusted_application)     { FactoryGirl.create :doorkeeper_application, :trusted }
+  let!(:untrusted_application) { FactoryGirl.create :doorkeeper_application }
+  let!(:trusted_application)   { FactoryGirl.create :doorkeeper_application, :trusted }
+
+  let!(:untrusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: nil
+  end
+  let!(:trusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: trusted_application,
+                                                 resource_owner_id: nil
+  end
+
   let!(:user_1)          { FactoryGirl.create :user, :terms_agreed }
-  let!(:user_2)          { FactoryGirl.create :user_with_emails, :terms_agreed, first_name: 'Bob',
-                                              last_name: 'Michaels', salesforce_contact_id: "somesfid" }
+  let!(:user_2)          do
+    FactoryGirl.create :user_with_emails, :terms_agreed,
+                       first_name: 'Bob', last_name: 'Michaels', salesforce_contact_id: "somesfid"
+  end
   let!(:unclaimed_user)  { FactoryGirl.create :user_with_emails, state:'unclaimed' }
   let!(:admin_user)      { FactoryGirl.create :user, :terms_agreed, :admin }
-
-  let!(:user_1_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                              application: untrusted_application,
-                                              resource_owner_id: user_1.id }
-
-  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                              application: untrusted_application,
-                                              resource_owner_id: user_2.id }
-
-
-  let!(:admin_token)       { FactoryGirl.create :doorkeeper_access_token,
-                                                application: untrusted_application,
-                                                resource_owner_id: admin_user.id }
-
-  let!(:untrusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-                                                application: untrusted_application,
-                                                resource_owner_id: nil }
-
-  let!(:trusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-                                                application: trusted_application,
-                                                resource_owner_id: nil }
-
-
-  let!(:billy_users) {
-    (0..45).to_a.collect{|ii|
+  let!(:billy_users) do
+    (0..45).to_a.map do |ii|
       FactoryGirl.create :user,
                          first_name: "Billy#{ii.to_s.rjust(2, '0')}",
                          last_name: "Fred_#{(45-ii).to_s.rjust(2,'0')}",
                          username: "billy_#{ii.to_s.rjust(2, '0')}"
-    }
-  }
+    end
+  end
+  let!(:bob_brown) do
+    FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb"
+  end
+  let!(:bob_jones) do
+    FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj"
+  end
+  let!(:tim_jones) do
+    FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj"
+  end
 
-  let!(:bob_brown) { FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb" }
-  let!(:bob_jones) { FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj" }
-  let!(:tim_jones) { FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj" }
+  let!(:user_1_token)    do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: user_1.id
+  end
+  let!(:user_2_token)    do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: user_2.id
+  end
+  let!(:admin_token) do
+    FactoryGirl.create :doorkeeper_access_token, application: untrusted_application,
+                                                 resource_owner_id: admin_user.id
+  end
 
-  describe "index" do
+  context "index" do
 
     it "returns a single result well" do
       api_get :index, trusted_application_token, parameters: {q: 'first_name:bob last_name:Michaels'}
@@ -82,7 +89,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
 
   end
 
-  describe "show" do
+  context "show" do
 
     it "should let a User get his info" do
       api_get :show, user_1_token
@@ -175,7 +182,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
 
   end
 
-  describe "update" do
+  context "update" do
     it "should let User update his own User" do
       api_put :update, user_2_token, raw_post_data: {first_name: "Jerry", last_name: "Mouse"}
       expect(response.code).to eq('200')
@@ -220,7 +227,7 @@ describe Api::V1::UsersController, type: :controller, api: true, version: :v1 do
 
   end
 
-  describe "find or create" do
+  context "find or create" do
     it "should create a new user for an app" do
       expect{
         api_post :find_or_create,

--- a/spec/controllers/contact_infos_controller_spec.rb
+++ b/spec/controllers/contact_infos_controller_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
-describe ContactInfosController, type: :controller do
+RSpec.describe ContactInfosController, type: :controller do
 
   let!(:user)         { FactoryGirl.create :user, :terms_agreed }
+  let!(:another_user) { FactoryGirl.create :user, :terms_agreed }
   let!(:contact_info) { FactoryGirl.build :email_address, user: user }
 
   context 'POST create' do
@@ -45,7 +46,9 @@ describe ContactInfosController, type: :controller do
     render_views
 
     before :each do
-      @email = FactoryGirl.create(:email_address, confirmation_code: '1234', verified: false, value: 'user@example.com')
+      @email = FactoryGirl.create(
+        :email_address, confirmation_code: '1234', verified: false, value: 'user@example.com'
+      )
     end
 
     it "returns error if no code given" do
@@ -57,7 +60,7 @@ describe ContactInfosController, type: :controller do
     end
 
     it "returns error if code doesn't match" do
-      get 'confirm', :code => 'abcd'
+      get 'confirm', code: 'abcd'
       expect(response.code).to eq('400')
       expect(response.body).to have_no_missing_translations
       expect(response.body).to have_content(t :"contact_infos.confirm.verification_code_not_found")
@@ -65,39 +68,79 @@ describe ContactInfosController, type: :controller do
     end
 
     it "returns success if code matches" do
-      get 'confirm', :code => @email.confirmation_code
+      get 'confirm', code: @email.confirmation_code
       expect(response).to be_success
       expect(response.body).to have_no_missing_translations
       expect(response.body).to have_content(t :"contact_infos.confirm.page_heading.success")
-      expect(response.body).to have_content(t :"contact_infos.confirm.you_may_now_close_this_window")
+      expect(response.body).to(
+        have_content(t :"contact_infos.confirm.you_may_now_close_this_window")
+      )
       expect(EmailAddress.find_by_value(@email.value).verified).to be_truthy
     end
   end
 
   context "GET 'confirm/unclaimed'" do
     render_views
-    let(:user){ FactoryGirl.create :user_with_emails, state: 'unclaimed', emails_count: 1 }
+    let(:user)  { FactoryGirl.create :user_with_emails, state: 'unclaimed', emails_count: 1 }
 
-    let(:email){
+    let(:email) do
       FactoryGirl.create(:email_address, user: user,
                         confirmation_code: '1234', verified: false, value: 'user@example.com' )
-    }
+    end
 
     it "returns error if no code given" do
       get 'confirm_unclaimed'
       expect(response.code).to eq('400')
       expect(response.body).to have_no_missing_translations
-      expect(response.body).to have_content(t :"contact_infos.confirm_unclaimed.verification_code_not_found")
+      expect(response.body).to(
+        have_content(t :"contact_infos.confirm_unclaimed.verification_code_not_found")
+      )
     end
 
     it "returns success if code matches" do
-      get 'confirm_unclaimed', :code => email.confirmation_code
+      get 'confirm_unclaimed', code: email.confirmation_code
       expect(response).to be_success
       expect(response.body).to have_no_missing_translations
-      expect(response.body).to have_content(t :"contact_infos.confirm_unclaimed.thanks_for_validating")
+      expect(response.body).to(
+        have_content(t :"contact_infos.confirm_unclaimed.thanks_for_validating")
+      )
       expect(EmailAddress.find_by_value(email.value).verified).to be_truthy
     end
+  end
 
+  context '#resend_confirmation' do
+    before { contact_info.save! }
+
+    context 'another user' do
+      before { controller.sign_in! another_user }
+
+      it 'returns 403 forbidden' do
+        put :resend_confirmation, id: contact_info.id
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context 'same user' do
+      before { controller.sign_in! user }
+
+      it 'returns an `already_confirmed` error when confirmed' do
+        ConfirmContactInfo.call(contact_info)
+        put :resend_confirmation, id: contact_info.id
+        expect(response).to have_http_status :success
+        expect(response.body).to include(I18n.t :"controllers.contact_infos.already_verified")
+      end
+
+      it 'sends the confirmation if all good' do
+        expect_any_instance_of(SendContactInfoConfirmation).to(
+          receive(:call).with(contact_info: contact_info).and_call_original
+        )
+        put :resend_confirmation, id: contact_info.id
+        expect(response).to have_http_status :success
+        expect(response.body_as_hash[:message]).to include(
+          I18n.t :"controllers.contact_infos.verification_sent", address: contact_info.value
+        )
+      end
+    end
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
-describe User, type: :model do
+RSpec.describe User, type: :model do
+
+  subject(:user) { FactoryGirl.create :user }
 
   it { should have_many :security_logs }
 
+  it { should validate_uniqueness_of(:uuid).case_insensitive }
+  it { should validate_uniqueness_of(:support_identifier).case_insensitive }
+
   context 'when the user is activated' do
-    let(:user) { User.new.tap{|u| u.state = 'activated'} }
+    let(:user) { User.new.tap {|u| u.state = 'activated'} }
 
     context 'when the names start nil' do
       it 'is valid for the first name to stay blank' do
@@ -95,15 +100,34 @@ describe User, type: :model do
       user = FactoryGirl.create :user
       old_uuid = user.uuid
       user.update_attributes(first_name: 'New')
-      user.reload
-      expect(user.first_name).to eq('New')
+      expect(user.reload.first_name).to eq('New')
       expect(user.uuid).to eq(old_uuid)
 
       new_uuid = SecureRandom.uuid
       user.uuid = new_uuid
       user.save
-      user.reload
-      expect(user.uuid).to eq(old_uuid)
+      expect(user.reload.uuid).to eq(old_uuid)
+    end
+  end
+
+  context 'support_identifier' do
+    it 'is generated when created' do
+      user = FactoryGirl.create :user
+      expect(user.support_identifier).to start_with('cs')
+      expect(user.support_identifier.length).to eq(10)
+    end
+
+    it 'cannot be updated' do
+      user = FactoryGirl.create :user
+      old_identifier = user.support_identifier
+      user.update_attributes(first_name: 'New')
+      expect(user.reload.first_name).to eq('New')
+      expect(user.support_identifier).to eq(old_identifier)
+
+      new_identifier = "cs#{SecureRandom.hex(4)}"
+      user.support_identifier = new_identifier
+      user.save
+      expect(user.reload.support_identifier).to eq(old_identifier)
     end
   end
 
@@ -157,18 +181,17 @@ describe User, type: :model do
 
     it 'does not interfere with updates if duplicated but not changed' do
       user_1 = FactoryGirl.create :user, username: "MyUs3Rn4M3"
-
-      user_2 = FactoryGirl.build :user, username: user_1.username.upcase
-      user_2.save!(validate: false)
-      expect(user_2).to be_valid
+      user_2 = FactoryGirl.create :user
+      user_2.update_column :username, user_1.username.upcase
+      expect(user_2.reload).to be_valid
       expect(user_2.errors).to be_empty
 
       user_2.first_name = SecureRandom.hex(3)
       user_2.save!
 
-      user_3 = FactoryGirl.build :user, username: user_1.username.downcase
-      user_3.save!(validate: false)
-      expect(user_3).to be_valid
+      user_3 = FactoryGirl.create :user
+      user_3.update_column :username, user_1.username.downcase
+      expect(user_3.reload).to be_valid
       expect(user_3.errors).to be_empty
 
       user_3.first_name = SecureRandom.hex(3)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe User, type: :model do
     it 'is generated when created' do
       user = FactoryGirl.create :user
       expect(user.support_identifier).to start_with('cs')
-      expect(user.support_identifier.length).to eq(10)
+      expect(user.support_identifier.length).to eq(11)
     end
 
     it 'cannot be updated' do
@@ -124,7 +124,7 @@ RSpec.describe User, type: :model do
       expect(user.reload.first_name).to eq('New')
       expect(user.support_identifier).to eq(old_identifier)
 
-      new_identifier = "cs#{SecureRandom.hex(4)}"
+      new_identifier = "cs_#{SecureRandom.hex(4)}"
       user.support_identifier = new_identifier
       user.save
       expect(user.reload.support_identifier).to eq(old_identifier)

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UserRepresenter, type: :representer do
+  let(:user)            { FactoryGirl.create :user  }
+  subject(:representer) { described_class.new(user) }
+
+  context 'uuid' do
+    it 'can be read' do
+      expect(representer.to_hash['uuid']).to eq user.uuid
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      hash = { 'uuid' => SecureRandom.uuid }
+
+      expect(user).not_to receive(:uuid=)
+      expect { representer.from_hash(hash) }.not_to change { user.reload.uuid }
+    end
+  end
+
+  context 'support_identifier' do
+    it 'can be read' do
+      expect(representer.to_hash['support_identifier']).to eq user.support_identifier
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      hash = { 'support_identifier' => "cs#{SecureRandom.hex(4)}" }
+
+      expect(user).not_to receive(:support_identifier=)
+      expect { representer.from_hash(hash) }.not_to change { user.reload.support_identifier }
+    end
+  end
+end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
     end
 
     it 'cannot be written (attempts are silently ignored)' do
-      hash = { 'support_identifier' => "cs#{SecureRandom.hex(4)}" }
+      hash = { 'support_identifier' => "cs_#{SecureRandom.hex(4)}" }
 
       expect(user).not_to receive(:support_identifier=)
       expect { representer.from_hash(hash) }.not_to change { user.reload.support_identifier }

--- a/spec/requests/api/v1/application_users_requests_spec.rb
+++ b/spec/requests/api/v1/application_users_requests_spec.rb
@@ -2,32 +2,52 @@ require 'rails_helper'
 
 # Moved multiple request specs here from the controller spec
 
-describe 'Api::V1::ApplicationUsers multiple requests', type: :request, api: true, version: :v1 do
+RSpec.describe 'Api::V1::ApplicationUsers multiple requests',
+               type: :request, api: true, version: :v1 do
 
-  let!(:untrusted_application)     { FactoryGirl.create :doorkeeper_application }
-  let!(:trusted_application)     { FactoryGirl.create :doorkeeper_application, :trusted }
-  let!(:user_2)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'Bob',
-                                              last_name: 'Michaels' }
+  let!(:untrusted_application) { FactoryGirl.create :doorkeeper_application }
+  let!(:trusted_application)   { FactoryGirl.create :doorkeeper_application, :trusted }
+  let!(:user_2)       do
+    FactoryGirl.create :user_with_emails,
+                       first_name: 'Bob',
+                       last_name: 'Michaels'
+  end
 
-  let!(:user_2_token)    { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: user_2.id }
+  let!(:user_2_token) do
+    FactoryGirl.create :doorkeeper_access_token,
+                       application: untrusted_application,
+                       resource_owner_id: user_2.id
+  end
 
-  let!(:untrusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-    application: untrusted_application,
-    resource_owner_id: nil }
-  let!(:trusted_application_token) { FactoryGirl.create :doorkeeper_access_token,
-    application: trusted_application,
-    resource_owner_id: nil }
+  let!(:untrusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token,
+                       application: untrusted_application,
+                       resource_owner_id: nil
+  end
+  let!(:trusted_application_token) do
+    FactoryGirl.create :doorkeeper_access_token,
+                       application: trusted_application,
+                       resource_owner_id: nil
+  end
 
   let(:updated_endpoint) { "/api/application_users/updated" }
   let(:updates_endpoint) { "/api/application_users/updates" }
 
-  describe "updates" do
+  context "updates" do
+    let(:app_user) { user_2.application_users.first }
+    let(:expected_response) do
+      -> do
+        [
+          {
+            id: app_user.id,
+            user: user_matcher(user_2.reload, include_private_data: false),
+            unread_updates: app_user.unread_updates
+          }
+        ]
+      end
+    end
 
     it "should return properly formatted JSON responses" do
-      app_user = user_2.application_users.first
       expect(app_user.unread_updates).to eq 1
 
       user_2.first_name = 'Bo'
@@ -37,17 +57,11 @@ describe 'Api::V1::ApplicationUsers multiple requests', type: :request, api: tru
 
       api_get updates_endpoint, untrusted_application_token
 
-      expected_response = [{
-        id: app_user.id,
-        user: user_matcher(user_2.reload, include_private_data: false),
-        unread_updates: 2
-      }]
-
-      expect(response.body_as_hash).to match(expected_response)
+      expect(response.body_as_hash).to match(expected_response.call)
 
       api_get updates_endpoint, untrusted_application_token
 
-      expect(response.body_as_hash).to match(expected_response)
+      expect(response.body_as_hash).to match(expected_response.call)
 
       user_2.first_name = 'Bob'
       user_2.save!
@@ -57,41 +71,29 @@ describe 'Api::V1::ApplicationUsers multiple requests', type: :request, api: tru
 
       api_get updates_endpoint, untrusted_application_token
 
-      expected_response = [{
-        id: app_user.id,
-        user: user_matcher(user_2.reload, include_private_data: false),
-        unread_updates: 3
-      }]
-
-      expect(response.body_as_hash).to match(expected_response)
+      expect(response.body_as_hash).to match(expected_response.call)
 
       app_user.unread_updates = 2
       app_user.save!
 
       api_get updates_endpoint, untrusted_application_token
 
-      expected_response = [{
-        id: app_user.id,
-        user: user_matcher(user_2.reload, include_private_data: false),
-        unread_updates: 2
-      }]
-
-      expect(response.body_as_hash).to match(expected_response)
+      expect(response.body_as_hash).to match(expected_response.call)
 
       app_user.unread_updates = 0
       app_user.save!
 
       api_get updates_endpoint, untrusted_application_token
-      expected_response = [].to_json
 
-      expect(response.body).to eq(expected_response)
+      expect(response.body_as_hash).to match([])
     end
 
   end
 
-  describe "updated" do
+  context "updated" do
+    let(:app_user) { user_2.application_users.first }
+
     it "should properly change unread_updates" do
-      app_user = user_2.application_users.first
       expect(app_user.unread_updates).to eq 1
 
       user_2.first_name = 'Bo'

--- a/spec/routines/admin/search_users_spec.rb
+++ b/spec/routines/admin/search_users_spec.rb
@@ -89,11 +89,17 @@ RSpec.describe Admin::SearchUsers, type: :routine do
   end
 
   it "should match any fields when no prefix given" do
+    [ user_1, user_2, user_3, user_4 ].each_with_index do |user, index|
+      User.where(id: user.id).update_all(support_identifier: "cs_#{index}")
+    end
     outcome = described_class.call("jst").outputs.items.to_a
     expect(outcome).to eq [user_4, user_3, user_1]
   end
 
   it "should match any fields when no prefix given and intersect when prefix given" do
+    [ user_1, user_2, user_3, user_4 ].each_with_index do |user, index|
+      User.where(id: user.id).update_all(support_identifier: "cs_#{index}")
+    end
     outcome = described_class.call("jst username:jst").outputs.items.to_a
     expect(outcome).to eq [user_3, user_1]
   end
@@ -104,6 +110,9 @@ RSpec.describe Admin::SearchUsers, type: :routine do
   end
 
   it "should gather space-separated unprefixed search terms" do
+    [ user_1, user_2, user_3, user_4 ].each_with_index do |user, index|
+      User.where(id: user.id).update_all(support_identifier: "cs_#{index}")
+    end
     outcome = described_class.call("john strav").outputs.items.to_a
     expect(outcome).to eq [user_1]
   end

--- a/spec/routines/admin/search_users_spec.rb
+++ b/spec/routines/admin/search_users_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Admin::SearchUsers, type: :routine do
   end
 
   it "should match on partial support_identifier" do
-    partial_support_identifier = user_1.support_identifier.first(9).last(8)
+    partial_support_identifier = user_1.support_identifier.first(10).last(9)
     outcome = described_class.call(
       "support_identifier:#{partial_support_identifier}"
     ).outputs.items.to_a

--- a/spec/routines/admin/search_users_spec.rb
+++ b/spec/routines/admin/search_users_spec.rb
@@ -2,23 +2,26 @@ require 'rails_helper'
 
 RSpec.describe Admin::SearchUsers, type: :routine do
 
-  let!(:user_1)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'John',
-                                              last_name: 'Stravinsky',
-                                              username: 'jstrav' }
-  let!(:user_2)          { FactoryGirl.create :user,
-                                              first_name: 'Mary',
-                                              last_name: 'Mighty',
-                                              username: 'mary' }
-  let!(:user_3)          { FactoryGirl.create :user,
-                                              first_name: 'John',
-                                              last_name: 'Stead',
-                                              username: 'jstead' }
-
-  let!(:user_4)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'Bob',
-                                              last_name: 'JST',
-                                              username: 'bigbear' }
+  let!(:user_1)          do
+    FactoryGirl.create :user_with_emails, first_name: 'John',
+                                          last_name: 'Stravinsky',
+                                          username: 'jstrav'
+  end
+  let!(:user_2)          do
+    FactoryGirl.create :user, first_name: 'Mary',
+                              last_name: 'Mighty',
+                              username: 'mary'
+  end
+  let!(:user_3)          do
+    FactoryGirl.create :user, first_name: 'John',
+                              last_name: 'Stead',
+                              username: 'jstead'
+  end
+  let!(:user_4)          do
+    FactoryGirl.create :user_with_emails, first_name: 'Bob',
+                                          last_name: 'JST',
+                                          username: 'bigbear'
+  end
 
   before(:each) do
     user_4.contact_infos.email_addresses.order(:value).first.update_attribute(
@@ -58,6 +61,20 @@ RSpec.describe Admin::SearchUsers, type: :routine do
     expect(outcome).to eq [user_1]
   end
 
+  it "should match on full support_identifier" do
+    support_identifier = user_1.support_identifier
+    outcome = described_class.call("support_identifier:#{support_identifier}").outputs.items.to_a
+    expect(outcome).to eq [user_1]
+  end
+
+  it "should match on partial support_identifier" do
+    partial_support_identifier = user_1.support_identifier.first(9).last(8)
+    outcome = described_class.call(
+      "support_identifier:#{partial_support_identifier}"
+    ).outputs.items.to_a
+    expect(outcome).to eq [user_1]
+  end
+
   it "should match based on a partial email address" do
     email = user_1.contact_infos.email_addresses.order(:value).first.value.split('@').first
     outcome = described_class.call("email:#{email}").outputs.items.to_a
@@ -93,14 +110,14 @@ RSpec.describe Admin::SearchUsers, type: :routine do
 
   context "pagination and sorting" do
 
-    let!(:billy_users) {
-      (0..45).to_a.collect{|ii|
+    let!(:billy_users) do
+      (0..45).to_a.map do |ii|
         FactoryGirl.create :user,
                            first_name: "Billy#{ii.to_s.rjust(2, '0')}",
                            last_name: "Bob_#{(45-ii).to_s.rjust(2,'0')}",
                            username: "billy_#{ii.to_s.rjust(2, '0')}"
-      }
-    }
+      end
+    end
 
     it "should return the first page of values by default in default order" do
       outcome = described_class.call("username:billy").outputs.items.all
@@ -126,15 +143,25 @@ RSpec.describe Admin::SearchUsers, type: :routine do
 
   context "sorting" do
 
-    let!(:bob_brown) { FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb" }
-    let!(:bob_jones) { FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj" }
-    let!(:tim_jones) { FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj" }
+    let!(:bob_brown) do
+      FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb"
+    end
+    let!(:bob_jones) do
+      FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj"
+    end
+    let!(:tim_jones) do
+      FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj"
+    end
 
     it "should allow sort by multiple fields in different directions" do
-      outcome = described_class.call("username:foo", order_by: "first_name, last_name DESC").outputs.items.to_a
+      outcome = described_class.call(
+        "username:foo", order_by: "first_name, last_name DESC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_jones, bob_brown, tim_jones]
 
-      outcome = described_class.call("username:foo", order_by: "first_name, last_name ASC").outputs.items.to_a
+      outcome = described_class.call(
+        "username:foo", order_by: "first_name, last_name ASC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_brown, bob_jones, tim_jones]
     end
 

--- a/spec/routines/search_application_users_spec.rb
+++ b/spec/routines/search_application_users_spec.rb
@@ -1,24 +1,28 @@
 require 'rails_helper'
 
-describe SearchApplicationUsers do
+RSpec.describe SearchApplicationUsers do
   let!(:application) { FactoryGirl.create :doorkeeper_application }
 
-  let!(:user_1) { FactoryGirl.create :user_with_emails,
-                                     first_name: 'John',
-                                     last_name: 'Stravinsky',
-                                     username: 'jstrav' }
-  let!(:user_2) { FactoryGirl.create :user,
-                                     first_name: 'Mary',
-                                     last_name: 'Mighty',
-                                     username: 'mary' }
-  let!(:user_3) { FactoryGirl.create :user,
-                                     first_name: 'John',
-                                     last_name: 'Stead',
-                                     username: 'jstead' }
-  let!(:user_4) { FactoryGirl.create :user_with_emails,
-                                     first_name: 'Bob',
-                                     last_name: 'JST',
-                                     username: 'bigbear' }
+  let!(:user_1)          do
+    FactoryGirl.create :user_with_emails, first_name: 'John',
+                                          last_name: 'Stravinsky',
+                                          username: 'jstrav'
+  end
+  let!(:user_2)          do
+    FactoryGirl.create :user, first_name: 'Mary',
+                              last_name: 'Mighty',
+                              username: 'mary'
+  end
+  let!(:user_3)          do
+    FactoryGirl.create :user, first_name: 'John',
+                              last_name: 'Stead',
+                              username: 'jstead'
+  end
+  let!(:user_4)          do
+    FactoryGirl.create :user_with_emails, first_name: 'Bob',
+                                          last_name: 'JST',
+                                          username: 'bigbear'
+  end
 
   before(:each) do
     [user_1, user_2, user_3].each do |user|
@@ -33,97 +37,97 @@ describe SearchApplicationUsers do
   end
 
   it "should not return results if application is nil" do
-    outcome = SearchApplicationUsers.call(nil, 'username:jstra').outputs.items
+    outcome = described_class.call(nil, 'username:jstra').outputs.items
     expect(outcome).to eq nil
   end
 
   it "should match based on username" do
-    outcome = SearchApplicationUsers.call(application, 'username:jstra').outputs.items
+    outcome = described_class.call(application, 'username:jstra').outputs.items
     expect(outcome).to eq [user_1]
   end
 
   it "should ignore leading wildcards on username searches" do
-    outcome = SearchApplicationUsers.call(application, 'username:%rav').outputs.items.to_a
+    outcome = described_class.call(application, 'username:%rav').outputs.items.to_a
     expect(outcome).to eq []
   end
 
   it "should match based on one first name" do
-    outcome = SearchApplicationUsers.call(application, 'first_name:"John"').outputs.items.to_a
+    outcome = described_class.call(application, 'first_name:"John"').outputs.items.to_a
     expect(outcome).to eq [user_3, user_1]
   end
 
   it "should match based on one full name" do
-    outcome = SearchApplicationUsers.call(application, 'name:"Mary Mighty"').outputs.items.to_a
+    outcome = described_class.call(application, 'name:"Mary Mighty"').outputs.items.to_a
     expect(outcome).to eq [user_2]
   end
 
   it "should match based on an exact email address" do
     email = user_1.contact_infos.email_addresses.order(:value).first.value
-    outcome = SearchApplicationUsers.call(application, "email:#{email}").outputs.items.to_a
+    outcome = described_class.call(application, "email:#{email}").outputs.items.to_a
     expect(outcome).to eq [user_1]
   end
 
   it "should not match based on an incomplete email address" do
     email = user_1.contact_infos.email_addresses.order(:value).first.value.split('@').first
-    outcome = SearchApplicationUsers.call(application, "email:#{email}").outputs.items.to_a
+    outcome = described_class.call(application, "email:#{email}").outputs.items.to_a
     expect(outcome).to eq []
   end
 
   it "should return all results if the query is empty" do
-    outcome = SearchApplicationUsers.call(application, "").outputs.items.to_a
+    outcome = described_class.call(application, "").outputs.items.to_a
     expect(outcome).to eq [user_3, user_1, user_2]
   end
 
   it "should match any fields when no prefix given" do
-    outcome = SearchApplicationUsers.call(application, "jst").outputs.items.to_a
+    outcome = described_class.call(application, "jst").outputs.items.to_a
     expect(outcome).to eq [user_3, user_1]
   end
 
   it "should match any fields when no prefix given and intersect when prefix given" do
-    outcome = SearchApplicationUsers.call(application, "jst username:jst").outputs.items.to_a
+    outcome = described_class.call(application, "jst username:jst").outputs.items.to_a
     expect(outcome).to eq [user_3, user_1]
   end
 
   it "shouldn't allow users to add their own wildcards" do
-    outcome = SearchApplicationUsers.call(application, "username:'%ar'").outputs.items.to_a
+    outcome = described_class.call(application, "username:'%ar'").outputs.items.to_a
     expect(outcome).to eq []
   end
 
   it "should gather space-separated unprefixed search terms" do
-    outcome = SearchApplicationUsers.call(application, "john strav").outputs.items.to_a
+    outcome = described_class.call(application, "john strav").outputs.items.to_a
     expect(outcome).to eq [user_1]
   end
 
   context "pagination and sorting" do
 
-    let!(:billy_users) {
-      (0..45).to_a.collect{|ii|
-        user = FactoryGirl.create :user,
-                                  first_name: "Billy#{ii.to_s.rjust(2, '0')}",
-                                  last_name: "Bob_#{(45-ii).to_s.rjust(2,'0')}",
-                                  username: "billy_#{ii.to_s.rjust(2, '0')}"
-        FactoryGirl.create :application_user, application: application,
-                                              user: user
-        user
-      }
-    }
+    let!(:billy_users) do
+      (0..45).to_a.map do |ii|
+        FactoryGirl.create(
+          :user, first_name: "Billy#{ii.to_s.rjust(2, '0')}",
+                 last_name: "Bob_#{(45-ii).to_s.rjust(2,'0')}",
+                 username: "billy_#{ii.to_s.rjust(2, '0')}"
+        ).tap do |user|
+          FactoryGirl.create :application_user, application: application, user: user
+        end
+      end
+    end
 
     it "should return the first page of values by default in default order" do
-      outcome = SearchApplicationUsers.call(application, "username:billy").outputs.items.to_a
+      outcome = described_class.call(application, "username:billy").outputs.items.to_a
       expect(outcome.length).to eq 20
       expect(outcome[0]).to eq User.where{username.eq "billy_00"}.first
       expect(outcome[19]).to eq User.where{username.eq "billy_19"}.first
     end
 
     it "should return the 2nd page when requested" do
-      outcome = SearchApplicationUsers.call(application, "username:billy", page: 1).outputs.items.to_a
+      outcome = described_class.call(application, "username:billy", page: 1).outputs.items.to_a
       expect(outcome.length).to eq 20
       expect(outcome[0]).to eq User.where{username.eq "billy_20"}.first
       expect(outcome[19]).to eq User.where{username.eq "billy_39"}.first
     end
 
     it "should return the incomplete 3rd page when requested" do
-      outcome = SearchApplicationUsers.call(application, "username:billy", page: 2).outputs.items.to_a
+      outcome = described_class.call(application, "username:billy", page: 2).outputs.items.to_a
       expect(outcome.length).to eq 6
       expect(outcome[5]).to eq User.where{username.eq "billy_45"}.first
     end
@@ -149,10 +153,14 @@ describe SearchApplicationUsers do
     end
 
     it "should allow sort by multiple fields in different directions" do
-      outcome = SearchApplicationUsers.call(application, "username:foo", order_by: "first_name, last_name DESC").outputs.items.to_a
+      outcome = described_class.call(
+        application, "username:foo", order_by: "first_name, last_name DESC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_jones, bob_brown, tim_jones]
 
-      outcome = SearchApplicationUsers.call(application, "username:foo", order_by: "first_name, last_name ASC").outputs.items.to_a
+      outcome = described_class.call(
+        application, "username:foo", order_by: "first_name, last_name ASC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_brown, bob_jones, tim_jones]
     end
 

--- a/spec/routines/search_users_spec.rb
+++ b/spec/routines/search_users_spec.rb
@@ -2,37 +2,42 @@ require 'rails_helper'
 
 RSpec.describe SearchUsers, type: :routine do
 
-  let!(:user_1)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'John',
-                                              last_name: 'Stravinsky',
-                                              username: 'jstrav' }
-  let!(:user_2)          { FactoryGirl.create :user,
-                                              first_name: 'Mary',
-                                              last_name: 'Mighty',
-                                              username: 'mary' }
-  let!(:user_3)          { FactoryGirl.create :user,
-                                              first_name: 'John',
-                                              last_name: 'Stead',
-                                              username: 'jstead' }
+  let!(:user_1)          do
+    FactoryGirl.create :user_with_emails, first_name: 'John',
+                                          last_name: 'Stravinsky',
+                                          username: 'jstrav'
+  end
+  let!(:user_2)          do
+    FactoryGirl.create :user, first_name: 'Mary',
+                              last_name: 'Mighty',
+                              username: 'mary'
+  end
+  let!(:user_3)          do
+    FactoryGirl.create :user, first_name: 'John',
+                              last_name: 'Stead',
+                              username: 'jstead'
+  end
+  let!(:user_4)          do
+    FactoryGirl.create :user_with_emails, first_name: 'Bob',
+                                          last_name: 'JST',
+                                          username: 'bigbear'
+  end
 
-  let!(:user_4)          { FactoryGirl.create :user_with_emails,
-                                              first_name: 'Bob',
-                                              last_name: 'JST',
-                                              username: 'bigbear' }
-
-  let!(:billy_users) {
-    (0..8).to_a.collect{|ii|
+  let!(:billy_users) do
+    (0..8).to_a.map do |ii|
       FactoryGirl.create :user,
                          first_name: "Billy#{ii.to_s.rjust(2, '0')}",
                          last_name: "Bob_#{(45-ii).to_s.rjust(2,'0')}",
                          username: "billy_#{ii.to_s.rjust(2, '0')}"
-    }
-  }
+    end
+  end
 
   before(:each) do
     MarkContactInfoVerified.call(user_1.contact_infos.email_addresses.order(:value).first)
     MarkContactInfoVerified.call(user_4.contact_infos.email_addresses.order(:value).first)
-    user_4.contact_infos.email_addresses.order(:value).first.update_attribute(:value, 'jstoly292929@hotmail.com')
+    user_4.contact_infos.email_addresses.order(:value).first.update_attribute(
+      :value, 'jstoly292929@hotmail.com'
+    )
     user_1.reload
   end
 
@@ -41,7 +46,7 @@ RSpec.describe SearchUsers, type: :routine do
     wildcard_fields.each do |field|
       outputs = described_class.call("#{field}:\"\"").outputs
       expect(outputs.items).to be_empty # Because more than 10 results are returned
-      expect(outputs.total_count).to be > SearchUsers::MAX_MATCHING_USERS
+      expect(outputs.total_count).to be > described_class::MAX_MATCHING_USERS
     end
 
     exact_fields = [:id, :email]
@@ -128,17 +133,34 @@ RSpec.describe SearchUsers, type: :routine do
     expect(outcome).to eq [user_3]
   end
 
+  it 'should not match by support_identifier' do
+    outcome = described_class.call(
+      "support_identifier:#{user_3.support_identifier}"
+    ).outputs.items.to_a
+    expect(outcome).to eq []
+  end
+
   context "sorting" do
 
-    let!(:bob_brown) { FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb" }
-    let!(:bob_jones) { FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj" }
-    let!(:tim_jones) { FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj" }
+    let!(:bob_brown) do
+      FactoryGirl.create :user, first_name: "Bob", last_name: "Brown", username: "foo_bb"
+    end
+    let!(:bob_jones) do
+      FactoryGirl.create :user, first_name: "Bob", last_name: "Jones", username: "foo_bj"
+    end
+    let!(:tim_jones) do
+      FactoryGirl.create :user, first_name: "Tim", last_name: "Jones", username: "foo_tj"
+    end
 
     it "should allow sort by multiple fields in different directions" do
-      outcome = described_class.call("username:foo", order_by: "first_name, last_name DESC").outputs.items.to_a
+      outcome = described_class.call(
+        "username:foo", order_by: "first_name, last_name DESC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_jones, bob_brown, tim_jones]
 
-      outcome = described_class.call("username:foo", order_by: "first_name, last_name ASC").outputs.items.to_a
+      outcome = described_class.call(
+        "username:foo", order_by: "first_name, last_name ASC"
+      ).outputs.items.to_a
       expect(outcome).to eq [bob_brown, bob_jones, tim_jones]
     end
 

--- a/spec/routines/search_users_spec.rb
+++ b/spec/routines/search_users_spec.rb
@@ -128,8 +128,18 @@ RSpec.describe SearchUsers, type: :routine do
     expect(outcome).to eq [user_1] # Not user_2 even though his first name is John
   end
 
+  it 'should match by full_name' do
+    outcome = described_class.call('full_name:"john stravinsky"').outputs.items.to_a
+    expect(outcome).to eq [user_1] # Not user_2 even though his first name is John
+  end
+
   it 'should match by UUID' do
     outcome = described_class.call("uuid:#{user_3.uuid}").outputs.items.to_a
+    expect(outcome).to eq [user_3]
+  end
+
+  it 'should match by id' do
+    outcome = described_class.call("id:#{user_3.id}").outputs.items.to_a
     expect(outcome).to eq [user_3]
   end
 

--- a/spec/support/user_hash.rb
+++ b/spec/support/user_hash.rb
@@ -16,7 +16,8 @@ def user_hash(user, include_private_data: false)
     'last_name' => user.last_name,
     'full_name' => user.full_name,
     'uuid' => user.uuid,
-    'applications' => user.applications.order(:id).map{|app| {"id" => app.id, "name" => app.name}}
+    'support_identifier' => user.support_identifier,
+    'applications' => user.applications.order(:id).map {|app| {"id" => app.id, "name" => app.name}}
   }
 
   if include_private_data
@@ -33,7 +34,6 @@ def user_hash(user, include_private_data: false)
   base_hash
 end
 
-
 def user_matcher(user, include_private_data: false)
   base_hash = {
     id: user.id,
@@ -42,6 +42,7 @@ def user_matcher(user, include_private_data: false)
     last_name: user.last_name,
     full_name: user.full_name,
     uuid: user.uuid,
+    support_identifier: user.support_identifier,
     applications: a_collection_containing_exactly(
       *user.applications.map{|app|
         a_hash_including({id: app.id, name: app.name})


### PR DESCRIPTION
The request was to add a support_identifier field in Tutor that CS could use to talk about users without revealing PII in slack. I convinced JP that this should be in Accounts, since it would be more useful for CS if the support_identifiers were searchable in Accounts.