### PR TITLE
Push application source with SF leads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'will_paginate'
 gem 'chronic'
 
 # Salesforce
-gem 'openstax_salesforce', '~> 0.15.0'
+gem 'openstax_salesforce', '~> 1.0.0'
 # Fork that supports Ruby >= 2.1
 gem 'active_force', git: 'https://github.com/openstax/active_force', ref: '9695896f5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
     openstax_rescue_from (2.1.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 6.0)
-    openstax_salesforce (0.15.0)
+    openstax_salesforce (1.0.0)
       active_force
       omniauth-salesforce (~> 1.0.5)
       rails (~> 4.2.0)
@@ -655,7 +655,7 @@ DEPENDENCIES
   omniauth-twitter
   openstax_api (~> 8.2.0)
   openstax_rescue_from (~> 2.1.0)
-  openstax_salesforce (~> 0.15.0)
+  openstax_salesforce (~> 1.0.0)
   openstax_utilities (~> 4.2.0)
   p3p
   parallel_tests

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -76,7 +76,7 @@ module Oauth
 
     def admin_params
       params.require(:doorkeeper_application).permit(
-        :name, :redirect_uri, :scopes, :email_subject_prefix, :email_from_address, :trusted
+        :name, :redirect_uri, :scopes, :email_subject_prefix, :email_from_address, :trusted,
         :lead_application_source
       )
     end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -70,13 +70,14 @@ module Oauth
 
     def user_params
       params.require(:doorkeeper_application).permit(
-        :name, :redirect_uri, :scopes, :email_subject_prefix
+        :name, :redirect_uri, :scopes, :email_subject_prefix, :lead_application_source
       )
     end
 
     def admin_params
       params.require(:doorkeeper_application).permit(
         :name, :redirect_uri, :scopes, :email_subject_prefix, :email_from_address, :trusted
+        :lead_application_source
       )
     end
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -86,6 +86,7 @@ class SignupController < ApplicationController
 
       handle_with(handler,
                   contracts_required: !contracts_not_required,
+                  client_app: get_client_app,
                   success: lambda do
                     clear_signup_state
                     if current_user.student? || current_user.created_from_trusted_data?

--- a/app/handlers/faculty_access_apply.rb
+++ b/app/handlers/faculty_access_apply.rb
@@ -83,7 +83,10 @@ class FacultyAccessApply
         using_openstax: apply_params.using_openstax,
         subject: SubjectsUtils.form_choices_to_salesforce_string(apply_params.subjects),
         url: apply_params.url,
-        newsletter: apply_params.newsletter
+        newsletter: apply_params.newsletter,
+        # do not set source_application because this faculty access endpoint does
+        # not have a strong indication of where the user is coming from
+        source_application: nil
       )
     end
 

--- a/app/handlers/signup_profile.rb
+++ b/app/handlers/signup_profile.rb
@@ -63,7 +63,8 @@ class SignupProfile
         using_openstax: profile_params.using_openstax,
         subject: SubjectsUtils.form_choices_to_salesforce_string(profile_params.subjects),
         url: profile_params.url,
-        newsletter: profile_params.newsletter
+        newsletter: profile_params.newsletter,
+        source_application: options[:client_app]
       )
     end
   end

--- a/app/routines/push_salesforce_lead.rb
+++ b/app/routines/push_salesforce_lead.rb
@@ -4,7 +4,8 @@ class PushSalesforceLead
 
   protected
 
-  def exec(user:, email: nil, role:, phone_number:, school:, num_students:, using_openstax:, url:, newsletter:, subject:)
+  def exec(user:, email: nil, role:, phone_number:, school:, num_students:,
+           using_openstax:, url:, newsletter:, subject:, source_application:)
 
     raise(IllegalArgument, "Cannot push SF Leads for student roles") if role.match(/student/i)
 
@@ -33,7 +34,8 @@ class PushSalesforceLead
       website: url,
       adoption_status: using_openstax,
       num_students: num_students.to_i,
-      os_accounts_id: user.id
+      os_accounts_id: user.id,
+      application_source: source_application.try(:lead_application_source) || ''
     )
 
     lead.save

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -57,6 +57,16 @@
     </div>
   <% end %>
 
+  <%= content_tag :div,
+      class: "form-group#{' has-error' if application.errors[:lead_application_source].present?}" do %>
+    <%= f.label :lead_application_source, class: 'col-sm-2 control-label',
+                                          for: 'doorkeeper_application_lead_application_source' %>
+    <div class="col-sm-10">
+      <%= f.text_field :lead_application_source, class: 'form-control' %>
+      <%= doorkeeper_errors_for application, :lead_application_source %>
+    </div>
+  <% end %>
+
   <% if @user.is_administrator? %>
     <%= content_tag :div,
         class: "form-group#{' has-error' if application.errors[:email_from_address].present?}" do %>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -40,6 +40,10 @@
 
     <p><%= @application.email_from_address %></p>
 
+    <h4>Lead Application Source:</h4>
+
+    <p><%= @application.lead_application_source %></p>
+
     <h4>Trusted?</h4>
 
     <p><%= @application.trusted ? 'Yes' : 'No' %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,12 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.  If SMTP used instead
+  # but without good credentials, results in 30 second pauses.
+  config.action_mailer.delivery_method = :test
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -57,7 +57,7 @@ ActionController::Base.class_exec do
 
   def complete_signup_profile
     return true if request.format != :html || request.options?
-    redirect_to signup_profile_path if current_user.is_needs_profile?
+    redirect_to main_app.signup_profile_path if current_user.is_needs_profile?
   end
 
   def check_if_password_expired

--- a/config/initializers/doorkeeper_models.rb
+++ b/config/initializers/doorkeeper_models.rb
@@ -1,6 +1,7 @@
 require_relative 'doorkeeper'
 
 Doorkeeper::Application.class_eval do
+
   has_many :application_users, foreign_key: :application_id,
                                dependent: :destroy,
                                inverse_of: :application

--- a/db/migrate/20171226134252_add_lead_source_to_oauth_applications.rb
+++ b/db/migrate/20171226134252_add_lead_source_to_oauth_applications.rb
@@ -1,0 +1,6 @@
+class AddLeadSourceToOauthApplications < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :lead_application_source, :string,
+                                    null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219220114) do
+ActiveRecord::Schema.define(version: 20171226134252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -184,19 +184,20 @@ ActiveRecord::Schema.define(version: 20171219220114) do
   end
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",                 :null=>false
-    t.string   "uid",                  :null=>false, :index=>{:name=>"index_oauth_applications_on_uid", :unique=>true}
-    t.string   "secret",               :null=>false
-    t.text     "redirect_uri",         :null=>false
-    t.datetime "created_at",           :null=>false
-    t.datetime "updated_at",           :null=>false
-    t.boolean  "trusted",              :default=>false
-    t.integer  "owner_id",             :index=>{:name=>"index_oauth_applications_on_owner_id_and_owner_type", :with=>["owner_type"]}
+    t.string   "name",                    :null=>false
+    t.string   "uid",                     :null=>false, :index=>{:name=>"index_oauth_applications_on_uid", :unique=>true}
+    t.string   "secret",                  :null=>false
+    t.text     "redirect_uri",            :null=>false
+    t.datetime "created_at",              :null=>false
+    t.datetime "updated_at",              :null=>false
+    t.boolean  "trusted",                 :default=>false
+    t.integer  "owner_id",                :index=>{:name=>"index_oauth_applications_on_owner_id_and_owner_type", :with=>["owner_type"]}
     t.string   "owner_type"
-    t.string   "email_from_address",   :default=>"", :null=>false
-    t.string   "email_subject_prefix", :default=>"", :null=>false
-    t.boolean  "skip_terms",           :default=>false, :null=>false
-    t.string   "scopes",               :default=>"", :null=>false
+    t.string   "email_from_address",      :default=>"", :null=>false
+    t.string   "email_subject_prefix",    :default=>"", :null=>false
+    t.boolean  "skip_terms",              :default=>false, :null=>false
+    t.string   "scopes",                  :default=>"", :null=>false
+    t.string   "lead_application_source", :default=>"", :null=>false
   end
 
   create_table "openstax_salesforce_users", force: :cascade do |t|

--- a/lib/tasks/accounts/create_admin.rake
+++ b/lib/tasks/accounts/create_admin.rake
@@ -24,6 +24,7 @@ namespace :accounts do
           auth.user_id = user.id
           auth.save!
         end
+        AddEmailToUser['admin@openstax.org', user, {already_verified: true}]
       rescue Exception => e
         puts e
         raise ActiveRecord::Rollback

--- a/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/allows_nil_source_application.yml
+++ b/spec/cassettes/PushSalesforceLead/connected_to_Salesforce/allows_nil_source_application.yml
@@ -5,11 +5,10 @@ http_interactions:
     uri: "<tutor_specs_instance_url>/services/data/v37.0/sobjects/Lead"
     body:
       encoding: UTF-8
-      string: '{"FirstName":"Rodger","LastName":"Gusikowski","Subject__c":"","Company":"JP
+      string: '{"FirstName":"Keyshawn","LastName":"Harvey","Subject__c":"","Company":"JP
         University","Website":"http://www.rice.edu","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":0,"OS_Accounts_ID__c":2,"Application_Source__c":"Tutor
-        Signup"}'
+        Adoption Won","Number_of_Students__c":0,"OS_Accounts_ID__c":3,"Application_Source__c":""}'
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -29,7 +28,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 27 Dec 2017 15:05:23 GMT
+      - Wed, 27 Dec 2017 15:05:25 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -41,26 +40,26 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=N_-tia_NRMKaHAmti2bUGQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        25-Feb-2018 15:05:23 GMT;Max-Age=5184000
+      - BrowserId=e-b6graSQJaOD0S8UPVy3w;Path=/;Domain=.salesforce.com;Expires=Sun,
+        25-Feb-2018 15:05:25 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
       - api-usage=7/48000
       Location:
-      - "/services/data/v37.0/sobjects/Lead/00QW0000006J2QJMA0"
+      - "/services/data/v37.0/sobjects/Lead/00QW0000006J2QOMA0"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"00QW0000006J2QJMA0","success":true,"errors":[]}'
+      string: '{"id":"00QW0000006J2QOMA0","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 27 Dec 2017 15:05:24 GMT
+  recorded_at: Wed, 27 Dec 2017 15:05:26 GMT
 - request:
     method: get
-    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid_c__c,%20Application_Source__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700QW0000006J2QJMA0%27)%20LIMIT%201"
+    uri: "<tutor_specs_instance_url>/services/data/v37.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Salutation,%20Subject__c,%20Company,%20Phone,%20Website,%20Status,%20Email,%20LeadSource,%20Newsletter__c,%20Newsletter_Opt_In__c,%20Adoption_Status__c,%20Number_of_Students__c,%20OS_Accounts_ID__c,%20accounts_uuid_c__c,%20Application_Source__c%20FROM%20Lead%20WHERE%20(Id%20=%20%2700QW0000006J2QOMA0%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -81,7 +80,7 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Wed, 27 Dec 2017 15:05:25 GMT
+      - Wed, 27 Dec 2017 15:05:26 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -93,24 +92,23 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Set-Cookie:
-      - BrowserId=CQuubuX5SaG0EVqa1Lks0A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        25-Feb-2018 15:05:25 GMT;Max-Age=5184000
+      - BrowserId=tcDc6ur0S9WACeOUU6TEcA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        25-Feb-2018 15:05:26 GMT;Max-Age=5184000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=10/48000
+      - api-usage=8/48000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
       - Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00QW0000006J2QJMA0"},"Id":"00QW0000006J2QJMA0","Name":"Rodger
-        Gusikowski","FirstName":"Rodger","LastName":"Gusikowski","Salutation":null,"Subject__c":null,"Company":"JP
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Lead","url":"/services/data/v37.0/sobjects/Lead/00QW0000006J2QOMA0"},"Id":"00QW0000006J2QOMA0","Name":"Keyshawn
+        Harvey","FirstName":"Keyshawn","LastName":"Harvey","Salutation":null,"Subject__c":null,"Company":"JP
         University","Phone":null,"Website":"http://www.rice.edu","Status":"Needs School","Email":"f@f.com","LeadSource":"OSC
         Faculty","Newsletter__c":true,"Newsletter_Opt_In__c":true,"Adoption_Status__c":"Confirmed
-        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"2","accounts_uuid_c__c":null,"Application_Source__c":"Tutor
-        Signup"}]}'
+        Adoption Won","Number_of_Students__c":30.0,"OS_Accounts_ID__c":"3","accounts_uuid_c__c":null,"Application_Source__c":null}]}'
     http_version: 
-  recorded_at: Wed, 27 Dec 2017 15:05:25 GMT
+  recorded_at: Wed, 27 Dec 2017 15:05:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/admin/oauth_application_crud_spec.rb
+++ b/spec/features/admin/oauth_application_crud_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'Admin oauth app create and edit', js: true do
+  context 'as an admin user' do
+    before(:each) do
+      @admin_user = create_admin_user
+      visit '/'
+      complete_login_username_or_email_screen('admin')
+      complete_login_password_screen('password')
+    end
+
+    it 'can create and edit applications' do
+      visit '/oauth/applications'
+      click_link 'New Application'
+      fill_in 'Name', with: 'Test'
+      fill_in 'Redirect URI', with: 'urn:ietf:wg:oauth:2.0:oob'
+      fill_in 'Email subject prefix', with: '[Test]'
+      fill_in 'Lead application source', with: 'Tutor Signup'
+      fill_in 'Email from address', with: 'blah@example.com'
+      click_button 'Submit'
+
+      expect(page).to have_content("Application: Test")
+      expect(page).to have_content("Tutor Signup")
+
+      click_link 'Edit'
+
+      fill_in 'Lead application source', with: 'App Source Blah'
+
+      click_button 'Submit'
+
+      expect(page).to have_content("App Source Blah")
+    end
+  end
+end


### PR DESCRIPTION
Lets admins set an "application source" for each oauth app.  When users sign up from one of those apps, this new source field is sent along with the lead to Salesforce.  

Will require us to set Tutor's source value to "Tutor Signup" after deployment 