### PR TITLE
Validate emails providers

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,7 +1,48 @@
 class EmailAddress < ContactInfo
   include EmailAddressValidations
 
+  WHITELIST = [
+    # popular email providers globally
+    'gmail.com', 'outlook.com', 'yahoo.com', 'icloud.com', 'hotmail.com', 'aol.com',
+    # popular ones currently in our DB - as of Feb 2019
+    'uga.edu',
+    'vols.utk.edu',
+    'email.vccs.edu',
+    'ku.edu',
+    'bruinmail.slcc.edu',
+  ]
+
   email_validation_formats.each do |format|
     validates :value, format: format
+  end
+
+  validate :mx_domain_validation
+
+  def mx_domain_validation
+    return true if self.is_domain_trusted? # check in our DB first
+
+    if self.class.is_domain_mx?(self.domain) # makes a DNS/HTTP request
+      EmailDomain.first_or_create(value: self.domain, has_mx: true) # store the result
+      return true
+    else
+      # essentially blacklist it
+      EmailDomain.first_or_create(value: self.domain, has_mx: false)
+      errors.add(:value, :missing_mx_records)
+      return false
+    end
+  end
+
+  protected
+
+  def is_domain_trusted?
+    return true if WHITELIST.include?(self.domain)
+
+    has_mx = -> (val) { EmailDomain.where(value: val, has_mx: true).any? }
+    has_no_mx = -> (val) { EmailDomain.where(value: val, has_mx: false).any? }
+    return has_mx.call(self.domain) && !has_no_mx.call(self.domain)
+  end
+
+  def domain
+    @domain ||= Mail::Address.new(self.value).domain
   end
 end

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -1,0 +1,2 @@
+class EmailDomain < ActiveRecord::Base
+end

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -133,6 +133,7 @@ en:
             # Marking &email_address for reference later.
             value: &email_addres_validations
               invalid: “%{value}” is not a valid email address
+              missing_mx_records: “%{value}” is not a valid email address
               too_many_dots: This email has too many dots in a row
               ends_with_dot: An email cannot end with a dot
               contains_tick: An email should not contain a tick (`)

--- a/config/locales/activerecord.pl.yml
+++ b/config/locales/activerecord.pl.yml
@@ -136,6 +136,7 @@ pl:
           attributes:
             value: &email_address_validations
               invalid: „%{value}” nie jest poprawnym adresem e-mail
+              missing_mx_records: „%{value}” nie jest poprawnym adresem e-mail
               too_many_dots: Adres e-mail ma zbyt wiele kropek pod rząd
               ends_with_dot: Adres e-mail nie może kończyć się kropką
               contains_tick: Adres e-mail nie może zawierać znaku „`”

--- a/db/migrate/20190206185243_create_email_domains.rb
+++ b/db/migrate/20190206185243_create_email_domains.rb
@@ -1,0 +1,10 @@
+class CreateEmailDomains < ActiveRecord::Migration
+  def change
+    create_table :email_domains do |t|
+      t.string :value, default: ''
+      t.boolean :has_mx, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180927002206) do
+ActiveRecord::Schema.define(version: 20190206185243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,13 @@ ActiveRecord::Schema.define(version: 20180927002206) do
     t.string   "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "email_domains", force: :cascade do |t|
+    t.string   "value",      :default=>""
+    t.boolean  "has_mx",     :default=>false
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
   end
 
   create_table "fine_print_contracts", force: :cascade do |t|

--- a/lib/email_address_validations.rb
+++ b/lib/email_address_validations.rb
@@ -1,3 +1,5 @@
+require 'email_domain_mx_validator'
+
 module EmailAddressValidations
   extend ActiveSupport::Concern
 
@@ -44,6 +46,9 @@ module EmailAddressValidations
         }
       ]
     end
-  end
 
+    def is_domain_mx?(domain)
+      return EmailDomainMxValidator.check(domain)
+    end
+  end
 end

--- a/lib/email_domain_mx_validator.rb
+++ b/lib/email_domain_mx_validator.rb
@@ -1,0 +1,45 @@
+require 'resolv'
+
+module EmailDomainMxValidator
+  class Base
+    def check(domain)
+      raise 'Must implement and return a boolean'
+    end
+  end
+
+  class DnsStrategy < Base
+    def check(domain)
+      return false if domain.blank?
+
+      mx_records = Resolv::DNS.open do |dns|
+        dns.getresources(domain, Resolv::DNS::Resource::IN::MX)
+      end
+
+      return mx_records.size > 0
+    end
+  end
+
+  class FakeStrategy < Base
+    def initialize(expecting: true)
+      @expecting = expecting
+    end
+
+    def check(*args, **kwargs)
+      return @expecting
+    end
+  end
+
+  class << self
+    def check(domain)
+      strategy.check(domain)
+    end
+
+    def strategy
+      @strategy ||= DnsStrategy.new
+    end
+
+    def strategy=(strategy)
+      @strategy = strategy
+    end
+  end
+end

--- a/spec/factories/email_domains.rb
+++ b/spec/factories/email_domains.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :email_domain do
+    value EmailAddress::WHITELIST.sample
+    has_mx true
+  end
+end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -257,6 +257,16 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
       screenshot!
     end
 
+    scenario 'failure because domain is not an email provider' do
+      EmailDomainMxValidator.strategy = EmailDomainMxValidator::FakeStrategy.new(expecting: false)
+
+      visit signup_path
+      select 'Instructor', from: "signup_role"
+      fill_in (t :"signup.start.email_placeholder"), with: "bob@missingmx99.edu"
+      click_button(t :"signup.start.next")
+      expect(page).to have_content "Email address is invalid"
+    end
+
     scenario 'decides they want to sign in' do
       visit signin_path(go: 'student_signup')
       expect(page).to have_selector('#signup_role', visible: false)

--- a/spec/lib/domain_mx_validator_spec.rb
+++ b/spec/lib/domain_mx_validator_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe EmailDomainMxValidator, type: :lib do
+  INVALID_PROVIDER = 'invalidjunk123.com'
+
+  it 'delegates responsibility to a strategy object' do
+    strategy = instance_double('FakeStrategy')
+    domain = 'example.com'
+
+    expect(strategy).to receive(:check).with(domain)
+
+    EmailDomainMxValidator.strategy = strategy
+    EmailDomainMxValidator.check(domain)
+  end
+
+  context 'the strategy' do
+    it 'returns false when invalid provider - doesnt blow up' do
+      # makes a real DNS/HTTP request
+      EmailDomainMxValidator.strategy = EmailDomainMxValidator::DnsStrategy.new
+      expect(subject.check(INVALID_PROVIDER)).to eq(false)
+    end
+  end
+end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -1,5 +1,83 @@
 require 'rails_helper'
 
-describe EmailAddress do
+describe EmailAddress, type: :model do
   # format validation specs in `email_address_validations_spec.rb`
+  # email address provider validation specs in `domain_mx_validator_spec.rb`
+
+  INVALID_PROVIDER = "#{SecureRandom.hex(3)}.#{SecureRandom.hex(3)}"
+
+  let(:strategy) { double('validator') }
+
+  before(:each) do
+    EmailDomainMxValidator.strategy = strategy
+  end
+
+  describe 'when email provider is whitelisted' do
+    it 'does not call the strategy' do
+      whitelisted_provider = EmailAddress::WHITELIST.sample
+      expect(strategy).to receive(:check).exactly(0).times
+
+      email = EmailAddress.new
+      email.user = FactoryGirl.create(:user)
+      email.value = "WHATEVER@#{whitelisted_provider}"
+      email.valid?
+    end
+  end
+
+  describe 'when not whitelisted nor blacklisted' do
+    it 'delegates responsibility of email provider validation' do
+      expect(strategy).to receive(:check).with(INVALID_PROVIDER)
+
+      email = EmailAddress.new
+      email.user = FactoryGirl.create(:user)
+      email.value = "WHATEVER@#{INVALID_PROVIDER}"
+      email.valid?
+    end
+  end
+
+  describe 'when not valid email provider' do
+    before do
+      expect(strategy).to receive(:check).with(INVALID_PROVIDER).and_return(false)
+    end
+
+    it 'adds an error missing_mx_records' do
+      email = EmailAddress.new
+      email.user = FactoryGirl.create(:user)
+      email.value = "WHATEVER@#{INVALID_PROVIDER}"
+      email.valid?
+      expect(email).to have_error(:value, :missing_mx_records)
+    end
+
+    it 'blacklists domain in the database' do
+      email = EmailAddress.new
+      email.user = FactoryGirl.create(:user)
+      email.value = "WHATEVER@#{INVALID_PROVIDER}"
+
+      expect{
+        email.valid?
+      }.to change {
+        EmailDomain.where(value: INVALID_PROVIDER, has_mx: false).count
+      }
+    end
+  end
+
+  describe 'when valid email provider' do
+    let(:provider) { 'anyValidEmailProvider123.com' }
+
+    before(:each) do
+      expect(strategy).to receive(:check).with(provider).and_return(true)
+    end
+
+    it 'whitelists email provider in the database' do
+      email = EmailAddress.new
+      email.user = FactoryGirl.create(:user)
+      email.value = "WHATEVER@#{provider}"
+
+      expect{
+        email.valid?
+      }.to change {
+        EmailDomain.where(value: provider, has_mx: true).count
+      }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -136,6 +136,7 @@ RSpec.configure do |config|
 
   config.prepend_before(:each) do
     DatabaseCleaner.start
+    EmailDomainMxValidator.strategy = EmailDomainMxValidator::FakeStrategy.new
   end
 
   # https://github.com/DatabaseCleaner/database_cleaner#rspec-with-capybara-example says:


### PR DESCRIPTION
Addresses issue https://github.com/openstax/bit/issues/243. It is expected that this validation will run any time an `EmailAddress` is created or updated; this is simply how Rails works—by adding a validation `validate :mx_domain_validation` [here](https://github.com/openstax/accounts/pull/650/files#diff-1db36b36de8317130613417fbca17344R23)