### PR TITLE
Default DB host to localhost if not specified

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: postgresql
-  host: <%= ENV['OXA_DB_HOST'] %>
+  host: <%= ENV['OXA_DB_HOST'] || 'localhost' %>
   username: <%= ENV['OXA_DB_USER'] || 'ox_accounts' %>
   password: <%= ENV['OXA_DB_PASS'] || 'ox_accounts' %>
 


### PR DESCRIPTION
Just convenience for me when reviewing PRs at home (Postgres 10 and 11 "just work" with Accounts if you add this setting).