### PR TITLE
Respond to ELB healthchecks in /ping and /ping/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,9 @@ gem 'rails-settings-cached'
 
 gem 'scout_apm', '~> 3.0.x'
 
+# Respond to ELB healthchecks in /ping and /ping/
+gem 'openstax_healthcheck'
+
 group :development, :test do
   # Get env variables from .env file
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       roar (>= 1.0)
       roar-rails (>= 1.0)
       uber (< 0.1.0)
-    openstax_healthcheck (0.0.2)
+    openstax_healthcheck (0.0.3)
       rails (>= 3.0)
     openstax_rescue_from (2.1.0)
       exception_notification (>= 4.1, < 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,8 @@ GEM
       roar (>= 1.0)
       roar-rails (>= 1.0)
       uber (< 0.1.0)
+    openstax_healthcheck (0.0.2)
+      rails (>= 3.0)
     openstax_rescue_from (2.1.0)
       exception_notification (>= 4.1, < 5.0)
       rails (>= 3.1, < 6.0)
@@ -654,6 +656,7 @@ DEPENDENCIES
   omniauth-identity
   omniauth-twitter
   openstax_api (~> 8.2.0)
+  openstax_healthcheck
   openstax_rescue_from (~> 2.1.0)
   openstax_salesforce (~> 1.0.0)
   openstax_utilities (~> 4.2.0)


### PR DESCRIPTION
I am in the process of moving our ELB healthcheck responses to the apps themselves, so we can detect a situation where nginx is still running but the application server failed. This PR makes accounts respond with 200 OK to /ping and /ping/

In the future, when everything has autoscaling, we might need to undo this (maybe).

Gem source: https://github.com/openstax/healthcheck