### PR TITLE
Prefix assets and add prefix to hardcoded paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,7 @@ gem 'scout_apm', '~> 3.0.x'
 gem 'openstax_healthcheck'
 
 # Allow Accounts routes to be accessed under an /accounts prefix (for use in CloudFront)
-gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "9d4f40693529"
+gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "c74c04fd6c1"
 
 group :development, :test do
   # Get env variables from .env file

--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,7 @@ gem 'scout_apm', '~> 3.0.x'
 gem 'openstax_healthcheck'
 
 # Allow Accounts routes to be accessed under an /accounts prefix (for use in CloudFront)
-gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "b6d8f45d8"
+gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "9d4f40693529"
 
 group :development, :test do
   # Get env variables from .env file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/openstax/path_prefixer.git
-  revision: b6d8f45d8b9e702ce6b9b941a83f17a311aed599
-  ref: b6d8f45d8
+  revision: 9d4f406935297f433834892dd18564cb416c50a2
+  ref: 9d4f40693529
   specs:
     openstax_path_prefixer (0.0.1)
       rails (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/openstax/path_prefixer.git
-  revision: 9d4f406935297f433834892dd18564cb416c50a2
-  ref: 9d4f40693529
+  revision: c74c04fd6c1517d52dd38d6e5d378ac38a1d1402
+  ref: c74c04fd6c1
   specs:
     openstax_path_prefixer (0.0.1)
       rails (>= 3.0)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ $ RAISE=true rspec
 
 If you encounter issues running features specs, check the version of chromedriver you have installed.  Version 2.38 is known to work.
 
+## Cloudfront
+
+Accounts is able to run with all URLs using an `/accounts` path prefix.  This lets us put Accounts under a Cloudfront distribution and route
+all `/accounts/*` requests to it.  Test this out by adding `/accounts` to the start of any page's path -- navigating from that point forward
+should keep you in an `/accounts` path prefix.
+
+If for some reason Accounts ever causes you to leave the `/accounts` prefix and just return to normal routes, this will be a problem when
+Accounts is deployed to Cloudfront, because Cloudfront won't route that request to Accounts.  We added some middleware to Accounts that will
+freak out if this happens.  You can run the rails server with a `SIMULATE_CLOUDFRONT=true` environment variable and the server will raise an exception if it ever receives a URL without the `/accounts` prefix.  This is useful for clicking around and making sure we have accounted for all of the routes.
+
+You can also use this environment variable when running tests, but note that the expectations on paths ("expect page to have path blah") have
+not been updated to expect the `/accounts` prefix.
+
 ## Background Jobs
 
 Accounts in production runs background jobs using `delayed_job`.

--- a/app/assets/javascripts/profile/authentication.coffee
+++ b/app/assets/javascripts/profile/authentication.coffee
@@ -18,8 +18,11 @@ class AuthenticationOption
   getType: ->
     this.$el.data('provider')
 
+  getScriptName: ->
+    this.$el.data('script_name')
+
   delete: ->
-    $.ajax({type: "DELETE", url: "/auth/#{@getType()}"})
+    $.ajax({type: "DELETE", url: "#{@getScriptName()}/auth/#{@getType()}"})
       .success( @handleDelete )
       .error(OX.Alert.display)
 
@@ -40,7 +43,7 @@ class AuthenticationOption
 
   add: ->
     # TODO: figure out a way for the BE to pass the url
-    window.location.href = "/add/#{@getType()}"
+    window.location.href = "#{@getScriptName()}/add/#{@getType()}"
 
   handleDelete: (response) ->
     if response.location?
@@ -57,10 +60,10 @@ class Password extends AuthenticationOption
   # TODO we should just use normal links for edit and add, instead of these JS handlers
 
   editPassword: ->
-    window.location.href = "/password/reset"
+    window.location.href = "#{@getScriptName()}/password/reset"
 
   add: ->
-    window.location.href = "/password/add"
+    window.location.href = "#{@getScriptName()}/password/add"
 
 SPECIAL_TYPES =
   identity: Password

--- a/app/assets/javascripts/profile/authentication.coffee
+++ b/app/assets/javascripts/profile/authentication.coffee
@@ -1,3 +1,5 @@
+BASE_URL = "#{OX.url_prefix}"
+
 class AuthenticationOption
 
   constructor: (@el) ->
@@ -18,11 +20,8 @@ class AuthenticationOption
   getType: ->
     this.$el.data('provider')
 
-  getScriptName: ->
-    this.$el.data('script_name')
-
   delete: ->
-    $.ajax({type: "DELETE", url: "#{@getScriptName()}/auth/#{@getType()}"})
+    $.ajax({type: "DELETE", url: "#{BASE_URL}/auth/#{@getType()}"})
       .success( @handleDelete )
       .error(OX.Alert.display)
 
@@ -43,7 +42,7 @@ class AuthenticationOption
 
   add: ->
     # TODO: figure out a way for the BE to pass the url
-    window.location.href = "#{@getScriptName()}/add/#{@getType()}"
+    window.location.href = "#{BASE_URL}/add/#{@getType()}"
 
   handleDelete: (response) ->
     if response.location?
@@ -60,10 +59,10 @@ class Password extends AuthenticationOption
   # TODO we should just use normal links for edit and add, instead of these JS handlers
 
   editPassword: ->
-    window.location.href = "#{@getScriptName()}/password/reset"
+    window.location.href = "#{BASE_URL}/password/reset"
 
   add: ->
-    window.location.href = "#{@getScriptName()}/password/add"
+    window.location.href = "#{BASE_URL}/password/add"
 
 SPECIAL_TYPES =
   identity: Password

--- a/app/assets/javascripts/profile/email.coffee
+++ b/app/assets/javascripts/profile/email.coffee
@@ -1,7 +1,8 @@
 # The forms in this control are written with x-editable styling so that it looks
 # similar to the other controls.
 
-BASE_URL = "/contact_infos"
+BASE_URL = "#{OX.url_prefix}/contact_infos"
+
 class Email
 
   constructor: (@el) ->

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -202,7 +202,11 @@ class SessionsController < ApplicationController
       url ||= begin
         referrer_uri = URI(request.referer)
         request_uri = URI(request.url)
-        "#{referrer_uri.scheme}://#{referrer_uri.host}:#{referrer_uri.port}/?#{request_uri.query}"
+        if referrer_uri.host == request_uri.host
+          "#{root_url}?#{request_uri.query}"
+        else
+          "#{referrer_uri.scheme}://#{referrer_uri.host}:#{referrer_uri.port}/?#{request_uri.query}"
+        end
       rescue # in case the referer is bad (see #179)
         root_url
       end

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -31,7 +31,7 @@ module ProfileHelper
       </span>
     SNIPPET
 
-    "<div class='authentication' data-provider='#{provider}' data-script_name='#{request.script_name}'>#{snippet}</div>".html_safe
+    "<div class='authentication' data-provider='#{provider}'>#{snippet}</div>".html_safe
   end
 
   def email_entry(value:, id:, is_verified:, is_searchable:)

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -31,7 +31,7 @@ module ProfileHelper
       </span>
     SNIPPET
 
-    "<div class='authentication' data-provider='#{provider}'>#{snippet}</div>".html_safe
+    "<div class='authentication' data-provider='#{provider}' data-script_name='#{request.script_name}'>#{snippet}</div>".html_safe
   end
 
   def email_entry(value:, id:, is_verified:, is_searchable:)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,11 @@
 <html>
 
   <head>
+    <script type="text/javascript">
+      window.OX = window.OX || {};
+      OX.I18n = <%= (t :javascript).to_json.html_safe %>;
+      OX.url_prefix = "<%= request.script_name %>";
+    </script>
 
     <% if @redirect_url %>
       <meta http-equiv='refresh' content='<%= @redirect_delay -%>;url=<%= @redirect_url -%>'>
@@ -23,10 +28,6 @@
     <title><%= @page_title + ' - ' if !@page_title.nil? %><%= PAGE_TITLE_SUFFIX %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <script type="text/javascript">
-      window.OX = window.OX || {}
-      OX.I18n = <%= (t :javascript).to_json.html_safe %>
-    </script>
   </head>
 
   <body class="<%= controller_name %> <%= action_name %>">

--- a/app/views/sessions/_authenticate_options.html.erb
+++ b/app/views/sessions/_authenticate_options.html.erb
@@ -48,7 +48,7 @@
   </div>
 
   <% end %>
-    <%= lev_form_for :login, url: '/auth/identity/callback',
+    <%= lev_form_for :login, url: post_auth_callback_path(provider: :identity),
         html: {class: 'identity-password'} do |f| %>
 
     <% fh = FormHelper::One.new(f: f,

--- a/app/views/signup/password.html.erb
+++ b/app/views/signup/password.html.erb
@@ -1,6 +1,6 @@
 <%= ox_card(heading: (t :'.page_heading')) do %>
 
-  <%= lev_form_for :signup, url: '/auth/identity/signup',
+  <%= lev_form_for :signup, url: post_auth_signup_path(provider: :identity),
     html: {id: 'signup', class: collect_errors.any? ? 'is-invalid' : ''} do |f| %>
 
     <p><%= t :".password_requirements" %></p>

--- a/config/initializers/cloudfront_simulator.rb
+++ b/config/initializers/cloudfront_simulator.rb
@@ -1,0 +1,7 @@
+require "cloudfront_simulator"
+
+Rails.application.configure do
+  if ENV['SIMULATE_CLOUDFRONT'] == 'true'
+    config.app_middleware.insert_before Rack::ETag, OpenStax::CloudfrontSimulator::Middleware
+  end
+end

--- a/config/initializers/openstax_path_prefixer.rb
+++ b/config/initializers/openstax_path_prefixer.rb
@@ -1,3 +1,4 @@
 OpenStax::PathPrefixer.configure do |config|
   config.prefix = "accounts"
+  config.prefix_assets = Rails.env.production?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,14 +17,14 @@ Rails.application.routes.draw do
 
     get 'reauthenticate'
 
-    get 'auth/:provider/callback', action: :create
-    post 'auth/:provider/callback', action: :create
+    get 'auth/:provider/callback', action: :create, as: :get_auth_callback
+    post 'auth/:provider/callback', action: :create, as: :post_auth_callback
 
     get 'logout', action: :destroy
 
     get 'redirect_back'
 
-    get 'failure', path: 'auth/failure'
+    get 'failure', path: 'auth/failure', as: :auth_failure
     post 'email_usernames'
 
     # Maintain these deprecated routes for a while until client code learns to
@@ -34,8 +34,15 @@ Rails.application.routes.draw do
   end
 
   scope controller: 'authentications' do
-    delete 'auth/:provider', action: :destroy
-    get 'add/:provider', action: :add
+    delete 'auth/:provider', action: :destroy, as: :destroy_authentication
+    get 'add/:provider', action: :add, as: :add_authentication
+  end
+
+  scope controller: 'signup' do
+    # Don't know if this is the right action; putting a route in here
+    # so we have a name for it and can use a url helper for it (which
+    # will prefix the route appropriately, e.g. for Cloudfront)
+    post 'auth/:provider/signup', action: :start, as: :post_auth_signup
   end
 
   # routes for access via an iframe

--- a/lib/cloudfront_simulator.rb
+++ b/lib/cloudfront_simulator.rb
@@ -1,0 +1,20 @@
+module OpenStax
+  module CloudfrontSimulator
+    class Middleware
+      def initialize(app, options = {})
+        @app = app
+      end
+
+      def call(env)
+        prefix = OpenStax::PathPrefixer.configuration.prefix
+        path = env['PATH_INFO']
+
+        if !path.starts_with?("/assets") && !path.starts_with?("/#{prefix}")
+          raise "#{path} not prefixed with Cloudfront path pattern '/#{prefix}'"
+        end
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -502,3 +502,23 @@ def expect_security_log(*args)
                                                 .with(*args)
                                                 .and_call_original
 end
+
+module Capybara
+  class Session
+    alias_method :original_visit, :visit
+    def visit(visit_uri)
+      # Note that the feature specs aren't yet modified to pass in a cloudfront simulation
+      # world.  Particularly, expectations on paths are hardcoded without the /accounts
+      # prefix and would need to be modified or taught how to expect during a cloudfront
+      # simulation
+
+      if ENV['SIMULATE_CLOUDFRONT'] == 'true'
+        uri = URI(visit_uri)
+        uri.path = "/#{OpenStax::PathPrefixer.configuration.prefix}#{uri.path}"
+        visit_uri = uri.to_s
+      end
+
+      original_visit(visit_uri)
+    end
+  end
+end


### PR DESCRIPTION
## DONE

* Updates openstax_path_prefixer gem to a version that supports prefixing assets (precompiles them into an `/accounts/assets` folder and makes references within the JS and CSS use `/accounts` prefixes when referring to fonts, images, etc).  The PR configures this library to only do the asset stuff on production b/c it really only works on production (only place it matters anyway).
* Goes through and changes some hardcoded paths in ERB to path helpers (which get the `/accounts` prefix as needed)
* Changes some of the Javascript hardcoded paths to use the prefix (does this by embedding the prefix in the HTML and then having the JS pull that `data` field out). **There are still other JS URLs to handle and @nathanstitt is going to have to do those b/c they are beyond me :-)**
* You can run the rails server with a `SIMULATE_CLOUDFRONT=true` environment variable and the server will raise an exception if it ever receives a URL without the `/accounts` prefix (similarly Cloudfront will fail because routes without an `/accounts` prefix will never even make it to Accounts).  This is useful for clicking around and making sure we have accounted for all of the routes.  

## TODO

* [x] Adding emails on the profile page uses Javascript which is not yet updated to use the `/accounts` prefix.  We need to modify the `app/assets/javascripts/profile/email.coffee` file to have logic similar to https://github.com/openstax/accounts/pull/659/commits/2f61db2a22411ceadf734c1f19a0a5f9bd35b1c1 -- NB: the `/accounts` prefix isn't added all the time -- only when the page is requested with it! (which is when the `request` has a populated `script_name` attribute)