### PR TITLE
Add is_test boolean field to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,10 @@ class User < ActiveRecord::Base
     "#{base}#{rand(10**num_digits_in_suffix).to_s.rjust(num_digits_in_suffix,'0')}"
   end
 
+  def is_test?
+    !!is_test
+  end
+
   def is_anonymous?
     false
   end

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -45,6 +45,12 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :is_test?,
+             as: :is_test,
+             type: :boolean,
+             readable: true,
+             writeable: false
+
     property :salesforce_contact_id,
              if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
              type: String,

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -49,7 +49,11 @@ module Api::V1
              as: :is_test,
              type: :boolean,
              readable: true,
-             writeable: false
+             writeable: false,
+             schema_info: {
+                description: "If true, the user is an internal test user," +
+                             "not a real OpenStax end user"
+             }
 
     property :salesforce_contact_id,
              if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -186,7 +186,16 @@
     </div>
   </div>
 
- <div class="form-group">
+  <div class="form-group">
+    <%= f.label :is_test, 'Test User?', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <div class="checkbox">
+        <%= f.check_box :is_test, style: 'margin-left: 0px' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <%= f.submit 'Save', class: 'btn btn-primary' %>
     </div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -3,5 +3,4 @@
 
 <% @page_header = 'User Details' %>
 
-
 <%= render 'form' %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -77,6 +77,10 @@
               <span class="admin">Administrator</span> |
             <% end %>
 
+            <% if user.is_test? %>
+              <span class="test">Test User</span> |
+            <% end %>
+
             <% sf_id = user.salesforce_contact_id %>
 
             <% if sf_id.present? %>
@@ -103,7 +107,11 @@
             </span> |
 
             <span class="uuid">
-              <i>UUID:</i> <%= user.uuid || '(no uuid)' %>
+              <i>UUID:</i> <%= user.uuid %>
+            </span>
+
+            <span class="support_identifier">
+              <i>Support Identifier:</i> <%= user.support_identifier || '(no support_identifier)' %>
             </span>
 
             <% if user.self_reported_school.present? %>

--- a/app/views/admin/users/search.js.erb
+++ b/app/views/admin/users/search.js.erb
@@ -7,8 +7,8 @@
   contents = osu.action_list(
     records: users,
     list: {
-      headings: ['ID', 'Username', 'First Name', 'Last Name', 'Is Admin?', 'Actions'],
-      widths: ['10%', '20%', '20%', '20%', '10%', '20%'],
+      headings: ['ID', 'Username', 'First Name', 'Last Name', 'Is Admin?', 'Is Test?', 'Actions'],
+      widths: ['10%', '20%', '20%', '20%', '10%', '10%', '10%'],
       data_procs:
         [
           Proc.new { |user| user.id.to_s },
@@ -19,6 +19,7 @@
           Proc.new { |user| user.first_name || '---' },
           Proc.new { |user| user.last_name || '---' },
           Proc.new { |user| user.is_administrator ? 'Yes' : 'No' },
+          Proc.new { |user| user.is_test? ? 'Yes' : 'No' }
           Proc.new { |user|
             sign_in_link = link_to 'Sign in as',
                                    become_admin_user_path(user),

--- a/db/migrate/20171221224623_add_is_test_to_users.rb
+++ b/db/migrate/20171221224623_add_is_test_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsTestToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :is_test, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -276,6 +276,7 @@ ActiveRecord::Schema.define(version: 20171226134252) do
     t.integer  "role",                   :default=>0, :null=>false, :index=>{:name=>"index_users_on_role"}
     t.jsonb    "trusted_signup_data"
     t.citext   "support_identifier",     :null=>false, :index=>{:name=>"index_users_on_support_identifier", :unique=>true}
+    t.boolean  "is_test"
   end
   add_index "users", ["username"], :name=>"index_users_on_username_case_insensitive", :case_sensitive=>false
 

--- a/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
+++ b/spec/cassettes/User_signs_up/connected_to_salesforce/happy_path_success_with_password.yml
@@ -52,11 +52,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"00Q0v0000010SqQEAU","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 24 May 2017 04:31:40 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0v0000010SqQEAU%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid_c__c,%20Application_Source__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700Q0v0000010SqQEAU%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,8 @@ http_interactions:
         Armstrong","FirstName":"Bob","LastName":"Armstrong","Salutation":null,"Subject__c":"Biology;Macro
         Econ","Company":"Rice University","Phone":"634-5789","Website":"http://www.ece.rice.edu/boba","Status":"Needs
         School","Email":"bob@bob.edu","LeadSource":"OSC Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"1","accounts_uuid__c":null}]}'
-    http_version: 
+        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"1","accounts_uuid_c__c":null,"Application_Source__c":"Tutor
+        Signup"}]}'
+    http_version:
   recorded_at: Wed, 24 May 2017 04:31:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -29,4 +29,17 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
       expect { representer.from_hash(hash) }.not_to change { user.reload.support_identifier }
     end
   end
+
+  context 'is_test' do
+    it 'can be read' do
+      expect(representer.to_hash['is_test']).to eq user.is_test?
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      hash = { 'is_test' => true }
+
+      expect(user).not_to receive(:is_test=)
+      expect { representer.from_hash(hash) }.not_to change { user.reload.is_test? }
+    end
+  end
 end

--- a/spec/support/user_hash.rb
+++ b/spec/support/user_hash.rb
@@ -17,6 +17,7 @@ def user_hash(user, include_private_data: false)
     'full_name' => user.full_name,
     'uuid' => user.uuid,
     'support_identifier' => user.support_identifier,
+    'is_test' => user.is_test?,
     'applications' => user.applications.order(:id).map {|app| {"id" => app.id, "name" => app.name}}
   }
 
@@ -43,10 +44,11 @@ def user_matcher(user, include_private_data: false)
     full_name: user.full_name,
     uuid: user.uuid,
     support_identifier: user.support_identifier,
+    is_test: user.is_test?,
     applications: a_collection_containing_exactly(
-      *user.applications.map{|app|
+      *user.applications.map do |app|
         a_hash_including({id: app.id, name: app.name})
-      }
+      end
     )
   }
 


### PR DESCRIPTION
For https://trello.com/c/57bX4YFN

JP said it could be useful to have this field live in Accounts.

Defaults to `nil` which means we don't know if it's a test account or not, but can be set to true or false by admins.

The `is_test?` method (with a `?`) will always return a boolean (returns false for nil)