### PR TITLE
Fix Bug: Accounts 500 error for bad login attempts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
     error.message = yield
   end
 
-  def ox_card(classes: "", heading: "", banners: [], &block)
+  def ox_card(classes: "", heading: "", banners: nil, &block)
     @hide_layout_errors = true
 
     content_tag :div, class: "ox-card #{classes}" do
@@ -155,6 +155,7 @@ module ApplicationHelper
         end
       end
 
+      banners ||= []
       banners_divs = banners.map do |banner|
         content_tag :div, class: "top-level-alerts info" do
           notice_tag(banner.message)

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -37,6 +37,14 @@ feature 'User logs in', js: true do
     end
   end
 
+  scenario 'with wrong username or email' do
+    with_forgery_protection do
+      arrive_from_app
+      complete_login_username_or_email_screen 'user' # bad
+      expect(page).to_not have_content("We had some unexpected") # 500 error msg
+    end
+  end
+
   scenario 'with an unknown username' do
     with_forgery_protection do
       arrive_from_app


### PR DESCRIPTION
Fixes a low priority bug related to the banners in login form when someone enters an incorrect password. Issue https://github.com/openstax/accounts/issues/615