### PR TITLE
update OpenStax::PathPrefixer to handle prefixed redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,7 @@ gem 'scout_apm', '~> 3.0.x'
 gem 'openstax_healthcheck'
 
 # Allow Accounts routes to be accessed under an /accounts prefix (for use in CloudFront)
-gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "eb239c532941f"
+gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "b6d8f45d8"
 
 group :development, :test do
   # Get env variables from .env file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/openstax/path_prefixer.git
-  revision: eb239c532941f61c4060f89dc29a9ace825aca55
-  ref: eb239c532941f
+  revision: b6d8f45d8b9e702ce6b9b941a83f17a311aed599
+  ref: b6d8f45d8
   specs:
     openstax_path_prefixer (0.0.1)
       rails (>= 3.0)

--- a/spec/features/remove_accounts_path_prefix_spec.rb
+++ b/spec/features/remove_accounts_path_prefix_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-class DummyApp
-  def call(env)
-  end
-end
-
 describe "Remove accounts path prefix" do
   # Ensure that the config.ru gets loaded before these tests
   let(:app) {
@@ -29,6 +24,13 @@ describe "Remove accounts path prefix" do
     it "should be start to sign up" do
       expect_any_instance_of(SignupController).to receive(:start)
       request.get("/accounts/signup")
+    end
+  end
+
+  context "redirects work" do
+    it "should redirect home page to login page with prefix" do
+      response = request.get("/accounts")
+      expect(URI(response.location).path).to eq "/accounts/login"
     end
   end
 


### PR DESCRIPTION
The `openstax_path_prefixer` gem was updated to handle prefixes on redirects (and path/url helpers).  This PR updates Accounts to use this new gem version.