### PR TITLE
Send Analytics if in Production

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.env.production? and Settings::GoogleAnalytics.send_google_analytics == true and !Settings::GoogleAnalytics.google_analytics_code.blank?  %>
+<% if (Rails.env.production? or Settings::GoogleAnalytics.send_google_analytics == true) and !Settings::GoogleAnalytics.google_analytics_code.blank?  %>
 <script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Previous PR https://github.com/openstax/accounts/pull/608
turned off Google Analytics unless the environment was production _and_ `send_google_analytics` was `true`. But it set `send_google_analytics` to `false`.
This PR sends Analytics if in Production, regardless of the `send_google_analytics` setting.