### PR TITLE
Change page title for profile to be "My Account"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -600,7 +600,7 @@ en:
       how_you_sign_in_html: How you<br class="wide"> log in
       name: Name
       other_sign_in_options_html: Other login<br class="wide"> options
-      page_heading: Your Account
+      page_heading: My Account
       username: Username
       sign_out: Log out
       check_searchable_if_you_want_to_be_searchable: >-


### PR DESCRIPTION
This way it'll match the Tutor menu option as requested in https://trello.com/c/d38ph5Fi/1180-menu-items-should-match-page-titles

@edwoodward will this be an issue with other users of accounts?