### PR TITLE
Replaced PhantomJS with headless Chrome and fixed a few flaky feature tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: bundler
 bundler_args: --without=production --retry=6
 addons:
   chrome: stable
-  postgresql: "9.5"
+  postgresql: 9.5
 before_script: bundle exec rake --trace parallel:create parallel:load_schema parallel:seed
 script: bundle exec rake parallel:spec
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
   only:
     - master
-    - 2016-accounts-flow
 dist: trusty
 sudo: false
 env: OXA_DB_USER=postgres OXA_TEST_DB=travis_ci_test PARALLEL_TEST_PROCESSORS=2
@@ -10,14 +9,8 @@ rvm: "2.2.3"
 cache: bundler
 bundler_args: --without=production --retry=6
 addons:
-  postgresql: "9.4"
-before_install:
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
-  - gem install bundler
+  chrome: stable
+  postgresql: "9.5"
 before_script: bundle exec rake --trace parallel:create parallel:load_schema parallel:seed
 script: bundle exec rake parallel:spec
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -212,9 +212,6 @@ group :test do
 
   gem 'db-query-matchers'
 
-  # Headless Capybara driver
-  gem 'poltergeist'
-
   # Testing emails
   gem 'capybara-email'
 
@@ -222,6 +219,10 @@ group :test do
   gem 'fakeredis', require: 'fakeredis/rspec'
 
   gem 'launchy'
+
+  gem 'chromedriver-helper'
+
+  gem 'capybara-selenium'
 
   gem 'capybara-screenshot', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,10 +56,13 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     apipie-rails (0.1.3)
       json
       rails (>= 3.0.10)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (6.0.3)
     ast (2.3.0)
     awesome_print (1.7.0)
@@ -77,23 +80,30 @@ GEM
       sass (~> 3.2)
     builder (3.2.3)
     byebug (9.0.6)
-    capybara (2.10.1)
+    capybara (2.18.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-email (2.5.0)
       capybara (~> 2.4)
       mail
-    capybara-screenshot (1.0.14)
-      capybara (>= 1.0, < 3)
+    capybara-screenshot (1.0.19)
+      capybara (>= 1.0, < 4)
       launchy
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     chunky_png (1.3.7)
-    cliver (0.3.2)
     codecov (0.1.9)
       json
       simplecov
@@ -253,6 +263,7 @@ GEM
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
     inflecto (0.0.2)
+    io-like (0.3.0)
     its-it (1.3.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -299,6 +310,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     modware (0.1.3)
@@ -378,10 +390,6 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
-    poltergeist (1.11.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     premailer (1.8.7)
@@ -396,6 +404,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (3.0.2)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.10)
@@ -509,6 +518,7 @@ GEM
     rspec-support (3.5.0)
     ruby-graphviz (1.2.3)
     ruby_dep (1.3.1)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -534,6 +544,9 @@ GEM
       schema_plus_core (~> 1.0)
       schema_plus_indexes (~> 0.1, >= 0.1.3)
     scout_apm (3.0.0.pre16)
+    selenium-webdriver (3.11.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
@@ -610,17 +623,14 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.6.4)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
     whenever (0.9.7)
       chronic (>= 0.6.3)
     whenever-test (1.0.1)
       whenever
     will_paginate (3.1.3)
     xml-simple (1.1.5)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -636,6 +646,8 @@ DEPENDENCIES
   byebug
   capybara-email
   capybara-screenshot
+  capybara-selenium
+  chromedriver-helper
   chronic
   codecov
   coffee-rails (~> 4.1.0)
@@ -678,7 +690,6 @@ DEPENDENCIES
   parallel_tests
   pattern-library!
   pg
-  poltergeist
   premailer-rails
   protected_attributes
   quiet_assets

--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ which will start Accounts up on port 2999, i.e. http://localhost:2999.
 
 ## Running Specs (Automated Tests)
 
-Specs require phantomjs. On a mac:
-```sh
-$ brew install phantomjs
-```
-
 To run specs,
 
 ```sh

--- a/app/controllers/admin/security_logs_controller.rb
+++ b/app/controllers/admin/security_logs_controller.rb
@@ -6,6 +6,5 @@ module Admin
       items = SearchSecurityLog.call(params[:search] || {}).outputs.items || SecurityLog.none
       @security_log = items.paginate(page: params[:page], per_page: params[:per_page] || 20)
     end
-
   end
 end

--- a/lib/authenticate_methods.rb
+++ b/lib/authenticate_methods.rb
@@ -24,6 +24,7 @@ module AuthenticateMethods
 
   def authenticate_admin!
     return if current_user.is_administrator?
+    return head(:forbidden) if signed_in?
 
     store_url
     redirect_to main_app.login_path(params.slice(:client_id))

--- a/spec/features/add_application_spec.rb
+++ b/spec/features/add_application_spec.rb
@@ -30,6 +30,6 @@ feature 'Add application to accounts', js: true do
     complete_login_password_screen('password')
 
     visit '/oauth/applications/new'
-    expect(page).to have_http_status :forbidden
+    expect(page).to have_content 'You are not allowed to do that. (403)'
   end
 end

--- a/spec/features/add_social_auth_spec.rb
+++ b/spec/features/add_social_auth_spec.rb
@@ -39,7 +39,7 @@ feature 'Add social auth', js: true do
       find('.authentication[data-provider="facebook"] .add').click
       wait_for_ajax
       expect_profile_page
-      expect(page).not_to have_content("already in use")
+      expect(page).to have_no_content("already in use")
       expect(page).to have_content('Facebook')
     end
   end

--- a/spec/features/admin/pre_auth_states_spec.rb
+++ b/spec/features/admin/pre_auth_states_spec.rb
@@ -25,17 +25,17 @@ feature 'Admin PreAuthStates page' do
       visit '/admin/pre_auth_states'
 
       expect(page).to have_content("d@d.com")
-      expect(page).not_to have_content("c@c.com")
+      expect(page).to have_no_content("c@c.com")
 
       click_link "1 week"
 
       expect(page).to have_content(/d@d\.com.*c@c\.com/)
-      expect(page).not_to have_content("b@b.com")
+      expect(page).to have_no_content("b@b.com")
 
       click_link "2 weeks"
 
       expect(page).to have_content(/d@d\.com.*c@c\.com.*b@b\.com/)
-      expect(page).not_to have_content("a@a.com")
+      expect(page).to have_no_content("a@a.com")
 
       click_link "All"
 

--- a/spec/features/admin/salesforce_spec.rb
+++ b/spec/features/admin/salesforce_spec.rb
@@ -11,14 +11,14 @@ feature 'Admin salesforce pages', js: true do
 
     it 'can visit the actions page' do
       visit '/admin/salesforce/actions'
-      expect(page).not_to have_content("We had some unexpected")
+      expect(page).to have_no_content("We had some unexpected")
     end
 
     it 'can trigger a user info update' do
       visit '/admin/salesforce/actions'
       expect(UpdateUserSalesforceInfo).to receive(:call)
       click_button 'Refresh'
-      expect(page).not_to have_content("We had some unexpected")
+      expect(page).to have_no_content("We had some unexpected")
       expect(page).to have_content("Refresh Salesforce User Info")
     end
   end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -20,7 +20,7 @@ feature 'Admin user pages', js: true do
           visit '/admin/users'
           click_button 'Search'
 
-          expect(page).not_to have_content("We had some unexpected")
+          expect(page).to have_no_content("We had some unexpected")
 
           page.all(:css, '.expand').each(&:click)
 
@@ -30,7 +30,7 @@ feature 'Admin user pages', js: true do
 
         it "can bring up the edit page without exploding" do
           visit "/admin/users/#{@sf_user.id}/edit"
-          expect(page).not_to have_content("We had some unexpected")
+          expect(page).to have_no_content("We had some unexpected")
         end
       end
 
@@ -41,7 +41,7 @@ feature 'Admin user pages', js: true do
           click_link 'Users'
           click_button 'Search'
 
-          expect(page).not_to have_content("We had some unexpected")
+          expect(page).to have_no_content("We had some unexpected")
 
           page.all(:css, '.expand').each(&:click)
 

--- a/spec/features/apply_for_faculty_access_spec.rb
+++ b/spec/features/apply_for_faculty_access_spec.rb
@@ -14,7 +14,7 @@ describe 'Apply for faculty access', type: :feature, js: true do
     screenshot!
 
     expect_sign_in_page
-    expect(page).not_to have_content("Sign up")
+    expect(page).to have_no_content("Sign up")
 
     complete_login_username_or_email_screen('user')
     complete_login_password_screen('password')
@@ -153,7 +153,7 @@ describe 'Apply for faculty access', type: :feature, js: true do
       [:first_name, :last_name, :email, :phone_number, :school, :url].each do |var|
         expect(page).to have_content(error_msg FacultyAccessApplyOther, var, :blank)
       end
-      expect(page).not_to have_content(error_msg FacultyAccessApplyOther, :num_students, :not_a_number)
+      expect(page).to have_no_content(error_msg FacultyAccessApplyOther, :num_students, :not_a_number)
     end
 
     scenario "email taken" do

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -16,7 +16,7 @@ feature 'Confirm email address', js: true do
   scenario 'without a confirmation code' do
     visit '/confirm'
     expect(page).to have_no_missing_translations
-    expect(page).to_not have_content('Alert: no_contact_info_for_code')
+    expect(page).to have_no_content('Alert: no_contact_info_for_code')
     expect(page).to have_content(t :"contact_infos.confirm.page_heading.error")
     expect(page).to have_content(t :"contact_infos.confirm.verification_code_not_found")
   end
@@ -24,7 +24,7 @@ feature 'Confirm email address', js: true do
   scenario 'with unmatched confirmation code' do
     visit '/confirm?code=1234'
     expect(page).to have_no_missing_translations
-    expect(page).to_not have_content('Alert: no_contact_info_for_code')
+    expect(page).to have_no_content('Alert: no_contact_info_for_code')
     expect(page).to have_content(t :"contact_infos.confirm.page_heading.error")
     expect(page).to have_content(t :"contact_infos.confirm.verification_code_not_found")
   end

--- a/spec/features/pose_terms_spec.rb
+++ b/spec/features/pose_terms_spec.rb
@@ -13,17 +13,16 @@ describe 'Terms', type: :feature, js: true do
     screenshot!
     expect(page).to have_content("Terms of Use")
     expect(page).to have_content(t :"terms.pose.contract_acceptance_required")
-    find(:css, '#agreement_i_agree').trigger('click')
+    find(:css, '#agreement_i_agree').click
     click_button (t :"terms.pose.agree")
 
     screenshot!
     expect(page).to have_content("Privacy Policy")
     expect(page).to have_content(t :"terms.pose.contract_acceptance_required")
-    find(:css, '#agreement_i_agree').trigger('click')
+    find(:css, '#agreement_i_agree').click
     click_button (t :"terms.pose.agree")
 
     expect_profile_page
   end
 
 end
-

--- a/spec/features/require_recent_sign_in_to_change_authentications_spec.rb
+++ b/spec/features/require_recent_sign_in_to_change_authentications_spec.rb
@@ -10,7 +10,7 @@ feature 'Require recent log in to change authentications', js: true do
     expect_profile_page
 
     Timecop.freeze(Time.now + RequireRecentSignin::REAUTHENTICATE_AFTER) do
-      expect(page).not_to have_content('Facebook')
+      expect(page).to have_no_content('Facebook')
       screenshot!
       click_link (t :"users.edit.enable_other_sign_in_options")
       wait_for_animations
@@ -61,7 +61,7 @@ feature 'Require recent log in to change authentications', js: true do
         find('.authentication[data-provider="identity"] .edit').click
 
         # Don't have to reauthenticate since just did
-        expect(page).not_to have_content(t :"sessions.reauthenticate.page_heading")
+        expect(page).to have_no_content(t :"sessions.reauthenticate.page_heading")
 
         complete_reset_password_screen
         complete_reset_password_success_screen
@@ -119,7 +119,7 @@ feature 'Require recent log in to change authentications', js: true do
         find('.authentication[data-provider="twitter"] .delete').click
         screenshot!
         click_button 'OK'
-        expect(page).not_to have_content('Twitter')
+        expect(page).to have_no_content('Twitter')
       end
     end
   end

--- a/spec/features/signed_login_flow_spec.rb
+++ b/spec/features/signed_login_flow_spec.rb
@@ -71,7 +71,7 @@ feature 'Sign in using signed parameters', js: true do
       click_sign_up
       expect_sign_up_page
 
-      expect(page).not_to have_field('signup_role') # no changing the role
+      expect(page).to have_no_field('signup_role') # no changing the role
       expect(page).to have_field('signup_email', with: payload[:email])
       click_button(t :"signup.start.next")
       wait_for_animations
@@ -112,7 +112,6 @@ feature 'Sign in using signed parameters', js: true do
 
       Timecop.travel(6.minutes.from_now) do
         complete_signup_profile_screen_with_whatever
-        expect(page.status_code).to eq 200
         expect_back_at_app # note, no "verification pending" step
       end
     end
@@ -148,7 +147,7 @@ feature 'Sign in using signed parameters', js: true do
     it 'signs up by default and links account' do
       arrive_from_app(params: signed_params, do_expect: false)
       expect_sign_up_page # students default to sign-up vs the standard sign-in
-      expect(page).not_to have_field('signup_role') # no changing the role
+      expect(page).to have_no_field('signup_role') # no changing the role
       expect(page).to have_field('signup_email', with: payload[:email])
       click_button(t :"signup.start.next")
       expect_signup_verify_screen
@@ -195,7 +194,7 @@ feature 'Sign in using signed parameters', js: true do
     it 'handles email missing from signed params' do
       payload[:email] = ""
       arrive_from_app(params: signed_params, do_expect: false)
-      expect(page).not_to have_field('signup_role') # no changing the role
+      expect(page).to have_no_field('signup_role') # no changing the role
       expect(page).to have_field('signup_email', with: '')
       fill_in (t :"signup.start.email_placeholder"), with: "bob@example.com"
       click_button(t :"signup.start.next")

--- a/spec/features/skipped_terms_spec.rb
+++ b/spec/features/skipped_terms_spec.rb
@@ -38,7 +38,7 @@ feature 'Skipped terms are respected', js: true do
                       privacy_policy: 'Privacy Policy')
 
     if should_skip
-      expect(page).not_to have_content(terms_content)
+      expect(page).to have_no_content(terms_content)
     else
       expect(page).to have_content(terms_content)
     end

--- a/spec/features/user_manages_emails_spec.rb
+++ b/spec/features/user_manages_emails_spec.rb
@@ -62,7 +62,7 @@ feature 'User manages emails', js: true do
         find('input').set('')
         find('.glyphicon-ok').click
       }
-      expect(page).to_not have_css('.email-entry.new input')
+      expect(page).to have_no_css('.email-entry.new input')
     end
 
     scenario 'with invalid value' do
@@ -75,7 +75,7 @@ feature 'User manages emails', js: true do
     end
 
     scenario 'toggles searchable field' do
-      expect(page).to_not have_content(t('users.edit.searchable'))
+      expect(page).to have_no_content(t('users.edit.searchable'))
       find(".email-entry[data-id=\"#{user.id}\"] .email").click
       expect(page).to have_content(t('users.edit.searchable'))
       screenshot!
@@ -107,15 +107,15 @@ feature 'User manages emails', js: true do
         within(:css, '.popover-content') {
           find('.confirm-dialog-btn-confirm').click
         }
-        expect(page).to_not have_content(email)
+        expect(page).to have_no_content(email)
         expect(page).to have_selector('.email')
-        expect(page).not_to have_selector('.email .delete')
+        expect(page).to have_no_selector('.email .delete')
       end
     end
 
     context 'when there is only one email' do
       scenario 'that email cannot be deleted' do
-        expect(page).not_to have_selector('.email .delete')
+        expect(page).to have_no_selector('.email .delete')
       end
     end
   end

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -243,7 +243,7 @@ feature 'User logs in', js: true do
 
   scenario 'anonymous user GETs `/auth/identity/callback` directly' do
     visit '/auth/identity/callback'
-    expect(page).not_to have_content(500)
+    expect(page).to have_no_content(500)
     expect(page).to have_content(I18n.t :"controllers.sessions.no_account_for_username_or_email")
   end
 
@@ -252,8 +252,8 @@ feature 'User logs in', js: true do
     visit '/'
     expect_sign_in_page
     expect(page).to have_content(t :"sessions.start.having_trouble")
-    expect(page).not_to have_content(t :"sessions.start.help")
-    expect(page).not_to have_link(t :"sessions.start.knowledge_base")
+    expect(page).to have_no_content(t :"sessions.start.help")
+    expect(page).to have_no_link(t :"sessions.start.knowledge_base")
 
     click_link t :"sessions.start.having_trouble"
     expect(page).to have_content(t :"sessions.start.help")

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -114,7 +114,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     arrive_from_app(do_expect: false, params: {sp: OpenStax::Api::Params.sign(secret: @app.secret, params: params)})
 
     expect_sign_up_page # students default to sign-up vs the standard sign-in
-    expect(page).not_to have_field('signup_role') # no changing the role
+    expect(page).to have_no_field('signup_role') # no changing the role
 
     fill_in (t :"signup.start.email_placeholder"), with: 'my-personal-email@test.com'
     click_button(t :"signup.start.next")
@@ -184,11 +184,11 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     scenario 'hiding/displaying edu email warning' do
       create_email_address_for(create_user('user'), "bob@bob.edu")
       visit signup_path
-      expect(page).not_to have_content t('signup.start.teacher_school_email')
+      expect(page).to have_no_content t('signup.start.teacher_school_email')
       select 'Instructor', from: "signup_role"
       expect(page).to have_content t('signup.start.teacher_school_email')
       select 'Student', from: "signup_role"
-      expect(page).not_to have_content t('signup.start.teacher_school_email')
+      expect(page).to have_no_content t('signup.start.teacher_school_email')
     end
 
     scenario 'profile selection is set to student role and hidden when coming from "student_signup"' do
@@ -237,7 +237,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       fill_in (t :"signup.start.email_placeholder"), with: "non@school.com"
       click_button(t :"signup.start.next")
       expect(page).to have_content 'To access faculty-only materials'
-      expect(page).not_to have_content 'Email already in use'
+      expect(page).to have_no_content 'Email already in use'
     end
 
     scenario 'failure because email blank' do
@@ -288,7 +288,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       complete_instructor_access_pending_screen
 
       expect(page).to have_content("bob2@bob.edu")
-      expect(page).not_to have_content("bob@bob.edu")
+      expect(page).to have_no_content("bob@bob.edu")
     end
 
     scenario 'user leaves verify screen to edit email and also changes role' do
@@ -296,8 +296,8 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       complete_signup_email_screen("Student","bob2@bob.com")
       complete_signup_verify_screen(pass: true)
       complete_signup_password_screen('password')
-      expect(page).to_not have_content(t('signup.profile.titles_interested'))
-      expect(page).to_not have_content(t('signup.profile.num_students'))
+      expect(page).to have_no_content(t('signup.profile.titles_interested'))
+      expect(page).to have_no_content(t('signup.profile.num_students'))
       complete_signup_profile_screen(
         role: :student,
         first_name: "Billy",
@@ -779,8 +779,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       # confirmation code was cleared and we got a 500
       visit confirm_link_path
 
-      expect(page.status_code).not_to eq 500
-      expect(page.body).not_to have_content("Sorry")
+      expect(page).to have_no_content("Sorry")
 
       complete_signup_password_screen('password')
       complete_signup_profile_screen_with_whatever(role: :instructor)

--- a/spec/features/user_updates_password_spec.rb
+++ b/spec/features/user_updates_password_spec.rb
@@ -31,7 +31,9 @@ feature 'User updates password on profile screen', js: true do
     complete_add_password_success_screen
     screenshot!
     expect(page).to have_no_missing_translations
-    expect(page.html).to include(t :"users.edit.how_you_sign_in_html")
+    expect(page).to have_content(
+      ActionView::Base.full_sanitizer.sanitize 'How you log in'
+    )
     expect(page).to have_css('[data-provider=facebook]')
     expect(page).to have_css('[data-provider=identity]')
   end
@@ -41,7 +43,9 @@ feature 'User updates password on profile screen', js: true do
     complete_reset_password_screen
     complete_reset_password_success_screen
     expect(page).to have_no_missing_translations
-    expect(page.html).to include(t :"users.edit.how_you_sign_in_html")
+    expect(page).to have_content(
+      ActionView::Base.full_sanitizer.sanitize t(:"users.edit.how_you_sign_in_html")
+    )
     expect(page).to have_css('[data-provider=identity]')
   end
 
@@ -53,7 +57,7 @@ feature 'User updates password on profile screen', js: true do
     expect(page).to have_css('[data-provider=identity]')
     find('[data-provider=identity] .delete').click
     find('.confirm-dialog-btn-confirm').click
-    expect(page).not_to have_css('[data-provider=identity]')
+    expect(page).to have_no_css('[data-provider=identity]')
     expect(@user.identity(true)).to be_nil
     expect(@user.authentications(true).count).to eq 1
   end

--- a/spec/features/weird_cases_spec.rb
+++ b/spec/features/weird_cases_spec.rb
@@ -25,7 +25,7 @@ feature 'Weird cases', js: true, vcr: VCR_OPTS do
     complete_login_username_or_email_screen 'other_user'
     complete_login_password_screen 'password'
 
-    expect(page).not_to have_content(500)
+    expect(page).to have_no_content(500)
     expect_back_at_app
   end
 

--- a/spec/lib/authenticate_methods_spec.rb
+++ b/spec/lib/authenticate_methods_spec.rb
@@ -57,10 +57,11 @@ RSpec.describe AuthenticateMethods, type: :lib do
     end
 
     context 'normal user' do
-      it 'authenticate_admin! redirects to the login page' do
-        expect(controller).to receive(:store_url)
-        expect(controller).to receive(:redirect_to)
-        expect(main_app).to receive(:login_path)
+      it 'authenticate_admin! returns 403 Forbidden' do
+        expect(controller).to receive(:head).with(:forbidden)
+        expect(controller).not_to receive(:store_url)
+        expect(controller).not_to receive(:redirect_to)
+        expect(main_app).not_to receive(:login_path)
         controller.authenticate_admin!
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,14 +48,16 @@ require 'selenium/webdriver'
 
 # https://robots.thoughtbot.com/headless-feature-specs-with-chrome
 Capybara.register_driver :selenium_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new args: [ '--lang=en' ]
+  options = Selenium::WebDriver::Chrome::Options.new args: [ 'lang=en' ]
 
   Capybara::Selenium::Driver.new app, browser: :chrome, options: options
 end
 
-# no-sandbox is required for it to work with Docker (Travis)
+# no-sandbox and disable-dev-shm-usage are required for Chrome to work with Docker (Travis)
 Capybara.register_driver :selenium_chrome_headless do |app|
-  options = Selenium::WebDriver::Chrome::Options.new args: [ 'headless', 'no-sandbox', '--lang=en' ]
+  options = Selenium::WebDriver::Chrome::Options.new args: [
+    'headless', 'no-sandbox', 'disable-dev-shm-usage', 'lang=en'
+  ]
 
   Capybara::Selenium::Driver.new app, browser: :chrome, options: options
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -424,10 +424,14 @@ def complete_instructor_access_pending_screen
   click_button (t :"signup.instructor_access_pending.ok")
 end
 
+def signin_as(username_or_email, password = 'password')
+  complete_login_username_or_email_screen username_or_email
+  complete_login_password_screen password
+end
+
 def log_in(username_or_email, password = 'password')
-  visit '/'
-  complete_login_username_or_email_screen(username_or_email)
-  complete_login_password_screen(password)
+  visit login_path
+  signin_as username_or_email, password
 end
 
 def log_out

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -53,13 +53,6 @@ def create_nonlocal_user(username, provider='facebook')
   user
 end
 
-def signin_as username, password='password'
-  fill_in 'login_username_or_email', with: username
-  click_button (t :"sessions.start.next")
-  fill_in 'login_password', with: password
-  click_button (t :"sessions.authenticate_options.login")
-end
-
 def create_new_application(trusted = false)
   click_link 'New Application'
   fill_in 'Name', with: 'example'
@@ -251,7 +244,7 @@ def expect_profile_page
 end
 
 def agree_and_click_create
-  find(:css, '#signup_i_agree').set(true)
+  check 'signup_i_agree'
   click_button (t :"signup.new_account.create_account")
 end
 
@@ -283,7 +276,6 @@ def complete_login_username_or_email_screen(username_or_email)
   expect(page).to have_no_missing_translations
   click_button (t :"sessions.start.next")
   expect(page).to have_no_missing_translations
-
 end
 
 def complete_login_password_screen(password)
@@ -361,16 +353,15 @@ def complete_signup_profile_screen(role:, first_name: "", last_name: "", suffix:
   fill_in (t :"signup.profile.school"), with: school
   fill_in (t :"signup.profile.url"), with: url if role != :student
   fill_in (t :"signup.profile.num_students"), with: num_students if role == :instructor
-  select using_openstax, from: "profile_using_openstax" if !using_openstax.blank? if role == :instructor
+  select using_openstax, from: "profile_using_openstax" \
+    if role == :instructor && !using_openstax.blank?
   if role != :student
-    subjects.each do |subject|
-      find_field(subject).set("1")
-    end
+    subjects.each { |subject| check subject }
   end
   expect(page).to have_content(t :"signup.profile.page_heading")
   expect(page).to have_no_missing_translations
 
-  find(:css, '#profile_i_agree').trigger('click') if agree
+  check 'profile_i_agree' if agree
 
   click_button (t :"signup.profile.create_account")
   expect(page).to have_no_missing_translations
@@ -418,12 +409,12 @@ end
 
 def complete_terms_screens(without_privacy_policy: false)
 
-  find(:css, '#agreement_i_agree').set(true)
+  check 'agreement_i_agree'
   expect(page).to have_content('Terms of Use')
   click_button (t :"terms.pose.agree")
   unless without_privacy_policy
     expect(page).to have_content('Privacy Policy')
-    find(:css, '#agreement_i_agree').set(true)
+    check 'agreement_i_agree'
     click_button (t :"terms.pose.agree")
   end
 end
@@ -433,7 +424,7 @@ def complete_instructor_access_pending_screen
   click_button (t :"signup.instructor_access_pending.ok")
 end
 
-def log_in(username_or_email, password)
+def log_in(username_or_email, password = 'password')
   visit '/'
   complete_login_username_or_email_screen(username_or_email)
   complete_login_password_screen(password)
@@ -481,9 +472,7 @@ def complete_faculty_access_apply_screen(role: nil, first_name: nil, last_name: 
   fill_in (t :"faculty_access.apply.num_students"), with: num_students if role == :instructor
   select using_openstax, from: "apply_using_openstax" if !using_openstax.blank? if role == :instructor
 
-  subjects.each do |subject|
-    find_field(subject).set("1")
-  end
+  subjects.each { |subject| check subject }
   page.check('apply[newsletter]') if newsletter
   click_button (t :"faculty_access.apply.submit")
   expect(page).to have_no_missing_translations

--- a/spec/support/screenshots.rb
+++ b/spec/support/screenshots.rb
@@ -2,7 +2,7 @@ if EnvUtilities.load_boolean(name: 'SSHOT', default: false)
   require 'capybara-screenshot/rspec'
   Capybara::Screenshot.autosave_on_failure = false
   Capybara::Screenshot.append_timestamp = false
-  WINDOW_SIZE = [ 800, 600 ]
+  WINDOW_SIZE = [ 1024, 768 ]
   CURRENT_TIME = Time.now.strftime('%Y-%m-%d-%H-%M-%S')
 
   def screenshots_dir

--- a/spec/support/screenshots.rb
+++ b/spec/support/screenshots.rb
@@ -1,0 +1,69 @@
+if EnvUtilities.load_boolean(name: 'SSHOT', default: false)
+  require 'capybara-screenshot/rspec'
+  Capybara::Screenshot.autosave_on_failure = false
+  Capybara::Screenshot.append_timestamp = false
+  WINDOW_SIZE = [ 800, 600 ]
+  CURRENT_TIME = Time.now.strftime('%Y-%m-%d-%H-%M-%S')
+
+  def screenshots_dir
+    $screenshots_dir ||= Rails.root.join(
+      "tmp/capybara/screenshots_#{CURRENT_TIME}"
+    ).tap { |path| FileUtils.mkdir_p path }
+  end
+
+  def screenshot!(suffix: nil, width: nil, height: nil)
+    include_html_screenshots = false
+
+    Capybara.current_session.current_window.resize_to(
+      width || WINDOW_SIZE[0], height || WINDOW_SIZE[1]
+    )
+
+    original_save_path = Capybara.save_path
+    begin
+      Capybara.save_path = screenshots_dir
+      saver = Capybara::Screenshot::Saver.new(
+        Capybara, Capybara.page, include_html_screenshots, screenshot_base(suffix)
+      )
+
+      wait_for_ajax
+      wait_for_animations
+
+      if saver.save
+        { html: saver.html_path, image: saver.screenshot_path }
+      end
+    ensure
+      Capybara.save_path = original_save_path
+    end
+  end
+
+  def capture_email!(address: nil, suffix: nil)
+    open_email(address) if address.present?
+
+    # Used to just call built-in `save_page`, but switched to below to add headers
+    # current_email.save_page("#{screenshots_dir}/#{screenshot_base(suffix)}.html")
+
+    path = "#{screenshots_dir}/#{screenshot_base(suffix)}.html"
+    FileUtils.mkdir_p(File.dirname(path))
+    File.open(path,'w') do |f|
+      f.write("Subject: #{current_email.subject}<br/>")
+      f.write("To: #{current_email.to.join(', ')}<br/>")
+      f.write("From: #{current_email.from.join(', ')}<br/>")
+      f.write("--------------------<br/><br/>")
+      f.write(current_email.body)
+    end
+  end
+
+  def screenshot_base(suffix=nil)
+    @screenshot_prefix_usage_counts ||= {}
+    prefix = "#{self.class.description}_#{RSpec.current_example.description}".gsub(/\W+/,'_')
+    @screenshot_prefix_usage_counts[prefix] ||= 0
+    next_available_index = (@screenshot_prefix_usage_counts[prefix] += 1)
+    "#{prefix}_#{next_available_index}#{'_' + suffix if suffix.present?}".gsub(/\W+/,'_')
+  end
+
+  def screenshots_enabled?; true; end
+else
+  def screenshot!(*args); end
+  def capture_email!(*args); end
+  def screenshots_enabled?; false; end
+end


### PR DESCRIPTION
Selenium does not support testing response codes (200, 403, 500 etc). Their argument is that it's out of scope.

Also fixed a redirect loop when a logged in non-admin user encountered the `authenticate_admin!` method that was causing the tests to fail.