### PR TITLE
Add ability to create banners

### DIFF
--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -1,0 +1,30 @@
+module Admin
+  class BannersController < BaseController
+    layout 'admin'
+
+    def index
+      @banners = Banner.where('expires_at > ?', DateTime.now)
+    end
+
+    def new; end
+
+    def create
+      handle_with(BannersCreate,
+        success: lambda do 
+          flash[:success] = 'Banner created'
+          redirect_to admin_banners_path
+        end,
+        failure: lambda do
+          flash[:alert] = 'Banner created'
+          redirect_to :back
+        end
+      )
+    end
+
+    def destroy
+      banner = Banner.where(id: params[:id]).first
+      banner.destroy
+      redirect_to :back
+    end
+  end
+end

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -9,13 +9,30 @@ module Admin
     def new; end
 
     def create
-      handle_with(BannersCreate,
-        success: lambda do 
+      handle_with(BannersManage,
+        success: lambda do
           flash[:success] = 'Banner created'
           redirect_to admin_banners_path
         end,
         failure: lambda do
-          flash[:alert] = 'Banner created'
+          flash[:alert] = 'Error in saving. Please try again.'
+          redirect_to :back
+        end
+      )
+    end
+
+    def edit
+      @banner = Banner.where(id: params[:id]).first
+    end
+
+    def update
+      handle_with(BannersManage,
+        success: lambda do
+          flash[:success] = 'Banner updated'
+          redirect_to admin_banners_path
+        end,
+        failure: lambda do
+          flash[:alert] = 'Error in saving. Please try again.'
           redirect_to :back
         end
       )

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
 
   # Login form
   def start
-    @banners = Banner.where('expires_at > ?', DateTime.now)
+    @banners = Banner.active
   end
 
   def lookup_login

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,6 +35,7 @@ class SessionsController < ApplicationController
 
   # Login form
   def start
+    @banner_message = Banner.where('expires_at > ?', DateTime.now).first.try(:message)
   end
 
   def lookup_login

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
 
   # Login form
   def start
-    @banner_message = Banner.where('expires_at > ?', DateTime.now).first.try(:message)
+    @banners = Banner.where('expires_at > ?', DateTime.now)
   end
 
   def lookup_login

--- a/app/handlers/admin/banners_create.rb
+++ b/app/handlers/admin/banners_create.rb
@@ -1,0 +1,36 @@
+module Admin
+  class BannersCreate
+
+    lev_handler
+
+    paramify :create do
+      attribute :message, type: String
+      validates :message, presence: true
+    end
+
+    protected
+
+    def authorized?
+      true
+    end
+
+    def handle
+      expires_at_central = string_from_date_select_params(params[:create], :expires_at)
+      expires_at = central_to_utc(expires_at_central)
+      outputs[:banner] = Banner.create(message: create_params.message, expires_at: expires_at)
+    end
+
+    # we could and perhaps should move this method into a shared location
+    # because it's something that Rails should've included
+    # as it's necessary for parsing dates from date_select tags
+    def string_from_date_select_params(params, key)
+      date_parts = params.select { |k,v| k.to_s =~ /\A#{key}\([1-6]{1}i\)/ }.values
+      date_parts[0..2].join('-') + ' ' + date_parts[3..-1].join(':')
+    end
+
+    def central_to_utc(date_string)
+      zone = "Central Time (US & Canada)"
+      ActiveSupport::TimeZone[zone].parse(date_string)
+    end
+  end
+end

--- a/app/handlers/admin/banners_manage.rb
+++ b/app/handlers/admin/banners_manage.rb
@@ -21,12 +21,13 @@ module Admin
         banner.message = params[:banner][:message]
         banner.expires_at = expires_at
         banner.save
+        transfer_errors_from(banner, { type: :verbatim })
       end
     end
 
     def date_from_params_hash(banner_params)
       key = 'expires_at'
-      DateTime.new(*flatten_date_array(banner_params, key))
+      ActiveSupport::TimeZone[Banner::TIME_ZONE].local(*flatten_date_array(banner_params, key))
     end
 
     def flatten_date_array(hash, key)

--- a/app/handlers/admin/banners_manage.rb
+++ b/app/handlers/admin/banners_manage.rb
@@ -1,9 +1,9 @@
 module Admin
-  class BannersCreate
+  class BannersManage
 
     lev_handler
 
-    paramify :create do
+    paramify :banner do
       attribute :message, type: String
       validates :message, presence: true
     end
@@ -15,14 +15,19 @@ module Admin
     end
 
     def handle
-      expires_at_central = string_from_date_select_params(params[:create], :expires_at)
+      expires_at_central = string_from_date_select_params(params[:banner], :expires_at)
       expires_at = central_to_utc(expires_at_central)
-      outputs[:banner] = Banner.create(message: create_params.message, expires_at: expires_at)
+
+      outputs[:banner] = Banner.where(id: params[:id]).first_or_initialize.tap { |banner|
+        banner.message = params[:banner][:message]
+        banner.expires_at = expires_at
+        banner.save
+      }
     end
 
-    # we could and perhaps should move this method into a shared location
+    # consider moving this method into a shared location
     # because it's something that Rails should've included
-    # as it's necessary for parsing dates from date_select tags
+    # as it is necessary for parsing dates from date_select tags
     def string_from_date_select_params(params, key)
       date_parts = params.select { |k,v| k.to_s =~ /\A#{key}\([1-6]{1}i\)/ }.values
       date_parts[0..2].join('-') + ' ' + date_parts[3..-1].join(':')

--- a/app/handlers/admin/banners_manage.rb
+++ b/app/handlers/admin/banners_manage.rb
@@ -15,27 +15,22 @@ module Admin
     end
 
     def handle
-      expires_at_central = string_from_date_select_params(params[:banner], :expires_at)
-      expires_at = central_to_utc(expires_at_central)
+      expires_at = date_from_params_hash(params[:banner])
 
-      outputs[:banner] = Banner.where(id: params[:id]).first_or_initialize.tap { |banner|
+      outputs[:banner] = Banner.where(id: params[:id]).first_or_initialize.tap do |banner|
         banner.message = params[:banner][:message]
         banner.expires_at = expires_at
         banner.save
-      }
+      end
     end
 
-    # consider moving this method into a shared location
-    # because it's something that Rails should've included
-    # as it is necessary for parsing dates from date_select tags
-    def string_from_date_select_params(params, key)
-      date_parts = params.select { |k,v| k.to_s =~ /\A#{key}\([1-6]{1}i\)/ }.values
-      date_parts[0..2].join('-') + ' ' + date_parts[3..-1].join(':')
+    def date_from_params_hash(banner_params)
+      key = 'expires_at'
+      DateTime.new(*flatten_date_array(banner_params, key))
     end
 
-    def central_to_utc(date_string)
-      zone = "Central Time (US & Canada)"
-      ActiveSupport::TimeZone[zone].parse(date_string)
+    def flatten_date_array(hash, key)
+      %w(1 2 3 4 5).map { |e| hash["#{key}(#{e}i)"].to_i }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -155,13 +155,11 @@ module ApplicationHelper
         end
       end
 
-      banners_divs = if banners.present?
-        banners.map do |banner|
-          content_tag :div, class: "top-level-alerts info" do
-            notice_tag(banner.message)
-          end
-        end.join("\n")
-      end
+      banners_divs = banners.map do |banner|
+        content_tag :div, class: "top-level-alerts info" do
+          notice_tag(banner.message)
+        end
+      end.join("\n")
 
       heading_div = if heading.present?
         content_tag(:h1, class: "title") { heading }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
     error.message = yield
   end
 
-  def ox_card(classes: "", heading: "", banner_message: "", &block)
+  def ox_card(classes: "", heading: "", banners: [], &block)
     @hide_layout_errors = true
 
     content_tag :div, class: "ox-card #{classes}" do
@@ -155,10 +155,12 @@ module ApplicationHelper
         end
       end
 
-      banner = if banner_message.present?
-        content_tag :div, class: "top-level-alerts info" do
-          notice_tag(banner_message)
-        end
+      banners_divs = if banners.present?
+        banners.map do |banner|
+          content_tag :div, class: "top-level-alerts info" do
+            notice_tag(banner.message)
+          end
+        end.join("\n")
       end
 
       heading_div = if heading.present?
@@ -167,7 +169,7 @@ module ApplicationHelper
 
       body = capture(&block)
 
-      "#{danger_alerts}\n#{info_alerts}\n#{banner}\n#{heading_div}\n#{body}".html_safe
+      "#{danger_alerts}\n#{info_alerts}\n#{banners_divs}\n#{heading_div}\n#{body}".html_safe
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,10 +138,11 @@ module ApplicationHelper
     error.message = yield
   end
 
-  def ox_card(classes: "", heading: "", &block)
+  def ox_card(classes: "", heading: "", banner_message: "", &block)
     @hide_layout_errors = true
 
     content_tag :div, class: "ox-card #{classes}" do
+
       danger_alerts = if flash[:alert].present?
         content_tag :div, class: "top-level-alerts danger" do
           alert_tag(flash[:alert])
@@ -154,13 +155,19 @@ module ApplicationHelper
         end
       end
 
+      banner = if banner_message.present?
+        content_tag :div, class: "top-level-alerts info" do
+          notice_tag(banner_message)
+        end
+      end
+
       heading_div = if heading.present?
         content_tag(:h1, class: "title") { heading }
       end
 
       body = capture(&block)
 
-      "#{danger_alerts}\n#{info_alerts}\n#{heading_div}\n#{body}".html_safe
+      "#{danger_alerts}\n#{info_alerts}\n#{banner}\n#{heading_div}\n#{body}".html_safe
     end
   end
 

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -1,0 +1,2 @@
+class Banner < ActiveRecord::Base
+end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,8 +5,14 @@ class Banner < ActiveRecord::Base
 
   validates :message, presence: true
   validates :expires_at, presence: true
+  validate :in_future
+
+  def in_future
+    return if expires_at.nil? || expires_at > Time.now
+    errors.add(:base, 'Active Until must be a future time')
+  end
 
   def active_until
-    self.expires_at.strftime("%m/%d/%Y %I:%M%p")
+    expires_at.in_time_zone(TIME_ZONE).strftime("%m/%d/%Y %I:%M%p %Z")
   end
 end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -1,2 +1,10 @@
 class Banner < ActiveRecord::Base
+  scope :active, -> { where('expires_at > ?', DateTime.now) }
+
+  validates :message, presence: true
+  validates :expires_at, presence: true
+
+  def expires_at=(expires_at)
+    super(expires_at).try(:in_time_zone, 'Central Time (US & Canada)')
+  end
 end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -1,10 +1,13 @@
 class Banner < ActiveRecord::Base
+  TIME_ZONE = 'Central Time (US & Canada)'
+
   scope :active, -> { where('expires_at > ?', DateTime.now) }
 
   validates :message, presence: true
   validates :expires_at, presence: true
 
   def expires_at=(expires_at)
-    super(expires_at).try(:in_time_zone, 'Central Time (US & Canada)')
+    with_time_zone = ActiveSupport::TimeZone[TIME_ZONE].parse(expires_at.to_s)
+    super(with_time_zone)
   end
 end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -6,8 +6,7 @@ class Banner < ActiveRecord::Base
   validates :message, presence: true
   validates :expires_at, presence: true
 
-  def expires_at=(expires_at)
-    with_time_zone = ActiveSupport::TimeZone[TIME_ZONE].parse(expires_at.to_s)
-    super(with_time_zone)
+  def active_until
+    self.expires_at.strftime("%m/%d/%Y %I:%M%p")
   end
 end

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -1,5 +1,5 @@
 <div style="width: 100%; max-width: 700px">
-  <%= lev_form_for :banner, url: url, method: method, 
+  <%= lev_form_for :banner, url: url, method: method,
                    html: {id: 'create-user-form', class: 'form-horizontal'} do |f| %>
 
     <div class='form-group'>
@@ -11,11 +11,11 @@
     <div class='form-group'>
       <label class='col-sm-3 control-label'>Expires at</label>
       <div class='col-sm-9 input-group'>
-        <%= f.datetime_select :expires_at, 
+        <%= f.datetime_select :expires_at,
             default: DateTime.now.in_time_zone('Central Time (US & Canada)'),
             ampm: true,
             minute_step: 10,
-            class: 'form-control' 
+            class: 'form-control'
         %>
         Central Time (US & Canada)
       </div>

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -12,12 +12,12 @@
       <label class='col-sm-3 control-label'>Expires at</label>
       <div class='col-sm-9 input-group'>
         <%= f.datetime_select :expires_at,
-            default: DateTime.now.in_time_zone('Central Time (US & Canada)'),
+            default: DateTime.now.in_time_zone(Banner::TIME_ZONE),
             ampm: true,
             minute_step: 10,
             class: 'form-control'
         %>
-        Central Time (US & Canada)
+        <%= Banner::TIME_ZONE %>
       </div>
     </div>
     <div class='form-group'>

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -1,0 +1,30 @@
+<div style="width: 100%; max-width: 700px">
+  <%= lev_form_for :banner, url: url, method: method, 
+                   html: {id: 'create-user-form', class: 'form-horizontal'} do |f| %>
+
+    <div class='form-group'>
+      <label class='col-sm-3 control-label'>Message</label>
+      <div class='col-sm-9'>
+        <%= f.text_field :message, class: 'form-control' %>
+      </div>
+    </div>
+    <div class='form-group'>
+      <label class='col-sm-3 control-label'>Expires at</label>
+      <div class='col-sm-9 input-group'>
+        <%= f.datetime_select :expires_at, 
+            default: DateTime.now.in_time_zone('Central Time (US & Canada)'),
+            ampm: true,
+            minute_step: 10,
+            class: 'form-control' 
+        %>
+        Central Time (US & Canada)
+      </div>
+    </div>
+    <div class='form-group'>
+      <div class='col-sm-offset-3 col-sm-9'>
+        <%= f.submit button_text, class: 'btn btn-primary' %>
+      </div>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class='form-group'>
-      <label class='col-sm-3 control-label'>Expires at</label>
+      <label class='col-sm-3 control-label'>Active until</label>
       <div class='col-sm-9 input-group'>
         <%= f.datetime_select :expires_at,
             default: DateTime.now.in_time_zone(Banner::TIME_ZONE),

--- a/app/views/admin/banners/edit.html.erb
+++ b/app/views/admin/banners/edit.html.erb
@@ -1,0 +1,3 @@
+<% @page_header = "Edit banner" %>
+
+<%= render partial: 'form', locals: { url: admin_banner_path, method: :put, button_text: 'Update' } %>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -13,7 +13,7 @@
   <% @banners.each do |banner| %>
     <% zebra = cycle('odd', 'even') %>
     <tr class="<%= zebra %>">
-      <td><%= banner.expires_at.in_time_zone('Central Time (US & Canada)').strftime("%m/%d/%Y %I:%M%p") %></td>
+      <td><%= banner.expires_at.in_time_zone('UTC').strftime("%m/%d/%Y %I:%M%p") %></td>
       <td><%= banner.message %></td>
       <td><%= link_to('Edit', edit_admin_banner_path(banner.id)) %></td>
       <td><%= link_to('Delete', admin_banner_path(banner.id), method: :delete) %></td>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -13,7 +13,7 @@
   <% @banners.each do |banner| %>
     <% zebra = cycle('odd', 'even') %>
     <tr class="<%= zebra %>">
-      <td><%= banner.expires_at.in_time_zone('UTC').strftime("%m/%d/%Y %I:%M%p") %></td>
+      <td><%= banner.expires_at.strftime("%m/%d/%Y %I:%M%p") %></td>
       <td><%= banner.message %></td>
       <td><%= link_to('Edit', edit_admin_banner_path(banner.id)) %></td>
       <td><%= link_to('Delete', admin_banner_path(banner.id), method: :delete) %></td>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -1,0 +1,20 @@
+<% @page_header = "Active Banners" %>
+
+
+<table id="search-results-list">
+
+  <tr>
+    <th style="width: 20%">Expires at</th>
+    <th>Message</th>
+    <th>Delete</th>
+  </tr>
+
+  <% @banners.each do |banner| %>
+    <% zebra = cycle('odd', 'even') %>
+    <tr class="<%= zebra %>">
+      <td><%= banner.expires_at.in_time_zone('Central Time (US & Canada)').strftime("%m/%d/%Y %I:%M%p") %></td>
+      <td><%= banner.message %></td>
+      <td><%= link_to('Delete', admin_banner_path(banner.id), method: :delete) %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -4,7 +4,7 @@
 <table id="search-results-list">
 
   <tr>
-    <th style="width: 20%">Expires at</th>
+    <th style="width: 20%">Active until</th>
     <th>Message</th>
     <th>Edit</th>
     <th>Delete</th>
@@ -13,7 +13,7 @@
   <% @banners.each do |banner| %>
     <% zebra = cycle('odd', 'even') %>
     <tr class="<%= zebra %>">
-      <td><%= banner.expires_at.strftime("%m/%d/%Y %I:%M%p") %></td>
+      <td><%= banner.active_until %></td>
       <td><%= banner.message %></td>
       <td><%= link_to('Edit', edit_admin_banner_path(banner.id)) %></td>
       <td><%= link_to('Delete', admin_banner_path(banner.id), method: :delete) %></td>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -6,6 +6,7 @@
   <tr>
     <th style="width: 20%">Expires at</th>
     <th>Message</th>
+    <th>Edit</th>
     <th>Delete</th>
   </tr>
 
@@ -14,6 +15,7 @@
     <tr class="<%= zebra %>">
       <td><%= banner.expires_at.in_time_zone('Central Time (US & Canada)').strftime("%m/%d/%Y %I:%M%p") %></td>
       <td><%= banner.message %></td>
+      <td><%= link_to('Edit', edit_admin_banner_path(banner.id)) %></td>
       <td><%= link_to('Delete', admin_banner_path(banner.id), method: :delete) %></td>
     </tr>
   <% end %>

--- a/app/views/admin/banners/new.html.erb
+++ b/app/views/admin/banners/new.html.erb
@@ -1,32 +1,3 @@
-<h4>Create a new banner</h4>
+<% @page_header = "Create a new banner" %>
 
-<div style="width: 100%; max-width: 700px">
-  <%= lev_form_for :create, url: admin_banners_path, remote: false, 
-                   html: {id: 'create-user-form', class: 'form-horizontal'} do |f| %>
-
-    <div class='form-group'>
-      <label class='col-sm-3 control-label'>Message</label>
-      <div class='col-sm-9'>
-        <%= f.text_field :message, class: 'form-control' %>
-      </div>
-    </div>
-    <div class='form-group'>
-      <label class='col-sm-3 control-label'>Expires at</label>
-      <div class='col-sm-9 input-group'>
-        <%= f.datetime_select :expires_at, 
-            default: DateTime.now.in_time_zone('Central Time (US & Canada)'),
-            ampm: true,
-            minute_step: 10,
-            class: 'form-control' 
-        %>
-        Central Time (US & Canada)
-      </div>
-    </div>
-    <div class='form-group'>
-      <div class='col-sm-offset-3 col-sm-9'>
-        <%= f.submit 'Create', class: 'btn btn-primary' %>
-      </div>
-    </div>
-
-  <% end %>
-</div>
+<%= render partial: 'form', locals: { url: admin_banners_path, method: :post, button_text: 'Create' } %>

--- a/app/views/admin/banners/new.html.erb
+++ b/app/views/admin/banners/new.html.erb
@@ -1,0 +1,32 @@
+<h4>Create a new banner</h4>
+
+<div style="width: 100%; max-width: 700px">
+  <%= lev_form_for :create, url: admin_banners_path, remote: false, 
+                   html: {id: 'create-user-form', class: 'form-horizontal'} do |f| %>
+
+    <div class='form-group'>
+      <label class='col-sm-3 control-label'>Message</label>
+      <div class='col-sm-9'>
+        <%= f.text_field :message, class: 'form-control' %>
+      </div>
+    </div>
+    <div class='form-group'>
+      <label class='col-sm-3 control-label'>Expires at</label>
+      <div class='col-sm-9 input-group'>
+        <%= f.datetime_select :expires_at, 
+            default: DateTime.now.in_time_zone('Central Time (US & Canada)'),
+            ampm: true,
+            minute_step: 10,
+            class: 'form-control' 
+        %>
+        Central Time (US & Canada)
+      </div>
+    </div>
+    <div class='form-group'>
+      <div class='col-sm-offset-3 col-sm-9'>
+        <%= f.submit 'Create', class: 'btn btn-primary' %>
+      </div>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -59,6 +59,15 @@
             </li>
 
             <li><%= link_to 'Settings', main_app.admin_rails_settings_ui_path %></li>
+
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Banners<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><%= link_to 'See active', main_app.admin_banners_path %></li>
+                <li><%= link_to 'New', main_app.new_admin_banner_path %></li>
+              </ul>
+            </li>
+
             <li><%= link_to 'Terms', main_app.fine_print_path %></li>
 
 <% if false %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -64,7 +64,7 @@
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Banners<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><%= link_to 'See active', main_app.admin_banners_path %></li>
-                <li><%= link_to 'New', main_app.new_admin_banner_path %></li>
+                <li><%= link_to 'Create new', main_app.new_admin_banner_path %></li>
               </ul>
             </li>
 

--- a/app/views/sessions/start.html.erb
+++ b/app/views/sessions/start.html.erb
@@ -27,7 +27,7 @@
   end
 %>
 
-<%= ox_card(classes: "login", heading: (t :".page_heading")) do %>
+<%= ox_card(classes: "login", heading: (t :".page_heading"), banner_message: @banner_message) do %>
 
   <%= lev_form_for :login, url: lookup_login_path do |f| %>
 

--- a/app/views/sessions/start.html.erb
+++ b/app/views/sessions/start.html.erb
@@ -27,7 +27,7 @@
   end
 %>
 
-<%= ox_card(classes: "login", heading: (t :".page_heading"), banner_message: @banner_message) do %>
+<%= ox_card(classes: "login", heading: (t :".page_heading"), banners: @banners) do %>
 
   <%= lev_form_for :login, url: lookup_login_path do |f| %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,7 +202,7 @@ Rails.application.routes.draw do
 
     resources :pre_auth_states, only: [:index]
 
-    resources :banners
+    resources :banners, except: :show
 
     mount RailsSettingsUi::Engine, at: 'settings'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,8 @@ Rails.application.routes.draw do
 
     resources :pre_auth_states, only: [:index]
 
+    resources :banners, only: [:index, :new, :create, :destroy]
+
     mount RailsSettingsUi::Engine, at: 'settings'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,7 +202,7 @@ Rails.application.routes.draw do
 
     resources :pre_auth_states, only: [:index]
 
-    resources :banners, only: [:index, :new, :create, :destroy]
+    resources :banners
 
     mount RailsSettingsUi::Engine, at: 'settings'
   end

--- a/db/migrate/20180717223039_create_banners.rb
+++ b/db/migrate/20180717223039_create_banners.rb
@@ -1,0 +1,10 @@
+class CreateBanners < ActiveRecord::Migration
+  def change
+    create_table :banners do |t|
+      t.string :message, null: false
+      t.datetime :expires_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180719225955_add_index_on_banner_expires_at.rb
+++ b/db/migrate/20180719225955_add_index_on_banner_expires_at.rb
@@ -1,0 +1,5 @@
+class AddIndexOnBannerExpiresAt < ActiveRecord::Migration
+  def change
+    add_index :banners, :expires_at
+  end
+end

--- a/db/migrate/20180720141256_not_null_banner_expires_at.rb
+++ b/db/migrate/20180720141256_not_null_banner_expires_at.rb
@@ -1,0 +1,5 @@
+class NotNullBannerExpiresAt < ActiveRecord::Migration
+  def change
+    change_column_null :banners, :expires_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180717223039) do
+ActiveRecord::Schema.define(version: 20180720141256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20180717223039) do
 
   create_table "banners", force: :cascade do |t|
     t.string   "message",    :null=>false
-    t.datetime "expires_at"
+    t.datetime "expires_at", :null=>false, :index=>{:name=>"index_banners_on_expires_at"}
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180312223738) do
+ActiveRecord::Schema.define(version: 20180717223039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,13 @@ ActiveRecord::Schema.define(version: 20180312223738) do
     t.datetime "created_at", :null=>false
     t.datetime "updated_at", :null=>false
     t.string   "login_hint"
+  end
+
+  create_table "banners", force: :cascade do |t|
+    t.string   "message",    :null=>false
+    t.datetime "expires_at"
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "contact_infos", force: :cascade do |t|

--- a/spec/controllers/admin/banners_controller.rb
+++ b/spec/controllers/admin/banners_controller.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Admin::BannersController, type: :controller do
+  let(:admin) { FactoryGirl.create :user, :admin, :terms_agreed }
+
+  before(:each) do
+    controller.sign_in! admin
+  end
+
+  it 'finds active (unexpired) banners' do
+    2.times {
+      Banner.create!(expires_at: 8.hours.from_now, message: 'This is a banner.')
+    }
+    Banner.create!(expires_at: 1.second.ago, message: 'This is an inactive/expired banner.')
+    get :index
+    expect(assigns(:banners).count).to eq 2
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe SessionsController, type: :controller do
 
   context '#start' do
-    it 'looks for a banner, the first banner in the database' do
+    it 'looks for active banners (ones whose expires_at is in the future)' do
       expected = Banner.create!(expires_at: 1.hour.from_now, message: 'aoidfhllakdjf').message
       get :start
-      expect(assigns(:banner_message)).to eq expected
+      expect(assigns(:banners).first.message).to eq expected
     end
 
     context 'with no banners in the database' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,6 +2,20 @@ require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
 
+  context '#start' do
+    it 'looks for a banner, the first banner in the database' do
+      expected = Banner.create!(expires_at: 1.hour.from_now, message: 'aoidfhllakdjf').message
+      get :start
+      expect(assigns(:banner_message)).to eq expected
+    end
+
+    context 'with no banners in the database' do
+      it 'success' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
   context '#create' do
     context 'invalid_omniauth_data' do
       it 'sends the user back to the home page with a message' do

--- a/spec/factories/banners.rb
+++ b/spec/factories/banners.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :banner do
-    message "MyString"
-    expires_at "2018-07-17 17:30:39"
+    message "This is a banner."
+    expires_at DateTime.now + 1.day
   end
 end

--- a/spec/factories/banners.rb
+++ b/spec/factories/banners.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :banner do
+    message "MyString"
+    expires_at "2018-07-17 17:30:39"
+  end
+end

--- a/spec/features/admin/create_banners_spec.rb
+++ b/spec/features/admin/create_banners_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature 'Create banners', js: true do
+  context 'as an admin user' do
+    before(:each) do
+      @admin_user = create_admin_user
+      visit '/'
+      complete_login_username_or_email_screen('admin')
+      complete_login_password_screen('password')
+    end
+
+    it 'can visit the banners page' do
+      visit '/admin/banners'
+      expect(page).not_to have_content("We had some unexpected")
+    end
+
+    it 'displays same time (therefore in the same timezone) that it was assigned' do
+      visit '/admin/banners/new'
+      fill_in 'banner[message]', with: 'whatever'
+      select "#{Time.current.year + 1}", from: 'banner[expires_at(1i)]'
+      select '05 PM', from: 'banner[expires_at(4i)]'
+      click_button 'Create'
+      expect(page).to have_content('05:00PM')
+    end
+  end
+end

--- a/spec/features/admin/create_banners_spec.rb
+++ b/spec/features/admin/create_banners_spec.rb
@@ -15,12 +15,17 @@ feature 'Create banners', js: true do
     end
 
     it 'displays same time (therefore in the same timezone) that it was assigned' do
+      time = DateTime.now.in_time_zone(Banner::TIME_ZONE) + 1.year
+
       visit '/admin/banners/new'
       fill_in 'banner[message]', with: 'whatever'
-      select "#{Time.current.year + 1}", from: 'banner[expires_at(1i)]'
-      select '05 PM', from: 'banner[expires_at(4i)]'
+      select "#{time.year}", from: 'banner[expires_at(1i)]'
+      select '05 PM', from: 'banner[expires_at(4i)]' # 5PM Central
+      select '00', from: 'banner[expires_at(5i)]'
       click_button 'Create'
-      expect(page).to have_content('05:00PM')
+
+      expect(page).to have_content('05:00PM') # 5PM Central
+      expect(Banner.last.expires_at).to eq(time.midnight + 17.hours)
     end
   end
 end

--- a/spec/handlers/admin/banners_create_spec.rb
+++ b/spec/handlers/admin/banners_create_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Admin::BannersCreate, type: :handler do
+
+  # let!(:user) { FactoryGirl.create :user }
+  let(:valid_params) {
+    {
+      create: {
+        expires_at: 12.hours.from_now,
+        message: 'This is a banner message.'
+      }
+    }
+  }
+
+  context 'success' do
+    it 'creates a new Banner' do
+      banner = described_class.call(params: valid_params).outputs[:banner]
+
+      expect(banner).to be_persisted
+      expect(banner.message).not_to be_blank
+    end
+  end
+end

--- a/spec/handlers/admin/banners_manage_spec.rb
+++ b/spec/handlers/admin/banners_manage_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 describe Admin::BannersManage, type: :handler do
 
-  # let!(:user) { FactoryGirl.create :user }
   let(:valid_params) {
     {
       banner: {
         message: 'This is a banner message.',
         # this is how expires_at datetime_select tag posts the params
-        "expires_at(1i)"=>"2018",
+        "expires_at(1i)"=>"2030",
         "expires_at(2i)"=>"7",
         "expires_at(3i)"=>"31",
         "expires_at(4i)"=>"11",

--- a/spec/handlers/admin/banners_manage_spec.rb
+++ b/spec/handlers/admin/banners_manage_spec.rb
@@ -1,13 +1,18 @@
 require 'rails_helper'
 
-describe Admin::BannersCreate, type: :handler do
+describe Admin::BannersManage, type: :handler do
 
   # let!(:user) { FactoryGirl.create :user }
   let(:valid_params) {
     {
-      create: {
-        expires_at: 12.hours.from_now,
-        message: 'This is a banner message.'
+      banner: {
+        message: 'This is a banner message.',
+        # this is how expires_at datetime_select tag posts the params
+        "expires_at(1i)"=>"2018",
+        "expires_at(2i)"=>"7",
+        "expires_at(3i)"=>"31",
+        "expires_at(4i)"=>"11",
+        "expires_at(5i)"=>"30"
       }
     }
   }

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Banner, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Banner, type: :model do
   end
 
   describe "timezone" do
-    it "saves UTC in the database" do
+    it "gives back time in the same timezone that was put in" do
       central_time = 'Wed, 01 Aug 2018 17:11:52 -0500'
       utc_time = 'Wed, 01 Aug 2018 22:11:52 UTC +00:00'
       banner = Banner.create(message: 'wtvr', expires_at: central_time)
-      expect(Banner.pluck(:expires_at)).to eq([central_time])
+      expect(Banner.last.expires_at).to eq(central_time)
     end
   end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -7,17 +7,8 @@ RSpec.describe Banner, type: :model do
   describe "#active_until" do
     it "nicely formats expires_at as string" do
       subject.expires_at = DateTime.new(2024, 8, 18, 3, 33)
-      expected = '08/18/2024 03:33AM'
+      expected = '08/17/2024 10:33PM CDT'
       expect(subject.active_until).to eq(expected)
-    end
-  end
-
-  describe "timezone" do
-    it "gives back time in the same timezone that was put in" do
-      central_time = 'Wed, 01 Aug 2018 17:11:52 -0500'
-      utc_time = 'Wed, 01 Aug 2018 22:11:52 UTC +00:00'
-      banner = Banner.create(message: 'wtvr', expires_at: central_time)
-      expect(Banner.last.expires_at).to eq(central_time)
     end
   end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -11,4 +11,13 @@ RSpec.describe Banner, type: :model do
       expect(subject.active_until).to eq(expected)
     end
   end
+
+  describe "timezone" do
+    it "saves UTC in the database" do
+      central_time = 'Wed, 01 Aug 2018 17:11:52 -0500'
+      utc_time = 'Wed, 01 Aug 2018 22:11:52 UTC +00:00'
+      banner = Banner.create(message: 'wtvr', expires_at: central_time)
+      expect(Banner.pluck(:expires_at)).to eq([central_time])
+    end
+  end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -3,4 +3,12 @@ require 'rails_helper'
 RSpec.describe Banner, type: :model do
   it { should validate_presence_of :message }
   it { should validate_presence_of :expires_at }
+
+  describe "#active_until" do
+    it "nicely formats expires_at as string" do
+      subject.expires_at = DateTime.new(2024, 8, 18, 3, 33)
+      expected = '08/18/2024 03:33AM'
+      expect(subject.active_until).to eq(expected)
+    end
+  end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Banner, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should validate_presence_of :message }
+  it { should validate_presence_of :expires_at }
 end


### PR DESCRIPTION
This PR adds the ability to create alert-like banners to the main page/login form, to be used when parts of the system are down, like Facebook login.

Note: we (meaning I) may still have to add more more tests and we may want to move all the timezone logic to a shared location like application helper.

![screen shot 2018-07-19 at 12 05 04 pm](https://user-images.githubusercontent.com/6620941/42958735-0fec1c3a-8b4c-11e8-9f43-0970ad6d7c87.png)
[Create]
===
![screen shot 2018-07-19 at 12 06 26 pm](https://user-images.githubusercontent.com/6620941/42958798-37c75792-8b4c-11e8-8109-97fbe5904df3.png)
[View all]
===
![screen shot 2018-07-19 at 12 06 12 pm](https://user-images.githubusercontent.com/6620941/42958794-35182ff8-8b4c-11e8-8f99-fc24d98963df.png)
