### PR TITLE
generate sso cookie using it's own key and salt

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -74,6 +74,7 @@ development:
   sso:
     shared_secret: <%= ENV["SSO_SHARED_SECRET"] ||
                        '265127c36133669bedcf47f326e64e22623c1be35fffe04199f0d86bf45a3485' %>
+    shared_secret_salt: <%= ENV["SSO_SHARED_SECRET_SALT"] || 'ox-shared-salt' %>
     cookie:
       name: <%= ENV["SSO_COOKIE_NAME"] || 'ox' %>
       options:
@@ -135,6 +136,7 @@ test:
   # Single Sign On
   sso:
     shared_secret: 54eb2d4915da54b0ab3b0486c2c4d3e6840264d415b936c663f45da4db90aa37
+    shared_secret_salt: ox-shared-salt
     cookie:
       name: ox
       options:

--- a/spec/lib/sso_cookie_jar_spec.rb
+++ b/spec/lib/sso_cookie_jar_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe SsoCookieJar do
 
   let(:mock_request) {
     OpenStruct.new(
-      env: {
-        ActionDispatch::Cookies::GENERATOR_KEY => Rails.application.key_generator
-      },
+      env: {},
       cookies: {}
     )
   }
@@ -19,7 +17,27 @@ RSpec.describe SsoCookieJar do
     }
 
     expect(sso_cookie_jar['some_name']).not_to be_blank # encrypted so hard to predict real value
-    expect(sso_cookie_jar.encrypted['some_name']).to eq ({ foo: :bar })
+    expect(sso_cookie_jar.encrypted['some_name']).to eq ({ 'foo' => 'bar' }) # json means string keys
   end
 
+  it 'cookie jar can be decoded using key' do
+    sso_cookie_jar = SsoCookieJar.build(mock_request)
+
+    sso_cookie_jar.encrypted['ox'] = {
+      value: { 'test-answer' => 4242 }
+    }
+
+    secret_key_base = Rails.application.secrets.sso['shared_secret']
+    cookie          = sso_cookie_jar['ox']
+    salt            = Rails.application.secrets.sso['shared_secret_salt']
+    signed_salt     = "signed encrypted #{salt}"
+    key_generator   = ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000)
+    secret          = key_generator.generate_key(salt)[0, OpenSSL::Cipher.new('aes-256-cbc').key_len]
+    sign_secret     = key_generator.generate_key(signed_salt)
+    encryptor       = ActiveSupport::MessageEncryptor.new(secret, sign_secret, serializer: JSON)
+
+    expect(
+      encryptor.decrypt_and_verify(cookie)
+    ).to eq({ 'test-answer' => 4242 })
+  end
 end


### PR DESCRIPTION
Previously it was actually using the same key as the main cookie.

This also sets it's options directly so it'll be more stable 🤞 not change until we need it to