### PR TITLE
Pass param to auth providers

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -26,7 +26,7 @@ class AuthenticationsController < ApplicationController
 
   # This wrapper of the oauth route exists to do reauth before adding
   def add
-    redirect_to "/auth/#{params[:provider]}"
+    redirect_to "/auth/#{params[:provider]}?add=true"
   end
 
 end

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -59,4 +59,26 @@ describe AuthenticationsController, type: :controller do
       end
     end
   end
+
+  context '#add' do
+    [ :facebook, :google ].each do |provider|
+      context 'with recent signin' do
+        before { controller.sign_in! user }
+
+        it "redirects to /auth/#{provider}?add=true" do
+          get 'add', provider: provider.to_s
+          expect(response).to redirect_to "/auth/#{provider}?add=true"
+        end
+      end
+
+      context 'with old signin' do
+        before { Timecop.freeze(11.minutes.ago) { controller.sign_in! user } }
+
+        it "prompts the user to login again" do
+          get 'add', provider: provider.to_s
+          expect(response).to redirect_to reauthenticate_path
+        end
+      end
+    end
+  end
 end

--- a/spec/handlers/sessions_create_shared_examples.rb
+++ b/spec/handlers/sessions_create_shared_examples.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'sessions create shared examples' do
+  let(:user_state) { MockUserState.new }
+  let(:login_providers) { nil }
+  let(:pre_auth_state) { nil }
+
+  context "logging in" do
+    context "no user linked to oauth response" do
+      let(:login_providers) { { 'does_not' => {'uid' => 'matter'} } }
+
+      it "returns mismatched_authentication status and does not log in" do
+        result = nil
+        expect do
+          # fabricated so no user will be linked
+          result = handle request: MockOmniauthRequest.new('facebook', 'blah', {})
+        end.not_to change { user_state.signed_in? }
+        expect(result.outputs.status).to eq :mismatched_authentication
+      end
+    end
+
+    context "oauth response doesn't match log in username/email" do
+      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
+      let(:login_providers) { { 'google_oauth2' => {'uid' => 'some_other_uid'} } }
+
+      it "returns mismatched_authentication status and does not log in" do
+        result = nil
+        expect do
+          result = handle(
+            request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {})
+          )
+        end.not_to change { user_state.signed_in? }
+        expect(result.outputs.status).to eq :mismatched_authentication
+      end
+    end
+
+    context "happy path" do
+      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
+      let(:login_providers) { { 'google_oauth2' => { 'uid' => authentication.uid } } }
+
+      it "returns returning_user status and logs in" do
+        result = handle(
+          request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {})
+        )
+        expect(result.outputs.status).to eq :returning_user
+        expect(user_state).to be_signed_in
+      end
+
+      it "as a side effect updates the login_hint for google oauth" do
+        result = handle(
+          request: MockOmniauthRequest.new(authentication.provider,
+                                           authentication.uid,
+                                           {email: "bob@bob.com"})
+        )
+        expect(result.outputs.authentication.login_hint).to eq "bob@bob.com"
+      end
+    end
+  end
+
+  context "signing up" do
+    context "oauth response already directly linked to a user" do
+      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
+      let(:pre_auth_state) do
+        FactoryGirl.create(
+          :pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com"
+        )
+      end
+
+      it "returns existing_user_signed_up_again status and transfers email" do
+        result = handle(
+          request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {})
+        )
+        expect(result.outputs.status).to eq :existing_user_signed_up_again
+        expect(authentication.user.contact_infos.verified.map(&:value)).to include "bob@bob.com"
+      end
+    end
+
+    context "oauth response already linked to user by email address" do
+      let(:other_user_email) { FactoryGirl.create(:email_address, verified: true)}
+      let(:pre_auth_state) do
+        FactoryGirl.create(
+          :pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com"
+        )
+      end
+
+      it "returns existing_user_signed_up_again status and transfers auth" do
+        expect do
+          result = handle(request: MockOmniauthRequest.new("facebook",
+                                                           "some_uid",
+                                                           {email: other_user_email.value}))
+          expect(result.outputs.status).to eq :existing_user_signed_up_again
+          expect(PreAuthState.count).to eq 0
+        end.to change{other_user_email.user.authentications.count}.by 1
+      end
+    end
+
+    context "normal password sign up" do
+      let(:identity) { FactoryGirl.create :identity }
+      let(:pre_auth_state) do
+        FactoryGirl.create(
+          :pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com"
+        )
+      end
+
+      it "adds authentication, logs in user, returns new_password_user" do
+        expect(identity.user.authentications).to be_empty
+        result = handle(request: MockOmniauthRequest.new("identity", identity.uid, {}))
+        expect(result.outputs.status).to eq :new_password_user
+        user = identity.user
+        expect(user.authentications).not_to be_empty
+        expect(user_state).to be_signed_in
+        expect(user.contact_infos.size).to eq 1
+        expect(user.contact_infos.first.value).to eq "bob@bob.com"
+        expect(user.contact_infos.first).to be_verified
+        expect(pre_auth_state).to be_destroyed
+      end
+    end
+
+    context "normal social sign up" do
+      let(:pre_auth_state) do
+        FactoryGirl.create(
+          :pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com"
+        )
+      end
+
+      it "adds authentication, logs in user, returns new_social_user" do
+        result = handle(request: MockOmniauthRequest.new("facebook", "zuckerberg", {}))
+        expect(result.outputs.status).to eq :new_social_user
+        expect(user_state).to be_signed_in
+        user = user_state.current_user
+        authentication = user.authentications(true).first
+        expect(authentication.provider).to eq "facebook"
+        expect(authentication.uid).to eq "zuckerberg"
+        expect(user.contact_infos.size).to eq 1
+        expect(user.contact_infos.first.value).to eq "bob@bob.com"
+        expect(user.contact_infos.first).to be_verified
+        expect(pre_auth_state).to be_destroyed
+      end
+    end
+  end
+
+  def handle(**args)
+    described_class.handle(user_state: user_state,
+                           login_providers: login_providers,
+                           pre_auth_state: pre_auth_state,
+                           **args)
+  end
+
+end

--- a/spec/handlers/sessions_create_spec.rb
+++ b/spec/handlers/sessions_create_spec.rb
@@ -1,140 +1,21 @@
 # coding: utf-8
 require 'rails_helper'
+require_relative 'sessions_create_shared_examples'
 
-describe SessionsCreate, type: :handler do
+RSpec.describe SessionsCreate, type: :handler do
 
-  let(:user_state) { MockUserState.new }
-  let(:login_providers) { nil }
-  let(:pre_auth_state) { nil }
-
-  context "logging in" do
-    context "no user linked to oauth response" do
-      let(:login_providers) { { 'does_not' => {'uid' => 'matter'} } }
-
-      it "returns mismatched_authentication status and does not log in" do
-        result = handle(
-          request: MockOmniauthRequest.new('facebook', 'blah', {}) # fabricated so no user will be linked
-        )
-        expect(result.outputs.status).to eq :mismatched_authentication
-        expect(user_state).not_to be_signed_in
-      end
-    end
-
-    context "oauth response doesn't match log in username/email" do
-      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
-      let(:login_providers) { { 'google_oauth2' => {'uid' => 'some_other_uid'} } }
-
-      it "returns mismatched_authentication status and does not log in" do
-        result = handle(
-          request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {})
-        )
-        expect(result.outputs.status).to eq :mismatched_authentication
-        expect(user_state).not_to be_signed_in
-      end
-    end
-
-    context "happy path" do
-      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
-      let(:login_providers) { { 'google_oauth2' => {'uid' => authentication.uid} } }
-
-      it "returns returning_user status and logs in" do
-        result = handle(
-          request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {})
-        )
-        expect(result.outputs.status).to eq :returning_user
-        expect(user_state).to be_signed_in
-      end
-
-      it "as a side effect updates the login_hint for google oauth" do
-        result = handle(
-          request: MockOmniauthRequest.new(authentication.provider,
-                                           authentication.uid,
-                                           {email: "bob@bob.com"})
-        )
-        expect(result.outputs.authentication.login_hint).to eq "bob@bob.com"
-      end
-    end
-  end
-
-  context "signing up" do
-    context "oauth response already directly linked to a user" do
-      let(:authentication) { FactoryGirl.create(:authentication, provider: 'google_oauth2') }
-      let(:pre_auth_state) {
-        FactoryGirl.create(:pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com")
-      }
-      it "returns existing_user_signed_up_again status and transfers email" do
-        result = handle(request: MockOmniauthRequest.new(authentication.provider, authentication.uid, {}))
-        expect(result.outputs.status).to eq :existing_user_signed_up_again
-        expect(authentication.user.contact_infos.verified.map(&:value)).to include "bob@bob.com"
-      end
-    end
-
-    context "oauth response already linked to user by email address" do
-      let(:other_user_email) { FactoryGirl.create(:email_address, verified: true)}
-      let(:pre_auth_state) {
-        FactoryGirl.create(:pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com")
-      }
-
-      it "returns existing_user_signed_up_again status and transfers auth" do
-        expect {
-          result = handle(request: MockOmniauthRequest.new("facebook",
-                                                           "some_uid",
-                                                           {email: other_user_email.value}))
-          expect(result.outputs.status).to eq :existing_user_signed_up_again
-          expect(PreAuthState.count).to eq 0
-        }.to change{other_user_email.user.authentications.count}.by 1
-      end
-    end
-
-    context "normal password sign up" do
-      let(:identity) { FactoryGirl.create :identity }
-      let(:pre_auth_state) {
-        FactoryGirl.create(:pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com")
-      }
-
-      it "adds authentication, logs in user, returns new_password_user" do
-        expect(identity.user.authentications).to be_empty
-        result = handle(request: MockOmniauthRequest.new("identity", identity.uid, {}))
-        expect(result.outputs.status).to eq :new_password_user
-        user = identity.user
-        expect(user.authentications).not_to be_empty
-        expect(user_state).to be_signed_in
-        expect(user.contact_infos.size).to eq 1
-        expect(user.contact_infos.first.value).to eq "bob@bob.com"
-        expect(user.contact_infos.first).to be_verified
-        expect(pre_auth_state).to be_destroyed
-      end
-    end
-
-    context "normal social sign up" do
-      let(:pre_auth_state) {
-        FactoryGirl.create(:pre_auth_state, :contact_info_verified, contact_info_value: "bob@bob.com")
-      }
-
-      it "adds authentication, logs in user, returns new_social_user" do
-        result = handle(request: MockOmniauthRequest.new("facebook", "zuckerberg", {}))
-        expect(result.outputs.status).to eq :new_social_user
-        expect(user_state).to be_signed_in
-        user = user_state.current_user
-        authentication = user.authentications(true).first
-        expect(authentication.provider).to eq "facebook"
-        expect(authentication.uid).to eq "zuckerberg"
-        expect(user.contact_infos.size).to eq 1
-        expect(user.contact_infos.first.value).to eq "bob@bob.com"
-        expect(user.contact_infos.first).to be_verified
-        expect(pre_auth_state).to be_destroyed
-      end
-    end
-  end
+  include_examples 'sessions create shared examples'
 
   context "logged in" do
     let(:current_user) { FactoryGirl.create :user }
     before(:each) { user_state.sign_in!(current_user) }
 
     context "authentication already on current user" do
-      before {
-        FactoryGirl.create(:authentication, provider: "facebook", uid: "blahuid", user: current_user)
-      }
+      before do
+        FactoryGirl.create(
+          :authentication, provider: "facebook", uid: "blahuid", user: current_user
+        )
+      end
 
       it "returns :no_action" do
         result = handle(request: MockOmniauthRequest.new("facebook", "blahuid", {}))
@@ -142,58 +23,74 @@ describe SessionsCreate, type: :handler do
       end
     end
 
-    context "authentication is for a different user" do
-      before {
-        FactoryGirl.create(:authentication, provider: "facebook",
-                                            uid: "blahuid",
-                                            user: FactoryGirl.create(:user))
-      }
-
-      it "returns :authentication_taken" do
-        result = handle(request: MockOmniauthRequest.new("facebook", "blahuid", {}))
-        expect(result.outputs.status).to eq :authentication_taken
-      end
+    context "not adding new authentication" do
+      include_examples 'sessions create shared examples'
     end
 
-    context "authentication provider already on current user" do
-      before {
-        FactoryGirl.create(:authentication, provider: "google_oauth2",
-                                            uid: "uid_one",
-                                            user: current_user)
-      }
+    context "adding new authentication to account" do
+      context "authentication is for a different user" do
+        before do
+          FactoryGirl.create(:authentication, provider: "facebook",
+                                              uid: "blahuid",
+                                              user: FactoryGirl.create(:user))
+        end
 
-      it "returns :same_provider" do
-        result = handle(request: MockOmniauthRequest.new("google_oauth2", "uid_two", {}))
-        expect(result.outputs.status).to eq :same_provider
+        it "returns :authentication_taken" do
+          result = handle(
+            request: MockOmniauthRequest.new("facebook", "blahuid", {}, 'add' => 'true')
+          )
+          expect(result.outputs.status).to eq :authentication_taken
+        end
       end
-    end
 
-    context "user hasn't signed in recently enough to complete action" do
-      before(:each) {
-        SecurityLog.create! user: current_user, remote_ip: '127.0.0.1',
-                            event_type: :sign_in_successful, event_data: {}
-        Timecop.freeze(Time.now + RequireRecentSignin::REAUTHENTICATE_AFTER)
-      }
+      context "authentication provider already on current user" do
+        before do
+          FactoryGirl.create(:authentication, provider: "google_oauth2",
+                                              uid: "uid_one",
+                                              user: current_user)
+        end
 
-      it "returns :new_signin_required" do
-        result = handle(request: MockOmniauthRequest.new("google_oauth2", "uid", {}))
-        expect(result.outputs.status).to eq :new_signin_required
+        it "returns :same_provider" do
+          result = handle(
+            request: MockOmniauthRequest.new("google_oauth2", "uid_two", {}, 'add' => 'true')
+          )
+          expect(result.outputs.status).to eq :same_provider
+        end
       end
-    end
 
-    context "happy path where authentication is added" do
-      before(:each) {
-        SecurityLog.create! user: current_user, remote_ip: '127.0.0.1',
-                            event_type: :sign_in_successful, event_data: {}
-      }
+      context "user hasn't signed in recently enough to complete action" do
+        before(:each) do
+          SecurityLog.create! user: current_user, remote_ip: '127.0.0.1',
+                              event_type: :sign_in_successful, event_data: {}
+          Timecop.freeze(Time.now + RequireRecentSignin::REAUTHENTICATE_AFTER)
+        end
 
-      it "add the authentication, adds the auth email, returns :authentication_added" do
-        result = handle(request: MockOmniauthRequest.new("google_oauth2", "uid", {email: "joe@joe.com"}))
-        expect(result.outputs.status).to eq :authentication_added
-        authentication = current_user.authentications(true).first
-        expect(authentication.provider).to eq "google_oauth2"
-        expect(authentication.uid).to eq "uid"
-        expect(current_user.contact_infos.verified.map(&:value)).to contain_exactly("joe@joe.com")
+        it "returns :new_signin_required" do
+          result = handle(
+            request: MockOmniauthRequest.new("google_oauth2", "uid", {}, 'add' => 'true')
+          )
+          expect(result.outputs.status).to eq :new_signin_required
+        end
+      end
+
+      context "happy path where authentication is added" do
+        before(:each) do
+          SecurityLog.create! user: current_user, remote_ip: '127.0.0.1',
+                              event_type: :sign_in_successful, event_data: {}
+        end
+
+        it "adds the authentication, adds the auth email, returns :authentication_added" do
+          result = handle(
+            request: MockOmniauthRequest.new(
+              "google_oauth2", "uid", { email: "joe@joe.com" }, 'add' => 'true'
+            )
+          )
+          expect(result.outputs.status).to eq :authentication_added
+          authentication = current_user.authentications(true).first
+          expect(authentication.provider).to eq "google_oauth2"
+          expect(authentication.uid).to eq "uid"
+          expect(current_user.contact_infos.verified.map(&:value)).to contain_exactly("joe@joe.com")
+        end
       end
     end
   end
@@ -248,13 +145,6 @@ describe SessionsCreate, type: :handler do
         expect(user_most_recently_used([@user4, @user3])).to eq @user4
       end
     end
-  end
-
-  def handle(**args)
-    described_class.handle(user_state: user_state,
-                           login_providers: login_providers,
-                           pre_auth_state: pre_auth_state,
-                           **args)
   end
 
   def user_most_recently_used(users)

--- a/spec/support/mock_omniauth_request.rb
+++ b/spec/support/mock_omniauth_request.rb
@@ -1,14 +1,18 @@
 
 class MockOmniauthRequest
 
-  def initialize(provider, uid, info)
+  def initialize(provider, uid, info, params = {})
     @provider = provider
     @uid = uid
     @info = info
+    @params = params
   end
 
   def env
-    { 'omniauth.auth' => { provider: @provider, uid: @uid, info: @info } }
+    {
+      'omniauth.auth' => { provider: @provider, uid: @uid, info: @info },
+      'omniauth.params' => @params
+    }
   end
 
 end


### PR DESCRIPTION
Last paragraph of https://trello.com/c/1F820U9N

Includes https://github.com/openstax/accounts/pull/593

Also has code that tries to separate the 2 flows of adding a new auth provider vs signing in/signing up by passing a parameter to the OAuth provider that should make it back to Accounts.

Tested on accounts-dev and seemed to work fine.