### PR TITLE
LMS students who have a pre-existing account

### DIFF
--- a/app/handlers/signup_start.rb
+++ b/app/handlers/signup_start.rb
@@ -19,18 +19,18 @@ class SignupStart
     end
     outputs.role = signup_params.role
 
+    # If email in use, want users to login with that email, not create another account
+    fatal_error(code: :email_in_use, offending_inputs: [:signup, :email]) if email_in_use?
+
     # is there a signup_state and it's email is unchanged
     if existing_signup_state.try(:contact_info_value) == email
       existing_signup_state.update_attributes(role: signup_params.role)
       outputs.signup_state = existing_signup_state
-      # signup_state may have beenn created in session start
+      # signup_state may have been created in session start
       # and the the confirmation email will not yet have been sent
       deliver_validation_email if existing_signup_state.confirmation_sent_at.nil?
       return
     end
-
-    # If email in use, want users to login with that email, not create another account
-    fatal_error(code: :email_in_use, offending_inputs: [:signup, :email]) if email_in_use?
 
     # Create a new one
     new_signup_state = SignupState.email_address.create(

--- a/lib/authenticate_methods.rb
+++ b/lib/authenticate_methods.rb
@@ -11,7 +11,7 @@ module AuthenticateMethods
     # try to use them again.
     store_url(url: request_url_without_signed_params)
 
-    if signup_state && signup_state.trusted_student?
+    if signup_state && signup_state.trusted_student? && signup_state_email_available?
       redirect_to main_app.signup_path
     else
       redirect_to(
@@ -43,6 +43,13 @@ module AuthenticateMethods
   def use_signed_params
     auto_login_external_user || prepare_for_new_external_user
   end
+
+  def signup_state_email_available?
+    LookupUsers.by_verified_email(
+      signup_state.contact_info_value
+    ).none?
+  end
+
 
   def auto_login_external_user
     return false unless external_user_uuid.present?


### PR DESCRIPTION
When there's a matching email for a student we send them to sign-in and if they do switch to sign-up we display a warning and don't proceed to sending a validation email
