### PR TITLE
Upgrade omniauth-google-oauth2 for Google+ deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'omniauth'
 gem 'omniauth-identity'
 gem 'omniauth-facebook', '~>4.0.0'
 gem 'omniauth-twitter'
-gem 'omniauth-google-oauth2'
+gem 'omniauth-google-oauth2', '~>0.6'
 
 # Key-value store for caching
 gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.1)
-    hashie (3.5.7)
+    hashie (3.6.0)
     highline (1.7.8)
     hike (1.2.3)
     htmlentities (4.3.4)
@@ -276,7 +276,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    jwt (1.5.6)
+    jwt (2.1.0)
     key_struct (0.4.2)
     keyword_search (1.5.0)
     kgio (2.10.0)
@@ -334,25 +334,24 @@ GEM
       rack (>= 1.2, < 3)
     oj (2.16.1)
     oj_mimic_json (1.0.1)
-    omniauth (1.8.1)
-      hashie (>= 3.4.6, < 3.6.0)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-google-oauth2 (0.4.1)
-      jwt (~> 1.5.2)
-      multi_json (~> 1.3)
+    omniauth-google-oauth2 (0.6.0)
+      jwt (>= 2.0)
       omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.3.1)
+      omniauth-oauth2 (>= 1.5)
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
-    omniauth-oauth2 (1.5.0)
+    omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
-      omniauth (~> 1.2)
+      omniauth (~> 1.9)
     omniauth-salesforce (1.0.5)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.0)
@@ -679,7 +678,7 @@ DEPENDENCIES
   oj_mimic_json
   omniauth
   omniauth-facebook (~> 4.0.0)
-  omniauth-google-oauth2
+  omniauth-google-oauth2 (~> 0.6)
   omniauth-identity
   omniauth-twitter
   openstax_api (~> 8.2.0)
@@ -727,4 +726,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
v0.6.0 of omniauth-google-oauth2 handles the changes in Google's deprecation of Google+ stuffs.