### PR TITLE
Allow redirect URIs to contain subdomain wildcards

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -16,6 +16,7 @@ require 'rate_limiting'
 require 'omniauth/strategies/custom_identity'
 require 'email_address_validations'
 require 'subjects_utils'
+require 'doorkeeper_monkeypatching'
 
 SITE_NAME = 'OpenStax Accounts'
 PAGE_TITLE_SUFFIX = SITE_NAME

--- a/lib/doorkeeper_monkeypatching.rb
+++ b/lib/doorkeeper_monkeypatching.rb
@@ -8,7 +8,12 @@ module Doorkeeper
           url = as_uri(url)
           client_url = as_uri(client_url)
           url.query = nil
-          urls_equal_with_wildcard(url, client_url) # was `url == client_url` in original
+
+          if client_url.host.match(/\.a15k\.org$|\.cnx\.org$|\.openstax\.org$/)
+            urls_equal_with_wildcard(url, client_url)
+          else
+            url == client_url # original behavior
+          end
         end
 
         def self.urls_equal_with_wildcard(url, client_url)

--- a/lib/doorkeeper_monkeypatching.rb
+++ b/lib/doorkeeper_monkeypatching.rb
@@ -1,0 +1,29 @@
+
+# Monkeypatch URL matcher to allow for subdomain wildcards
+module Doorkeeper
+  module OAuth
+    module Helpers
+      module URIChecker
+        def self.matches?(url, client_url)
+          url = as_uri(url)
+          client_url = as_uri(client_url)
+          url.query = nil
+          urls_equal_with_wildcard(url, client_url) # was `url == client_url` in original
+        end
+
+        def self.urls_equal_with_wildcard(url, client_url)
+          url = url.dup.normalize  # normalization borrowed from URI::Generic.==
+          client_url = client_url.dup.normalize
+
+          # Treat everything as a literal in the client URL host except for
+          # asterisks, which we convert to .*
+          client_url_host_regexp = Regexp.new(Regexp.escape(client_url.host).gsub("\\*",".*"))
+
+          url.scheme == client_url.scheme &&
+          url.path == client_url.path &&
+          url.host.match(client_url_host_regexp)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/wildcard_redirect_uri_spec.rb
+++ b/spec/features/wildcard_redirect_uri_spec.rb
@@ -7,13 +7,13 @@ feature "Wildcard redirect URIs" do
     create_email_address_for(user, 'user@example.com')
   }
 
-  context "subdomain wildcard" do
+  context "subdomain wildcard on openstax.org" do
     let!(:app) {
-      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.domain.com")
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.openstax.org")
     }
 
     scenario "subdomain works" do
-      test(redirect_uri: "https://sub.domain.com", should_succeed: true)
+      test(redirect_uri: "https://sub.openstax.org", should_succeed: true)
     end
 
     scenario "random other domain doesn't work" do
@@ -21,21 +21,21 @@ feature "Wildcard redirect URIs" do
     end
 
     scenario "top level domain doesn't work" do
-      test(redirect_uri: "https://domain.com", should_succeed: false)
+      test(redirect_uri: "https://openstax.org", should_succeed: false)
     end
 
     scenario "scheme must match" do
-      test(redirect_uri: "http://sub.domain.com", should_succeed: false)
+      test(redirect_uri: "http://sub.openstax.org", should_succeed: false)
     end
   end
 
   context "a normal domain and a subdomain wildcard" do
     let!(:app) {
-      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://domain.com https://*.domain.com")
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://openstax.org https://*.openstax.org")
     }
 
     scenario "subdomain works" do
-      test(redirect_uri: "https://sub.domain.com", should_succeed: true)
+      test(redirect_uri: "https://sub.openstax.org", should_succeed: true)
     end
 
     scenario "random other domain doesn't work" do
@@ -43,21 +43,45 @@ feature "Wildcard redirect URIs" do
     end
 
     scenario "top level domain DOES work" do
-      test(redirect_uri: "https://domain.com", should_succeed: true)
+      test(redirect_uri: "https://openstax.org", should_succeed: true)
+    end
+  end
+
+  context "a non pre approved domain with wildcard" do
+    let!(:app) {
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.other.org")
+    }
+
+    scenario "subdomain DOES NOT works" do
+      test(redirect_uri: "https://sub.other.org", should_succeed: false)
+    end
+  end
+
+  context "approved domains" do
+    let!(:app) {
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.a15k.org https://*.cnx.org")
+    }
+
+    scenario "a15k subdomain works" do
+      test(redirect_uri: "https://sub.a15k.org", should_succeed: true)
+    end
+
+    scenario "cnx subdomain works" do
+      test(redirect_uri: "https://sub.cnx.org", should_succeed: true)
     end
   end
 
   context "a subdomain wildcard with a path" do
     let!(:app) {
-      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.domain.com/howdy/")
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.openstax.org/howdy/")
     }
 
     scenario "subdomain works with good path" do
-      test(redirect_uri: "https://sub.domain.com/howdy/", should_succeed: true)
+      test(redirect_uri: "https://sub.openstax.org/howdy/", should_succeed: true)
     end
 
     scenario "subdomain doesn't work with bad path" do
-      test(redirect_uri: "https://sub.domain.com/there/", should_succeed: false)
+      test(redirect_uri: "https://sub.openstax.org/there/", should_succeed: false)
     end
   end
 

--- a/spec/features/wildcard_redirect_uri_spec.rb
+++ b/spec/features/wildcard_redirect_uri_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+feature "Wildcard redirect URIs" do
+
+  before {
+    user = create_user 'user'
+    create_email_address_for(user, 'user@example.com')
+  }
+
+  context "subdomain wildcard" do
+    let!(:app) {
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.domain.com")
+    }
+
+    scenario "subdomain works" do
+      test(redirect_uri: "https://sub.domain.com", should_succeed: true)
+    end
+
+    scenario "random other domain doesn't work" do
+      test(redirect_uri: "https://blah.com", should_succeed: false)
+    end
+
+    scenario "top level domain doesn't work" do
+      test(redirect_uri: "https://domain.com", should_succeed: false)
+    end
+
+    scenario "scheme must match" do
+      test(redirect_uri: "http://sub.domain.com", should_succeed: false)
+    end
+  end
+
+  context "a normal domain and a subdomain wildcard" do
+    let!(:app) {
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://domain.com https://*.domain.com")
+    }
+
+    scenario "subdomain works" do
+      test(redirect_uri: "https://sub.domain.com", should_succeed: true)
+    end
+
+    scenario "random other domain doesn't work" do
+      test(redirect_uri: "https://blah.com", should_succeed: false)
+    end
+
+    scenario "top level domain DOES work" do
+      test(redirect_uri: "https://domain.com", should_succeed: true)
+    end
+  end
+
+  context "a subdomain wildcard with a path" do
+    let!(:app) {
+      FactoryGirl.create(:doorkeeper_application, :trusted, redirect_uri: "https://*.domain.com/howdy/")
+    }
+
+    scenario "subdomain works with good path" do
+      test(redirect_uri: "https://sub.domain.com/howdy/", should_succeed: true)
+    end
+
+    scenario "subdomain doesn't work with bad path" do
+      test(redirect_uri: "https://sub.domain.com/there/", should_succeed: false)
+    end
+  end
+
+  def test(redirect_uri:, should_succeed:)
+    visit_authorize_uri(app: OpenStruct.new(redirect_uri: redirect_uri, uid: app.uid))
+    complete_login_username_or_email_screen 'user@example.com'
+
+    redirect_uri_path = URI.parse(redirect_uri).path
+
+    if should_succeed && redirect_uri_path.present?
+      # The app will redirect to the redirect_uri and rspec doesn't know what to do with
+      # the made up path
+      expect{
+        complete_login_password_screen 'password'
+      }.to raise_error(ActionController::RoutingError)
+    else
+      complete_login_password_screen 'password'
+
+      if should_succeed
+        expect(page.current_url).to match(redirect_uri)
+      else
+        expect(page.current_url).to match("example.com/oauth/authorize")
+        expect(page).to have_content("redirect uri included is not valid")
+      end
+    end
+  end
+
+end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'whenever schedule' do
-  before(:all) { load 'Rakefile' }
-
   let (:schedule) { Whenever::Test::Schedule.new(file: 'config/schedule.rb') }
 
   context 'basics' do


### PR DESCRIPTION
Let's us put wildcards in subdomains in oauth app redirect URIs, e.g. `https://*.somedomain.com` on an oauth app redirect URI will allow redirect URIs from `https://something.somedomain.com`.