### PR TITLE
Report GPDR location information for logged in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ set the environment variable `USE_REAL_BACKGROUND_JOBS=true` in your `.env` file
 and then start the `delayed_job` daemon:
 
 `bin/rake jobs:work`
+
+## GDPR
+
+For logged-in users, Accounts reports GDPR status in the `/api/user` endpoint via a `is_not_gdpr_location` flag.  When this value is `true`, the user is not in a GDPR location.  Otherwise (`false` or `nil` or not in the response), the user may be in a GDPR location.  To test this functionality in development, you can specify an IP address via the `IP_ADDRESS_FOR_GDPR` environment variable, which will override the normal localhost request IP address.

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -114,6 +114,10 @@ class Api::V1::UsersController < Api::V1::ApiController
 
     OSU::AccessPolicy.require_action_allowed!(:read, current_api_user, current_human_user)
 
+    SetGdprData.call(user: current_human_user,
+                     session: session,
+                     ip: ENV['IP_ADDRESS_FOR_GDPR'] || request.ip)
+
     respond_with current_human_user,
                  represent_with: Api::V1::UserRepresenter,
                  user_options: { include_private_data: true },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ActiveRecord::Base
 
   attr_readonly :uuid, :support_identifier
 
+  attribute :is_not_gdpr_location, :boolean, default: nil
+
   before_validation :generate_uuid, :generate_support_identifier, on: :create
 
   before_create :make_first_user_an_admin

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -55,6 +55,12 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :is_not_gdpr_location,
+             if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
+             type: :boolean,
+             readable: true,
+             writeable: false
+
     property :is_test?,
              as: :is_test,
              type: :boolean,

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -18,6 +18,7 @@ require 'email_address_validations'
 require 'subjects_utils'
 require 'host'
 require 'sso_cookie_jar'
+require 'set_gdpr_data'
 
 SITE_NAME = 'OpenStax Accounts'
 PAGE_TITLE_SUFFIX = SITE_NAME

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -88,6 +88,8 @@ development:
                         "SSO_COOKIE_HTTPONLY", true
                       ) %>
 
+  ip_api_key: the_ip_api_key
+
 test:
   # Used to encrypt and sign cookies
   # Changing this will invalidate all cookies
@@ -147,3 +149,5 @@ test:
         domain: ''
         secure: true
         httponly: true
+
+  ip_api_key: the_ip_api_key

--- a/lib/set_gdpr_data.rb
+++ b/lib/set_gdpr_data.rb
@@ -1,0 +1,134 @@
+require 'net/http'
+
+module SetGdprData
+
+  class GdprSessionData
+    def initialize(session)
+      @session = session
+    end
+
+    def ip
+      @session[:gdpr].try(:[],1..-1)
+    end
+
+    def status
+      raw_value = @session[:gdpr]
+      return :unknown if raw_value.blank?
+      case raw_value[0]
+      when 'i'
+        return :inside_gdpr
+      when 'o'
+        return :outside_gdpr
+      else
+        raise "Session GDPR status is improperly formatted"
+      end
+    end
+
+    def set(ip:, status:)
+      case status
+      when :unknown
+        @session.delete(:gdpr)
+      when :inside_gdpr
+        @session[:gdpr] = "i#{ip}"
+      when :outside_gdpr
+        @session[:gdpr] = "o#{ip}"
+      else
+        raise "Invalid GDPR status: #{status}"
+      end
+    end
+  end
+
+  def self.call(user:, session:, ip:)
+    gdpr_data = GdprSessionData.new(session)
+
+    if ip == gdpr_data.ip
+      # No need to lookup the location, it is already available in the session
+      status = gdpr_data.status
+    else
+      country_code = country_code(ip: ip)
+      status =
+        case country_code
+        when nil
+          :unknown
+        when *GDPR_COUNTRY_CODES
+          :inside_gdpr
+        else
+          :outside_gdpr
+        end
+
+      gdpr_data.set(ip: ip, status: status)
+    end
+
+    user.is_not_gdpr_location = :outside_gdpr == status
+  end
+
+  def self.country_code(ip:)
+    uri = URI("https://pro.ip-api.com/json/#{ip}?key=#{Rails.application.secrets.ip_api_key}")
+
+    begin
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: lookup_timeout) do |http|
+        response = Net::HTTP.get_response uri
+        body = JSON.parse(response.body)
+
+        if body["status"] == "success"
+          return body["countryCode"]
+        else
+          Raven.capture_message("Failed IP address location lookup", extra: body)
+          return nil
+        end
+      end
+    rescue Net::ReadTimeout => ee
+      Raven.capture_message("IP address location lookup timed out")
+      return nil
+    rescue => ee
+      # We don't want explosions here to trickle out and impact callers
+      Raven.capture_exception(ee)
+      return nil
+    end
+  end
+
+  def self.lookup_timeout
+    1
+  end
+
+  GDPR_COUNTRY_CODES = [
+    'AT', # Austria
+    'BE', # Belgium
+    'BG', # Bulgaria
+    'HR', # Croatia
+    'CY', # Cyprus
+    'CZ', # Czech Republic
+    'DK', # Denmark
+    'EE', # Estonia
+    'FI', # Finland
+    'FR', # France
+    'GF', # French Guiana
+    'DE', # Germany
+    'GR', # Greece
+    'GP', # Guadeloupe
+    'HU', # Hungary
+    'IS', # Iceland
+    'IE', # Ireland
+    'IT', # Italy
+    'LV', # Latvia
+    'LI', # Liechtenstein
+    'LT', # Lithuania
+    'LU', # Luxembourg
+    'MT', # Malta
+    'MQ', # Martinique
+    'YT', # Mayotte
+    'NL', # Netherlands
+    'NO', # Norway
+    'PL', # Poland
+    'PT', # Portugal
+    'RE', # Reunion
+    'RO', # Romania
+    'MF', # Saint Martin
+    'SK', # Slovakia
+    'SI', # Slovenia
+    'ES', # Spain
+    'SE', # Sweden
+    'GB', # United Kingdom
+  ];
+
+end

--- a/spec/cassettes/SetGdprData/_call/data_already_cached/cached_IP_different_from_called_IP/sets_the_user_status_makes_an_HTTP_request_and_changes_the_cached_session.yml
+++ b/spec/cassettes/SetGdprData/_call/data_already_cached/cached_IP_different_from_called_IP/sets_the_user_status_makes_an_HTTP_request_and_changes_the_cached_session.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pro.ip-api.com/json/8.8.8.8?key=<ip_api_key>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pro.ip-api.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 24 Aug 2019 22:44:16 GMT
+      Content-Length:
+      - '288'
+    body:
+      encoding: UTF-8
+      string: '{"as":"AS15169 Google LLC","city":"Ashburn","country":"United States","countryCode":"US","isp":"Level
+        3 Communications","lat":39.0438,"lon":-77.4874,"org":"Google Inc.","query":"8.8.8.8","region":"VA","regionName":"Virginia","status":"success","timezone":"America/New_York","zip":"20149"}'
+    http_version: 
+  recorded_at: Sat, 24 Aug 2019 22:44:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/SetGdprData/_call/data_already_cached/for_unresolvable_addresses/sets_the_user_status_to_unknown_and_clears_session_data.yml
+++ b/spec/cassettes/SetGdprData/_call/data_already_cached/for_unresolvable_addresses/sets_the_user_status_to_unknown_and_clears_session_data.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pro.ip-api.com/json/howdy?key=<ip_api_key>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pro.ip-api.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 24 Aug 2019 22:44:16 GMT
+      Content-Length:
+      - '59'
+    body:
+      encoding: UTF-8
+      string: '{"message":"invalid query","query":"howdy","status":"fail"}'
+    http_version: 
+  recorded_at: Sat, 24 Aug 2019 22:44:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/SetGdprData/_call/data_not_yet_cached/for_EU_addresses/sets_the_user_status_and_cache.yml
+++ b/spec/cassettes/SetGdprData/_call/data_not_yet_cached/for_EU_addresses/sets_the_user_status_and_cache.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pro.ip-api.com/json/82.216.111.122?key=<ip_api_key>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pro.ip-api.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 24 Aug 2019 22:44:16 GMT
+      Content-Length:
+      - '279'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJhcyI6IkFTMjE1MDIgU0ZSIFNBIiwiY2l0eSI6Ik5ldWlsbHktc3VyLVNlaW5lIiwiY291bnRyeSI6IkZyYW5jZSIsImNvdW50cnlDb2RlIjoiRlIiLCJpc3AiOiJOVU1FUklDQUJMRSIsImxhdCI6NDguODg3MSwibG9uIjoyLjI3NDUsIm9yZyI6IlNGUiBTQSIsInF1ZXJ5IjoiODIuMjE2LjExMS4xMjIiLCJyZWdpb24iOiJJREYiLCJyZWdpb25OYW1lIjoiw45sZS1kZS1GcmFuY2UiLCJzdGF0dXMiOiJzdWNjZXNzIiwidGltZXpvbmUiOiJFdXJvcGUvUGFyaXMiLCJ6aXAiOiI5MjIwMCJ9
+    http_version: 
+  recorded_at: Sat, 24 Aug 2019 22:44:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/SetGdprData/_country_code/returns_nil_for_bad_IP.yml
+++ b/spec/cassettes/SetGdprData/_country_code/returns_nil_for_bad_IP.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pro.ip-api.com/json/howdy?key=<ip_api_key>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pro.ip-api.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 24 Aug 2019 22:44:17 GMT
+      Content-Length:
+      - '59'
+    body:
+      encoding: UTF-8
+      string: '{"message":"invalid query","query":"howdy","status":"fail"}'
+    http_version: 
+  recorded_at: Sat, 24 Aug 2019 22:44:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/SetGdprData/_country_code/succeeds.yml
+++ b/spec/cassettes/SetGdprData/_country_code/succeeds.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pro.ip-api.com/json/8.8.8.8?key=<ip_api_key>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - pro.ip-api.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 24 Aug 2019 22:44:17 GMT
+      Content-Length:
+      - '288'
+    body:
+      encoding: UTF-8
+      string: '{"as":"AS15169 Google LLC","city":"Ashburn","country":"United States","countryCode":"US","isp":"Level
+        3 Communications","lat":39.0438,"lon":-77.4874,"org":"Google Inc.","query":"8.8.8.8","region":"VA","regionName":"Virginia","status":"success","timezone":"America/New_York","zip":"20149"}'
+    http_version: 
+  recorded_at: Sat, 24 Aug 2019 22:44:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                                                  resource_owner_id: admin_user.id
   end
 
+  let(:is_not_gdpr_location) { nil }
+
   context "index" do
 
     it "returns a single result well" do
@@ -92,6 +94,11 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
   end
 
   context "show" do
+    before(:each) do
+      allow(SetGdprData).to receive(:call) do |args|
+        args[:user].is_not_gdpr_location = is_not_gdpr_location
+      end
+    end
 
     it "should let a User get his info" do
       api_get :show, user_1_token
@@ -181,6 +188,17 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
         self_reported_role: "instructor",
       )
     end
+
+    context "gdpr location" do
+      let(:is_not_gdpr_location) { true }
+
+      it "reports gdpr location flag" do
+        api_get :show, user_1_token
+        # expected_response = user_matcher(user_1, include_private_data: true)
+        expect(response.body_as_hash).to include(is_not_gdpr_location: true)
+      end
+    end
+
 
   end
 

--- a/spec/lib/set_gdpr_data_spec.rb
+++ b/spec/lib/set_gdpr_data_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+require 'vcr_helper'
+require 'webmock/rspec'
+
+describe SetGdprData, vcr: VCR_OPTS do
+
+  let(:eu_ip) { "82.216.111.122" } # Paris DNS
+  let(:us_ip) { "8.8.8.8" } # Google Public DNS
+
+  describe SetGdprData::GdprSessionData do
+    let(:session) { Hash.new }
+
+    it 'reads existing IP address' do
+      expect(SetGdprData::GdprSessionData.new({gdpr: "o1.2.3.4"}).ip).to eq "1.2.3.4"
+      expect(SetGdprData::GdprSessionData.new({gdpr: ""}).ip).to be nil
+      expect(SetGdprData::GdprSessionData.new({}).ip).to be nil
+    end
+
+    it 'reads existing statuses' do
+      expect(SetGdprData::GdprSessionData.new({gdpr: "o1.2.3.4"}).status).to eq :outside_gdpr
+      expect(SetGdprData::GdprSessionData.new({gdpr: "i1.2.3.4"}).status).to eq :inside_gdpr
+      expect(SetGdprData::GdprSessionData.new({gdpr: ""}).status).to eq :unknown
+      expect(SetGdprData::GdprSessionData.new({}).status).to eq :unknown
+    end
+
+    it 'sets IP address and outside status in the session' do
+      SetGdprData::GdprSessionData.new(session).set(ip: "1.2.3.4", status: :outside_gdpr)
+      expect(session[:gdpr]).to eq "o1.2.3.4"
+    end
+
+    it 'sets IP address and inside status in the session' do
+      SetGdprData::GdprSessionData.new(session).set(ip: "1.2.3.4", status: :inside_gdpr)
+      expect(session[:gdpr]).to eq "i1.2.3.4"
+    end
+
+    it 'sets IP address and unknown status in the session' do
+      SetGdprData::GdprSessionData.new(session).set(ip: "1.2.3.4", status: :unknown)
+      expect(session[:gdpr]).to eq nil
+    end
+  end
+
+  describe "#country_code" do
+    it 'succeeds' do
+      expect(described_class.country_code(ip: us_ip)).to eq "US"
+    end
+
+    it 'returns nil for bad IP' do
+      expect(Raven).to receive(:capture_message).with(/Failed IP/, any_args)
+      expect(described_class.country_code(ip: "howdy")).to eq nil
+    end
+
+    it 'returns nil for net timeout' do
+      # cannot really test read timeout b/c of how webmock inserts itself
+      # https://github.com/bblimke/webmock/issues/286#issuecomment-19457387
+      allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout)
+      expect(Raven).to receive(:capture_message).with(/timed out/)
+      expect(described_class.country_code(ip: us_ip)).to eq nil
+    end
+
+    it 'returns nil for any other problem' do
+      allow(Net::HTTP).to receive(:start).and_raise(StandardError)
+      expect(Raven).to receive(:capture_exception)
+      expect(described_class.country_code(ip: us_ip)).to eq nil
+    end
+  end
+
+  describe "#call" do
+    let(:ip) { }
+    let(:user) { OpenStruct.new(is_not_gdpr_location: nil) }
+
+    context "data already cached" do
+      context "cached IP matches called IP" do
+        it "sets the user status and does not make an HTTP request" do
+          described_class.call(user: user, session: {gdpr: "i#{eu_ip}"}, ip: eu_ip)
+          expect(WebMock).to_not have_requested(:get, /.*/)
+          expect(user.is_not_gdpr_location).to eq false
+        end
+      end
+
+      context "cached IP different from called IP" do
+        it "sets the user status, makes an HTTP request, and changes the cached session" do
+          session = {gdpr: "i#{eu_ip}"}
+          described_class.call(user: user, session: session, ip: us_ip)
+          expect(WebMock).to have_requested(:get, /.*/)
+          expect(user.is_not_gdpr_location).to eq true
+          expect(session).to eq ({gdpr: "o#{us_ip}"})
+        end
+      end
+
+      context "for unresolvable addresses" do
+        it "sets the user status to unknown and clears session data" do
+          session = {gdpr: "i#{eu_ip}"}
+          described_class.call(user: user, session: session, ip: "howdy")
+          expect(user.is_not_gdpr_location).to eq false
+          expect(session).to eq ({})
+        end
+      end
+    end
+
+    context "data not yet cached" do
+      context "for EU addresses" do
+        it "sets the user status and cache" do
+          session = {}
+          described_class.call(user: user, session: session, ip: eu_ip)
+          expect(user.is_not_gdpr_location).to eq false
+          expect(session).to eq({gdpr: "i#{eu_ip}"})
+        end
+      end
+
+      context "for unresolvable addresses" do
+        it "sets the user status to unknown and clears session data" do
+
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe Api::V1::UserRepresenter, type: :representer do
       expect { representer.from_hash(hash) }.not_to change { user.reload.is_test? }
     end
   end
+
+  context 'is_not_gdpr_location' do
+    it 'is not there normally' do
+      expect(representer.to_hash).not_to have_key('is_not_gdpr_location')
+    end
+
+    it "is there when set and private data included" do
+      user.is_not_gdpr_location = false
+      expect(representer.to_hash(user_options: {include_private_data: true})['is_not_gdpr_location']).to eq false
+    end
+  end
 end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -21,6 +21,14 @@ VCR.configure do |c|
       c.filter_sensitive_data("<#{salesforce_secret_name}>") { value } if value.present?
     end
   end
+
+  %w(
+    ip_api_key
+  ).each do |secret_name|
+    Rails.application.secrets[secret_name.to_sym].tap do |value|
+      c.filter_sensitive_data("<#{secret_name}>") { value } if value.present?
+    end
+  end
 end
 
 VCR_OPTS = {


### PR DESCRIPTION
In the `/api/user` endpoint, provides a `is_not_gdpr_location` flag if the user is not in a GDPR location based on the user's IP address.  I chose a negative flag (`is_not...`) because we don't always know for sure that a user _is_ in a GDPR location due to the fact that sometimes our test may not return a good location or an error or timeout may prevent a location from being received.  

The flag is cached in the user's session, so we should only have to make the request once rarely (not every time `/api/user` is called).

We aggressively rescue exceptions in the code that makes the IP address location request as we want to always be able to return a result from `/api/user`.