### PR TITLE
Make social login work with Cloudfront path prefixing

### DIFF
--- a/app/views/sessions/_authenticate_options.html.erb
+++ b/app/views/sessions/_authenticate_options.html.erb
@@ -12,7 +12,8 @@
 <% end %>
 
 <% if providers.keys.include?('google_oauth2') %>
-  <%= link_to "/auth/google_oauth2?login_hint=#{providers['google_oauth2']['login_hint']}",
+
+  <%= link_to oauth_path(:google_oauth2, login_hint: providers['google_oauth2']['login_hint']),
               class: 'btn btn-block btn-social btn-google',
               id: 'google-login-button' do %>
     <span class="fa fa-google"></span> <%= t :".sign_in_with_google" %>
@@ -20,8 +21,9 @@
 <% end %>
 
 <% if providers.keys.include?('facebook') %>
-  <%= link_to "/auth/facebook", class: 'btn btn-block btn-social btn-facebook',
-                                id: 'facebook-login-button' do %>
+  <%= link_to oauth_path(:facebook),
+              class: 'btn btn-block btn-social btn-facebook',
+              id: 'facebook-login-button' do %>
     <span class="fa fa-facebook"></span> <%= t :".sign_in_with_facebook" %>
   <% end %>
 <% end %>
@@ -30,8 +32,9 @@
     users to a different authentication %>
 
 <% if providers.keys.include?('twitter') %>
-  <%= link_to "/auth/twitter", class: 'btn btn-block btn-social btn-twitter',
-                               id: 'twitter-login-button' do %>
+  <%= link_to oauth_path(:twitter),
+              class: 'btn btn-block btn-social btn-twitter',
+              id: 'twitter-login-button' do %>
     <span class="fa fa-twitter"></span> <%= t :".sign_in_with_twitter" %>
   <% end %>
 <% end %>

--- a/app/views/signup/social.html.erb
+++ b/app/views/signup/social.html.erb
@@ -1,11 +1,11 @@
 <%= ox_card(heading: (t :'.page_heading')) do %>
 
     <div class="button-form-group">
-      <%= link_to "/auth/facebook", class: 'btn btn-block btn-social btn-facebook', id: 'facebook-login-button' do %>
+      <%= link_to oauth_path(:facebook), class: 'btn btn-block btn-social btn-facebook', id: 'facebook-login-button' do %>
         <span class="fa fa-facebook"></span> <%= t :".facebook" %>
       <% end %>
 
-      <%= link_to "/auth/google_oauth2", class: 'btn btn-block btn-social btn-google', id: 'google-login-button' do %>
+      <%= link_to oauth_path(:google_oauth2), class: 'btn btn-block btn-social btn-google', id: 'google-login-button' do %>
         <span class="fa fa-google"></span> <%= t :".google" %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,11 @@ Rails.application.routes.draw do
 
   mount OpenStax::Salesforce::Engine, at: '/admin/salesforce'
   OpenStax::Salesforce.set_top_level_routes(self)
+  
+  # Create a named path for links like `/auth/facebook` so that the path prefixer gem
+  # will appropriately prefix the path.  https://stackoverflow.com/a/40125738/1664216
+  get "/auth/:provider", to: lambda{ |env| [404, {}, ["Not Found"]] }, as: :oauth
+
 
   scope controller: 'authentications' do
     delete 'auth/:provider', action: :destroy, as: :destroy_authentication


### PR DESCRIPTION
Adds a path helper for the omniauth social login links (e.g. `/auth/facebook`) so that when the `/accounts` URL path prefix is being used the social login links also have the prefix (e.g. `/accounts/auth/facebook`).  

In at least local testing, this fixes social for Facebook.  Still need to test Google and Twitter.  Also for this to work, we need to update the Facebook, Google, and Twitter apps to allow callback URLs that have the `/accounts/` prefix.