### PR TITLE
allow login redirects without a host

### DIFF
--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -71,11 +71,11 @@ ActionController::Base.class_exec do
   end
 
   def save_redirect
-    return true if request.format != :html || request.options?
+    return true if request.format != :html || request.options? || params["r"].blank?
 
-    url = params["r"]
-
-    return true if url.blank? || !Host.trusted?(url)
+    url = Host.default_host(params["r"], request.referer)
+    
+    return true if !Host.trusted?(url)
 
     store_url(url: url)
   end

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -71,11 +71,11 @@ ActionController::Base.class_exec do
   end
 
   def save_redirect
-    return true if request.format != :html || request.options? || params["r"].blank?
+    return true if request.format != :html || request.options?
 
-    url = Host.default_host(params["r"], request.referer)
-    
-    return true if !Host.trusted?(url)
+    url = params["r"]
+
+    return true if url.blank? || !Host.trusted?(url)
 
     store_url(url: url)
   end

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -3,18 +3,10 @@ module Host
     /\A(.*\.)?#{host.gsub('.', '\.')}\z/
   end
 
-  def self.default_host(url_or_path, default_source)
-    subject = Addressable::URI.parse(url_or_path)
-    return url_or_path if subject.host
-
-    default = Addressable::URI.parse(default_source)
-    return "#{default.scheme}://#{default.host}/#{subject.path.gsub(/^\//, '')}" if default
-
-    url_or_path
-  end
-
   def self.trusted?(url)
     uri = Addressable::URI.parse url
+
+    return true if not uri.host
 
     TRUSTED_HOST_REGEXES.any? { |regex| regex.match uri.host }
   end

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -6,7 +6,7 @@ module Host
   def self.trusted?(url)
     uri = Addressable::URI.parse url
 
-    return true if not uri.host
+    return true if not uri.host and url.chr == '/'
 
     TRUSTED_HOST_REGEXES.any? { |regex| regex.match uri.host }
   end

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -3,6 +3,16 @@ module Host
     /\A(.*\.)?#{host.gsub('.', '\.')}\z/
   end
 
+  def self.default_host(url_or_path, default_source)
+    subject = Addressable::URI.parse(url_or_path)
+    return url_or_path if subject.host
+
+    default = Addressable::URI.parse(default_source)
+    return "#{default.scheme}://#{default.host}/#{subject.path.gsub(/^\//, '')}" if default
+
+    url_or_path
+  end
+
   def self.trusted?(url)
     uri = Addressable::URI.parse url
 

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -21,16 +21,9 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       expect_to_save_redirect("https://tutor.openstax.org/hi")
       get :index, r: "https://tutor.openstax.org/hi"
     end
-
-    it 'saves a redirect path from an approved referer' do
-      request.headers.merge!(referer: 'https://openstax.org/cool/page')
-      expect_to_save_redirect("https://openstax.org/hi")
-      get :index, r: "/hi"
-    end
-
-    it 'saves a redirect without a path from an approved referer' do
-      request.headers.merge!(referer: 'https://openstax.org/cool/page')
-      expect_to_save_redirect("https://openstax.org/")
+    
+    it 'saves a redirect that has a param without a host' do
+      expect_to_save_redirect("/")
       get :index, r: "/"
     end
 
@@ -44,11 +37,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       it 'has a blank param' do
         get :index, r: ""
       end
-
-      it 'has a param without a host or referer' do
-        get :index, r: "/"
-      end
-
+      
       it 'has a param not matching valid iframe origins' do
         get :index, r: "https://openstax.badsite.org/hi"
       end
@@ -58,16 +47,11 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       end
 
       it 'has an badly formatted valid URL' do
-        get :index, r: "openstax.org/blah"
+        get :index, r: "openstax"
       end
 
       it 'has a param for a bad site ending with openstax.org' do
         get :index, r: "https://pirateopenstax.org"
-      end
-
-      it 'does not save a redirect path for an unapproved referer' do
-        request.headers.merge!(referer: 'http://pirateopenstax.org')
-        get :index, r: "/hi"
       end
     end
   end

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
         get :index, r: "openstax"
       end
 
+      it 'has an relative path' do
+        get :index, r: "../foo/bar"
+      end
+
       it 'has a param for a bad site ending with openstax.org' do
         get :index, r: "https://pirateopenstax.org"
       end

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       get :index, r: "https://tutor.openstax.org/hi"
     end
 
+    it 'saves a redirect path from an approved referer' do
+      request.headers.merge!(referer: 'https://openstax.org/cool/page')
+      expect_to_save_redirect("https://openstax.org/hi")
+      get :index, r: "/hi"
+    end
+
+    it 'saves a redirect without a path from an approved referer' do
+      request.headers.merge!(referer: 'https://openstax.org/cool/page')
+      expect_to_save_redirect("https://openstax.org/")
+      get :index, r: "/"
+    end
+
     context "does not store a redirect if" do
       before(:each) { expect_not_to_save_redirect }
 
@@ -33,7 +45,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
         get :index, r: ""
       end
 
-      it 'has a param without a host' do
+      it 'has a param without a host or referer' do
         get :index, r: "/"
       end
 
@@ -51,6 +63,11 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
 
       it 'has a param for a bad site ending with openstax.org' do
         get :index, r: "https://pirateopenstax.org"
+      end
+
+      it 'does not save a redirect path for an unapproved referer' do
+        request.headers.merge!(referer: 'http://pirateopenstax.org')
+        get :index, r: "/hi"
       end
     end
   end

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
         get :index, r: "openstax"
       end
 
-      it 'has an relative path' do
+      it 'has a relative path' do
         get :index, r: "../foo/bar"
       end
 

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       expect_to_save_redirect("https://tutor.openstax.org/hi")
       get :index, r: "https://tutor.openstax.org/hi"
     end
-    
+
     it 'saves a redirect that has a param without a host' do
       expect_to_save_redirect("/")
       get :index, r: "/"
@@ -37,7 +37,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
       it 'has a blank param' do
         get :index, r: ""
       end
-      
+
       it 'has a param not matching valid iframe origins' do
         get :index, r: "https://openstax.badsite.org/hi"
       end
@@ -46,7 +46,7 @@ RSpec.describe "Controllers affected by initializers/controllers.rb", type: :con
         get :index, format: :json
       end
 
-      it 'has an badly formatted valid URL' do
+      it 'doesn\'t start with a slash' do
         get :index, r: "openstax"
       end
 


### PR DESCRIPTION
please nitpick my ruby, i don't ruby great.

login redirects without a host will be processed using the accounts host

~if there is concern over using the `referrer` header it would also work for me to default it to the `host` header set by cloudfront. `referrer` is more flexible and i'm _**pretty sure**_ that there is no way to manipulate referrer when actually sending a user somewhere~

