### PR TITLE
Allow users created through find_or_create to be marked as test users

### DIFF
--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -12,6 +12,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :support_identifier,
+             type: String,
+             readable: true,
+             writeable: false
+
     property :email,
              type: String,
              readable: false,

--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -113,5 +113,13 @@ module Api::V1
                }"
              }
 
+  property :is_test,
+           type: :boolean,
+           readable: false,
+           writeable: true,
+           schema_info: {
+             description: 'Whether or not this is a test user'
+           }
+
   end
 end

--- a/app/routines/create_user.rb
+++ b/app/routines/create_user.rb
@@ -13,7 +13,7 @@ class CreateUser
   def exec(state:, username: nil,
            title: nil, first_name: nil, last_name: nil, suffix: nil,
            salesforce_contact_id: nil, faculty_status: nil, role: nil,
-           school_type: nil, ensure_no_errors: false)
+           school_type: nil, is_test: nil, ensure_no_errors: false)
 
     username = generate_unique_valid_username(username) if ensure_no_errors
     create_method = ensure_no_errors ? :create! : :create
@@ -29,6 +29,7 @@ class CreateUser
       user.faculty_status = faculty_status || :no_faculty_info
       user.role = role || :unknown_role
       user.school_type = school_type || :unknown_school_type
+      user.is_test = is_test
     end
 
     transfer_errors_from(outputs[:user], type: :verbatim)

--- a/app/routines/find_or_create_unclaimed_user.rb
+++ b/app/routines/find_or_create_unclaimed_user.rb
@@ -38,6 +38,7 @@ class FindOrCreateUnclaimedUser
                faculty_status: options[:faculty_status],
                role: options[:role],
                school_type: options[:school_type],
+               is_test: options[:is_test],
                ensure_no_errors: true).outputs.user
 
     # routine is smart and gracefully handles case of missing options[:email]

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -239,7 +239,9 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       }.to change{User.count}.by(1)
       expect(response.code).to eq('201')
       new_user = User.order(:id).last
-      expect(response.body_as_hash).to eq({id: new_user.id, uuid: new_user.uuid})
+      expect(response.body_as_hash).to eq(
+        id: new_user.id, uuid: new_user.uuid, support_identifier: new_user.support_identifier
+      )
     end
 
     it 'creates a new user with first name, last name and full name if given' do
@@ -286,14 +288,20 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
         api_post :find_or_create, trusted_application_token,
                  raw_post_data: {email: unclaimed_user.contact_infos.first.value}
         expect(response.code).to eq('201')
-        expect(response.body_as_hash).to eq({id: unclaimed_user.id, uuid: unclaimed_user.uuid})
+        expect(response.body_as_hash).to eq(
+          id: unclaimed_user.id,
+          uuid: unclaimed_user.uuid,
+          support_identifier: unclaimed_user.support_identifier
+        )
       end
       it "does so for claimed users" do
         api_post :find_or_create,
                  trusted_application_token,
                  raw_post_data: {email: user_2.contact_infos.first.value}
         expect(response.code).to eq('201')
-        expect(response.body_as_hash).to eq({id: user_2.id, uuid: user_2.uuid})
+        expect(response.body_as_hash).to eq(
+          id: user_2.id, uuid: user_2.uuid, support_identifier: user_2.support_identifier
+        )
       end
     end
 

--- a/spec/routines/find_or_create_unclaimed_user_spec.rb
+++ b/spec/routines/find_or_create_unclaimed_user_spec.rb
@@ -103,6 +103,20 @@ describe FindOrCreateUnclaimedUser do
 
       end
 
+      context 'and is_test' do
+        it 'sets is_test' do
+          is_test = [true, false].sample
+          new_user = FindOrCreateUnclaimedUser.call(
+            email:"anunusedemail@example.com",
+            username: 'bobsmith', email: 'anunusedemail@example.com',
+            first_name: Faker::Name.first_name, last_name: Faker::Name.last_name,
+            is_test: is_test
+          ).outputs.user
+          expect(new_user.is_test).to eq is_test
+          expect(new_user.reload.is_test).to eq is_test
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
Turns out there's no way to create test users through find_or_create currently, since the property is not set and the app is not allowed to update it after creation.

Allow setting is_test during unclaimed user creation.

Required for:
- https://github.com/openstax/accounts-rails/pull/81
- https://github.com/openstax/tutor-server/pull/1881