### PR TITLE
Remove all the exernal uuids from an account

### DIFF
--- a/app/controllers/admin/contact_infos_controller.rb
+++ b/app/controllers/admin/contact_infos_controller.rb
@@ -12,5 +12,10 @@ module Admin
       end
     end
 
+    def destroy
+      contact_info = ContactInfo.find(params[:id])
+      contact_info.delete
+      redirect_to edit_admin_user_path(contact_info.user)
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -31,6 +31,9 @@ module Admin
           security_log :admin_deleted, user_id: params[:id], username: @user.username \
             if !@user.is_administrator && was_administrator
 
+          security_log :trusted_launch_removed, user_id: params[:id], username: @user.username \
+            if params[:user][:trusted_launch_user] == '0'
+
           format.html { redirect_to edit_admin_user_path(@user),
                         notice: 'User profile was successfully updated.' }
         else
@@ -122,7 +125,9 @@ module Admin
       @user.is_test = params[:user][:is_test]
       @user.faculty_status = params[:user][:faculty_status] if params[:user][:faculty_status]
       @user.school_type = params[:user][:school_type] if params[:user][:school_type]
-
+      if @user.external_uuids.any? && params[:user][:trusted_launch_user] == '0'
+        @user.external_uuids.destroy_all
+      end
       user_params = params[:user].slice(:first_name, :last_name, :username)
 
       @user.update_attributes(user_params)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,7 +32,7 @@ module Admin
             if !@user.is_administrator && was_administrator
 
           security_log :trusted_launch_removed, user_id: params[:id], username: @user.username \
-            if params[:user][:trusted_launch_user] == '0'
+            if params[:user][:keep_external_uuids] == '0'
 
           format.html { redirect_to edit_admin_user_path(@user),
                         notice: 'User profile was successfully updated.' }
@@ -125,7 +125,7 @@ module Admin
       @user.is_test = params[:user][:is_test]
       @user.faculty_status = params[:user][:faculty_status] if params[:user][:faculty_status]
       @user.school_type = params[:user][:school_type] if params[:user][:school_type]
-      if @user.external_uuids.any? && params[:user][:trusted_launch_user] == '0'
+      if @user.external_uuids.any? && params[:user][:keep_external_uuids] == '0'
         @user.external_uuids.destroy_all
       end
       user_params = params[:user].slice(:first_name, :last_name, :username)

--- a/app/models/security_log.rb
+++ b/app/models/security_log.rb
@@ -46,7 +46,8 @@ class SecurityLog < ActiveRecord::Base
     :contact_info_confirmed_by_admin,
     :authentication_transfer_failed,
     :login_not_found,
-    :faculty_verified
+    :faculty_verified,
+    :trusted_launch_removed,
   ]
 
   json_serialize :event_data, Hash

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -221,7 +221,7 @@
     <%= f.label :trusted_launch_user, 'External authentications?', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <div class="checkbox">
-        <%= f.check_box :trusted_launch_user, checked: true, style: 'margin-left: 0px'  %>
+        <%= f.check_box :keep_external_uuids, checked: true, style: 'margin-left: 0px'  %>
         <i style="margin-left: 1rem">(Unchecking will remove all links between this account and external systems such as LMS)</i>
       </div>
     </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -125,7 +125,13 @@
     <%= f.label :email_addresses, class: "col-sm-2 control-label" %>
     <ul class="col-sm-10 form-control-static">
     <% @user.email_addresses.each do |email| %>
-      <li style="margin-left: 20px;">
+    <li style="margin-left: 20px;">
+
+      <%= link_to raw('<i class="fa fa-trash" aria-hidden="false"></i>'),
+          admin_delete_contact_info_path(email),
+          method: :delete,
+          data: {confirm: "Are you sure you want to delete \"#{email.value}\" ?"}
+          %>
       <%= email.value %>
       <% if email.verified %>
         (Confirmed)
@@ -209,6 +215,17 @@
       </div>
     </div>
   </div>
+
+  <% if @user.external_uuids.any? %>
+  <div class="form-group">
+    <%= f.label :trusted_launch_user, 'Trusted Launch User?', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10">
+      <div class="checkbox">
+        <%= f.check_box :trusted_launch_user, checked: true, style: 'margin-left: 0px'  %>
+      </div>
+    </div>
+  </div>
+  <% end %>
 
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -218,10 +218,11 @@
 
   <% if @user.external_uuids.any? %>
   <div class="form-group">
-    <%= f.label :trusted_launch_user, 'Trusted Launch User?', class: "col-sm-2 control-label" %>
+    <%= f.label :trusted_launch_user, 'External authentications?', class: "col-sm-2 control-label" %>
     <div class="col-sm-10">
       <div class="checkbox">
         <%= f.check_box :trusted_launch_user, checked: true, style: 'margin-left: 0px'  %>
+        <i style="margin-left: 1rem">(Unchecking will remove all links between this account and external systems such as LMS)</i>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,8 @@ Rails.application.routes.draw do
 
     resource :security_log, only: [:show]
 
+    delete :delete_contact_info, path: '/contact_infos/:id/verify',
+         controller: :contact_infos, action: :destroy
     post :verify_contact_info, path: '/contact_infos/:id/verify',
          controller: :contact_infos, action: :verify
 

--- a/spec/controllers/admin/contact_infos_controller_spec.rb
+++ b/spec/controllers/admin/contact_infos_controller_spec.rb
@@ -3,15 +3,25 @@ require 'rails_helper'
 RSpec.describe Admin::ContactInfosController, type: :controller do
   let!(:user) { FactoryGirl.create :user_with_emails }
   let(:admin) { FactoryGirl.create :user, :admin, :terms_agreed }
+  let(:email) { user.email_addresses.first }
 
   before(:each) do
     controller.sign_in! admin
   end
 
   it 'marks contact info as verified' do
-    email = user.email_addresses.first
     post :verify, id: email.id
     expect(email.reload.verified).to be true
     expect(response.body).to eq '(Confirmed)'
   end
+
+  describe '#delete contact_info' do
+    it 'removes a contact info' do
+      MarkContactInfoVerified.call(email)
+      delete :destroy, id: email.id
+      expect{ email.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Admin::UsersController, type: :controller do
     end
   end
 
+  describe 'trusted lauch removal' do
+    it 'removes all the external uuids' do
+      user.external_uuids.create!({ uuid: SecureRandom.uuid })
+      put :update, id: user.id,
+          user: { trusted_launch_user: '0' }
+
+      expect(user.external_uuids.reload.none?).to be true
+    end
+  end
+
   describe "PUT #mark_users_updated" do
     it "should update unread_updates at a button push" do
       FactoryGirl.create :application_user, unread_updates: 1

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Admin::UsersController, type: :controller do
     it 'removes all the external uuids' do
       user.external_uuids.create!({ uuid: SecureRandom.uuid })
       put :update, id: user.id,
-          user: { trusted_launch_user: '0' }
+          user: { keep_external_uuids: '0' }
 
       expect(user.external_uuids.reload.none?).to be true
     end


### PR DESCRIPTION
This is needed so that an LMS launch can be re-associated with a different user

![image](https://user-images.githubusercontent.com/79566/52145963-0bcc5a80-2628-11e9-8c27-ac0935ad2988.png)

