### PR TITLE
Fix name of export users last login date

### DIFF
--- a/lib/tasks/export_users_last_login_date.rake
+++ b/lib/tasks/export_users_last_login_date.rake
@@ -1,4 +1,4 @@
 desc "Creates a CSV file with users' last login date and their email addresses"
-task :export_users_last_login_dates => [:environment] do
+task :export_users_last_login_date => [:environment] do
   puts ExportUsersLastLoginDate.call(delete_after: false).outputs.filename
 end


### PR DESCRIPTION
1. It should've been a `.rake` file, not `.rb`.
2. And renames `export_last_login_dates` → `export_users_last_login_date`