### PR TITLE
Update claiming account invite flow

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -169,6 +169,8 @@ class Api::V1::UsersController < Api::V1::ApiController
     # OpenStax::Api#standard_(update|create) require an ActiveRecord model, which we don't have
     # Substitue a Hashie::Mash to read the JSON encoded body
     payload = consume!(Hashie::Mash.new, represent_with: Api::V1::FindOrCreateUserRepresenter)
+
+    payload.application = current_api_user.application
     result = FindOrCreateUnclaimedUser.call(payload)
     if result.errors.any?
       render json: { errors: result.errors }, status: :conflict

--- a/app/routines/find_or_create_unclaimed_user.rb
+++ b/app/routines/find_or_create_unclaimed_user.rb
@@ -11,6 +11,7 @@ class FindOrCreateUnclaimedUser
   lev_routine
 
   uses_routine CreateUser, translations: { outputs: { type: :verbatim } }
+  uses_routine FindOrCreateApplicationUser
   uses_routine AddEmailToUser
   uses_routine CreateIdentity
 
@@ -41,6 +42,10 @@ class FindOrCreateUnclaimedUser
 
     # routine is smart and gracefully handles case of missing options[:email]
     run(AddEmailToUser, options[:email], user)
+
+    if options[:application]
+      FindOrCreateApplicationUser[options[:application].id, user.id]
+    end
 
     if options[:password]
       identity = run(CreateIdentity, {

--- a/app/views/contact_infos/confirm_unclaimed.html.erb
+++ b/app/views/contact_infos/confirm_unclaimed.html.erb
@@ -2,18 +2,12 @@
                         :".verification_code_not_found" :
                         :".thanks_for_validating")) do %>
 
-  <% if @handler_result.outputs.can_log_in %>
-    <%= t :".you_can_now_sign_in.content_html",
-          link: (link_to (t :".you_can_now_sign_in.sign_in"),
-                         signin_url)
-        %>
-  <% else %>
-    <%# TODO replace root_url with right value %>
-    <%= t :".please_sign_up.content_html",
-          link: (link_to (t :".please_sign_up.sign_up"),
-                         root_url),
-          email: @handler_result.outputs.email_address
-        %>
-  <% end %>
+<%
+  link = @handler_result.outputs.can_log_in ?
+   link_to(t(".you_can_now_sign_in.reset_password"), password_reset_url) :
+   link_to(t(".you_can_now_sign_in.add_password"), password_add_url)
+%>
+
+<%= t :".you_can_now_sign_in.content_html", link: link %>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,8 +172,9 @@ en:
       you_can_now_sign_in:
         # %{link}   a hyperlink pointing to sing in page. Label of the link
         #           is defined by the .sign_up key.
-        content_html: You can now %{link} to your new account.
-        sign_in: log in
+        content_html: Please %{link} before you can sign into your new account.
+        reset_password: reset your password
+        add_password: set your password
 
   errors:
     please_enable_javascript: >-

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -256,6 +256,7 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       expect(new_user.last_name).to eq 'Test'
       expect(new_user.full_name).to eq 'Sarah Test'
       expect(new_user.role).to eq 'instructor'
+      expect(new_user.applications).to eq [ trusted_application ]
       expect(new_user.uuid).not_to be_blank
     end
 

--- a/spec/controllers/contact_infos_controller_spec.rb
+++ b/spec/controllers/contact_infos_controller_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe ContactInfosController, type: :controller do
     it "returns error if no code given" do
       get 'confirm'
       expect(response.code).to eq('400')
+
       expect(response.body).to have_no_missing_translations
       expect(response.body).to have_content(t :"contact_infos.confirm.verification_code_not_found")
       expect(EmailAddress.find_by_value(@email.value).verified).to be_falsey
@@ -91,10 +92,6 @@ RSpec.describe ContactInfosController, type: :controller do
     it "returns error if no code given" do
       get 'confirm_unclaimed'
       expect(response.code).to eq('400')
-      expect(response.body).to have_no_missing_translations
-      expect(response.body).to(
-        have_content(t :"contact_infos.confirm_unclaimed.verification_code_not_found")
-      )
     end
 
     it "returns success if code matches" do


### PR DESCRIPTION
This way it will either set or reset the password and will redirect back to the
application that created the account once terms are agreed to