### PR TITLE
Do not explode when trusted data missing email

### DIFF
--- a/app/handlers/signup_start.rb
+++ b/app/handlers/signup_start.rb
@@ -34,6 +34,7 @@ class SignupStart
 
     # Create a new one
     new_signup_state = SignupState.email_address.create(
+      is_partial_info_allowed: false,
       contact_info_value: email,
       role: signup_params.role,
       trusted_data: existing_signup_state.try(:trusted_data),

--- a/app/models/signup_state.rb
+++ b/app/models/signup_state.rb
@@ -1,5 +1,5 @@
 class SignupState < ActiveRecord::Base
-  attr_accessible :contact_info_value, :role, :return_to, :trusted_data, :verified
+  attr_accessible :contact_info_value, :role, :return_to, :trusted_data, :verified, :is_partial_info_allowed
 
   enum contact_info_kind: [:email_address]
 
@@ -9,24 +9,23 @@ class SignupState < ActiveRecord::Base
   include EmailAddressValidations
 
   email_validation_formats.each do |format|
-    validates :contact_info_value, format: format, if: -> { email_address? }
+    validates :contact_info_value, format: format, if: -> { !is_partial_info_allowed && email_address? }
   end
 
-  validates :contact_info_kind, presence: true
-  validates :contact_info_value, presence: true
+  validates :contact_info_kind, presence: true, unless: -> { is_partial_info_allowed }
+  validates :contact_info_value, presence: true, unless: -> { is_partial_info_allowed }
 
   scope :verified, -> { where(verified: true) }
   sifter :verified do verified.eq true end
-
-  DUMMY_TRUSTED_DATA_EMAIL = "fake_email@openstax.org"
 
   def self.create_from_trusted_data(data)
     role = User.roles[data[:role]] ? data['role'] : nil
     data['external_user_uuid'] = data.delete('uuid')
     SignupState.create!(
+      is_partial_info_allowed: true,
       role: role,
       verified: false,
-      contact_info_value: data['email'].blank? ? DUMMY_TRUSTED_DATA_EMAIL : data['email'],
+      contact_info_value: data['email'],
       trusted_data: data.merge(role: role)
     )
   end

--- a/app/models/signup_state.rb
+++ b/app/models/signup_state.rb
@@ -18,13 +18,15 @@ class SignupState < ActiveRecord::Base
   scope :verified, -> { where(verified: true) }
   sifter :verified do verified.eq true end
 
+  DUMMY_TRUSTED_DATA_EMAIL = "fake_email@openstax.org"
+
   def self.create_from_trusted_data(data)
     role = User.roles[data[:role]] ? data['role'] : nil
     data['external_user_uuid'] = data.delete('uuid')
     SignupState.create!(
       role: role,
       verified: false,
-      contact_info_value: data['email'],
+      contact_info_value: data['email'].blank? ? DUMMY_TRUSTED_DATA_EMAIL : data['email'],
       trusted_data: data.merge(role: role)
     )
   end

--- a/db/migrate/20180105205907_allow_partial_signup_state.rb
+++ b/db/migrate/20180105205907_allow_partial_signup_state.rb
@@ -1,0 +1,8 @@
+class AllowPartialSignupState < ActiveRecord::Migration
+  def change
+    change_column_null :signup_states, :contact_info_value, true
+    change_column_null :signup_states, :contact_info_kind, true
+
+    add_column :signup_states, :is_partial_info_allowed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -237,17 +237,18 @@ ActiveRecord::Schema.define(version: 20180117215851) do
   end
 
   create_table "signup_states", force: :cascade do |t|
-    t.integer  "contact_info_kind",    :default=>0, :null=>false, :index=>{:name=>"index_signup_states_on_contact_info_kind"}
-    t.string   "contact_info_value",   :null=>false
-    t.boolean  "verified",             :default=>false
+    t.integer  "contact_info_kind",       :default=>0, :index=>{:name=>"index_signup_states_on_contact_info_kind"}
+    t.string   "contact_info_value"
+    t.boolean  "verified",                :default=>false
     t.string   "confirmation_code"
     t.string   "confirmation_pin"
     t.datetime "confirmation_sent_at"
-    t.datetime "created_at",           :null=>false
-    t.datetime "updated_at",           :null=>false
-    t.string   "role",                 :null=>false
+    t.datetime "created_at",              :null=>false
+    t.datetime "updated_at",              :null=>false
+    t.string   "role",                    :null=>false
     t.text     "return_to"
     t.jsonb    "trusted_data"
+    t.boolean  "is_partial_info_allowed", :default=>false, :null=>false
   end
 
   create_table "user_external_uuids", force: :cascade do |t|

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -89,9 +89,7 @@ module UserSessionManagement
   end
 
   def signup_email
-    signup_state.try(:contact_info_value).tap do |value|
-      return nil if value == SignupState::DUMMY_TRUSTED_DATA_EMAIL
-    end
+    signup_state.try(:contact_info_value)
   end
 
   def set_client_app(client_id)

--- a/lib/user_session_management.rb
+++ b/lib/user_session_management.rb
@@ -89,7 +89,9 @@ module UserSessionManagement
   end
 
   def signup_email
-    signup_state.try(:contact_info_value)
+    signup_state.try(:contact_info_value).tap do |value|
+      return nil if value == SignupState::DUMMY_TRUSTED_DATA_EMAIL
+    end
   end
 
   def set_client_app(client_id)

--- a/spec/features/trusted_login_flow_spec.rb
+++ b/spec/features/trusted_login_flow_spec.rb
@@ -190,6 +190,16 @@ feature 'Sign in using trusted parameters', js: true do
       expect_back_at_app
       expect_validated_records(params: payload.merge(email: 'test-modified@test.com'))
     end
+
+    it 'handles email missing from signed params' do
+      payload[:email] = ""
+      arrive_from_app(params: signed_params, do_expect: false)
+      expect(page).not_to have_field('signup_role') # no changing the role
+      expect(page).to have_field('signup_email', with: '')
+      fill_in (t :"signup.start.email_placeholder"), with: "bob@example.com"
+      click_button(t :"signup.start.next")
+      expect_signup_verify_screen
+    end
   end
 
   describe 'first arrival but already signed in' do


### PR DESCRIPTION
In some situations, the trusted data that Accounts receives can be missing email.  We convert this data into a `SignupState` record which requires the email to be present.  In the case where it is missing, this PR allows the missing data up until the point where the user starts filling in forms, after which we require the email
  