### PR TITLE
Make Homeschool Instructor a valid user role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
   has_many :security_logs
 
   enum faculty_status: [:no_faculty_info, :pending_faculty, :confirmed_faculty, :rejected_faculty]
-  enum role: [:unknown_role, :student, :instructor, :administrator, :librarian, :designer, :other, :adjunct]
+  enum role: [:unknown_role, :student, :instructor, :administrator, :librarian, :designer, :other, :adjunct, :homeschool]
   enum school_type: [:unknown_school_type, :other_school_type, :college]
 
   DEFAULT_FACULTY_STATUS = :no_faculty_info


### PR DESCRIPTION
This part is missing from PR #641. I noticed it only after merging and there was no spec failure because there is currently not a test for this type of change.

Screenshot of current behavior which this PR fixes:

![Screen Shot 2019-07-11 at 12 04 11 PM](https://user-images.githubusercontent.com/6620941/61071801-9aaf8100-a3d7-11e9-83b0-cca6a5af922b.png)
