### PR TITLE
Enable cache compression

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,8 @@ module Accounts
     config.cache_store = :redis_store, {
       url: redis_secrets['url'],
       namespace: redis_secrets['namespaces']['cache'],
-      expires_in: 90.minutes
+      expires_in: 90.minutes,
+      compress: true,
     }
 
     def is_real_production?


### PR DESCRIPTION
Resolve issue https://github.com/openstax/business-intel/issues/147

Note: the default compression threshold for Rails [according to the docs](https://api.rubyonrails.org/v4.2.7/classes/ActiveSupport/Cache/Store.html) is **16K** [bytes], and for Rails 5 it's **1kB** according to the [docs here](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html). The threshold can be configured with this setting: `compress_threshold: 1600`. I didn't specify that, so the default will apply.