### PR TITLE
add specs that fail for sso cookie jar

### DIFF
--- a/config/initializers/sso_cookies.rb
+++ b/config/initializers/sso_cookies.rb
@@ -1,5 +1,7 @@
 # https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/cookies.rb
 
+# Note: when we upgrade to Rails 5, everyone will be logged out of SSO.
+
 # The base class in Rails 5 is EncryptedKeyRotatingCookieJar
 class SsoEncryptedCookieJar < ActionDispatch::Cookies::EncryptedCookieJar
   # Rails 5: def initialize(parent_jar)
@@ -8,7 +10,7 @@ class SsoEncryptedCookieJar < ActionDispatch::Cookies::EncryptedCookieJar
 
     @encryptor = ActiveSupport::MessageEncryptor.new(
       Rails.application.secrets.sso['shared_secret'],
-      cipher: 'aes-256-gcm',
+      cipher: 'aes-256-cbc',
       serializer: ActiveSupport::MessageEncryptor::NullSerializer
     )
   end

--- a/spec/lib/sso_cookie_jar_spec.rb
+++ b/spec/lib/sso_cookie_jar_spec.rb
@@ -18,12 +18,8 @@ RSpec.describe SsoCookieJar do
       value: { foo: :bar }
     }
 
-    # works
-    expect(sso_cookie_jar['some_name']).not_to be_blank
-
-    # fails - down in activesupport-4.2.7.1/lib/active_support/message_encryptor.rb:92,
-    # `cipher.final` raises a `OpenSSL::Cipher::CipherError`
-    expect(sso_cookie_jar.encrypted['some_name']).not_to be_blank
+    expect(sso_cookie_jar['some_name']).not_to be_blank # encrypted so hard to predict real value
+    expect(sso_cookie_jar.encrypted['some_name']).to eq ({ foo: :bar })
   end
 
 end

--- a/spec/lib/sso_cookie_jar_spec.rb
+++ b/spec/lib/sso_cookie_jar_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SsoCookieJar do
+
+  let(:mock_request) {
+    OpenStruct.new(
+      env: {
+        ActionDispatch::Cookies::GENERATOR_KEY => Rails.application.key_generator
+      },
+      cookies: {}
+    )
+  }
+
+  it "can write a cookie and read it back" do
+    sso_cookie_jar = SsoCookieJar.build(mock_request)
+
+    sso_cookie_jar.encrypted['some_name'] = {
+      value: { foo: :bar }
+    }
+
+    # works
+    expect(sso_cookie_jar['some_name']).not_to be_blank
+
+    # fails - down in activesupport-4.2.7.1/lib/active_support/message_encryptor.rb:92,
+    # `cipher.final` raises a `OpenSSL::Cipher::CipherError`
+    expect(sso_cookie_jar.encrypted['some_name']).not_to be_blank
+  end
+
+end

--- a/spec/lib/user_session_management_spec.rb
+++ b/spec/lib/user_session_management_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe UserSessionManagement, type: :lib do
       expect(controller.get_alternate_signup_url).to be_nil
     end
 
-    it 'sets the SSO cookie' do
+    it 'can read the current SSO user' do
       controller.sign_in! user_1
       expect(controller.current_sso_user).to eq user_1
     end

--- a/spec/lib/user_session_management_spec.rb
+++ b/spec/lib/user_session_management_spec.rb
@@ -174,6 +174,11 @@ RSpec.describe UserSessionManagement, type: :lib do
       controller.set_alternate_signup_url(nil)
       expect(controller.get_alternate_signup_url).to be_nil
     end
+
+    it 'sets the SSO cookie' do
+      controller.sign_in! user_1
+      expect(controller.current_sso_user).to eq user_1
+    end
   end
 
   context 'signed in user' do


### PR DESCRIPTION
I can manually verify that the SSO cookie is getting set (within Rails), but was unable to pull the value out of it (just got `nil` back).  Wrote specs that show this.