### PR TITLE
Start new sign in/up flow - create layout and form skeleton

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/openstax/pattern-library.git
-  revision: 810c7ea897c093348203819fd306c3f2da9332c1
+  revision: 68befb92b322dd41c61a802ee89ad9f8d6d45bff
   branch: master
   specs:
     pattern-library (1.1.0)

--- a/app/assets/javascripts/newflow.coffee
+++ b/app/assets/javascripts/newflow.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the newflow controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/newflow_layout.scss
+++ b/app/assets/stylesheets/newflow_layout.scss
@@ -1,0 +1,99 @@
+@import "font-awesome";
+@import "pattern-library";
+
+html {
+    // font-family: 'HelveticaNeue-Bold', 'Helvetica Neue Bold', 'Helvetica Neue';
+    font-family: 'ArialMT', 'Arial';
+}
+
+body {
+    background-color: #fff;
+}
+
+.content form, form.content {
+    background-color: white;
+}
+
+// sign in/up form
+#signinup-form {
+    max-width: 75rem;
+    border-top: 0;
+    margin-top: 3rem;
+    margin-left: auto;
+    margin-right: auto;
+
+    form {
+        border-color: #d5d5d5;
+        border-style: solid;
+        border-width: 0.1rem;
+        border-top: 0;
+
+        h1 {
+            font-size: 36px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        label {
+            font-weight: bold;
+        }
+    }
+
+    .divider {
+        font-weight: bold;
+        font-size: 12px;
+        text-align: center;
+    }
+
+    .tab-group {
+        padding: 0;
+    }
+
+    .tab {
+        border-bottom: 0.1rem solid #d5d5d5;
+        width: 172px;
+        height: 51px;
+        padding: 0;
+        border-style: solid;
+        border-color: #d5d5d5;
+        border-width: 0.1rem;
+
+        &:first-child {
+            border-right: 0;
+        }
+
+        &.active {
+            border-bottom-width: 0;
+            border-bottom-color: #fff;
+        }
+
+        &.inactive {
+            background-color: #f6f8fa;
+        }
+    }
+
+    .tab__placeholder {
+        border: 0;
+        border-bottom: 0.1rem solid #d5d5d5;
+        background-color: #fff; // TODO: same as html or body background color OR transparent
+    }
+
+    [type="submit"] {
+        width: 172px;
+    }
+
+    [type="checkbox"] {
+        height: auto;
+    }
+}
+
+// temporary styling for the social buttons until the styling is added to the pattern-library
+.btn-facebook {
+    background-color: #3b5998;
+    color: white;
+}
+
+.btn-google {
+    color: #fff;
+    background-color: #dd4b39;
+}

--- a/app/controllers/newflow_controller.rb
+++ b/app/controllers/newflow_controller.rb
@@ -1,0 +1,10 @@
+class NewflowController < ApplicationController
+    layout 'newflow_layout'
+    skip_before_action :authenticate_user!
+
+    def signin
+    end
+
+    def signup
+    end
+end

--- a/app/helpers/newflow_helper.rb
+++ b/app/helpers/newflow_helper.rb
@@ -1,0 +1,2 @@
+module NewflowHelper
+end

--- a/app/views/layouts/newflow_layout.html.erb
+++ b/app/views/layouts/newflow_layout.html.erb
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+
+    <title>OpenStax Accounts</title>
+    <%= stylesheet_link_tag 'newflow_layout', media: 'all', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'newflow', 'data-turbolinks-track' => true %>
+    <%= csrf_meta_tags %>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="content">
+
+      <%= render 'layouts/attention' %>
+
+      <%= yield %>
+    </div>
+
+  <%= yield :javascript %>
+
+  </body>
+</html>

--- a/app/views/newflow/signin.html.erb
+++ b/app/views/newflow/signin.html.erb
@@ -1,0 +1,42 @@
+<div id="signinup-form">
+    <div class="content">
+        <div class="tab-group">
+            <div class="tab active">Log in</div>
+            <div class="tab inactive">Sign up</div>
+            <div class="tab tab__placeholder"></div>
+            <div class="tab tab__placeholder"></div>
+            <div class="tab tab__placeholder"></div>
+        </div>
+        <form>
+            <h1>Log in to your OpenStax account</h1>
+
+            <div class="content">
+                <div>Login with:</div>
+                <div>
+                    <a class="btn btn-social btn-facebook">
+                        <i class="fa fa-facebook"></i> Facebook
+                    </a>
+                    <a class="btn btn-social btn-google">
+                        <i class="fa fa-google"></i> Google
+                    </a>
+                </div>
+            </div>
+
+            <div class="control-group">
+                <label class="field-label">Email *</label>
+                <input type="text" name="email"
+                            placeholder="Email" class="delay-validation" required>
+                <!-- <div class="invalid-message">Your email address or login with social</div> -->
+            </div>
+
+            <div class="control-group">
+                <label class="field-label">Password *</label>
+                <input type="password" name="password"
+                            placeholder="Password" class="delay-validation" required>
+                <!-- <div class="invalid-message">A secure password</div> -->
+            </div>
+
+            <span><input type="submit" value="Continue" class="primary"></span>
+        </form>
+    </input>
+</div>

--- a/app/views/newflow/signup.html.erb
+++ b/app/views/newflow/signup.html.erb
@@ -1,0 +1,68 @@
+<div id="signinup-form">
+    <div class="content">
+        <div class="tab-group">
+            <div class="tab inactive">Log in</div>
+            <div class="tab active">Sign up</div>
+            <div class="tab tab__placeholder"></div>
+            <div class="tab tab__placeholder"></div>
+            <div class="tab tab__placeholder"></div>
+        </div>
+        <form>
+                <h1>Set up your account</h1>
+
+                <input type="button" value="Student" class="disabled">
+
+                <div class="content">
+                    <div>Sign up with:</div>
+                    <div>
+                        <a class="btn btn-social btn-facebook">
+                            <i class="fa fa-facebook"></i> Facebook
+                        </a>
+                        <a class="btn btn-social btn-google">
+                            <i class="fa fa-google"></i> Google
+                        </a>
+                    </div>
+                </div>
+
+                <div class="divider">OR SIGN UP BELOW</div>
+
+                <div class="control-group">
+                    <label class="field-label">First name *</label>
+                    <input type="text" name="first_name"
+                                placeholder="First name" class="delay-validation" required>
+                    <!-- <div class="invalid-message">You surely have a first name</div> -->
+                </div>
+
+                <div class="control-group">
+                    <label class="field-label">Last name *</label>
+                    <input type="text" name="last_name"
+                                placeholder="Last name" class="delay-validation" required>
+                    <!-- <div class="invalid-message">You surely have a last name</div> -->
+                </div>
+
+                <div class="control-group">
+                    <label class="field-label">Email *</label>
+                    <input type="text" name="email"
+                                placeholder="Email" class="delay-validation" required>
+                    <!-- <div class="invalid-message">Your email address or login with social</div> -->
+                </div>
+
+                <div class="control-group">
+                    <label class="field-label">Password *</label>
+                    <input type="password" name="password"
+                                placeholder="Password" class="delay-validation" required>
+                    <!-- <div class="invalid-message">A secure password</div> -->
+                </div>
+
+                <div class="control-group">
+                    <input type="checkbox" name="newsletter" checked><span>Send me the OpenStax newsletter</span>
+                    <br>
+
+                    <input type="checkbox" name="toc">
+                    <span>I agree to the Terms of Use and Privacy Policy</span>
+                </div>
+
+                <span><input type="submit" value="Continue" class="primary"></span>
+        </form>
+    </input>
+</div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,4 +17,6 @@ Rails.application.config.assets.precompile += %w(
   bootstrap-editable/clear.png
   application_body_api_docs.css
   syntax_highlight.css
+  newflow_layout.css
+  newflow.js
 )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'static_pages#home'
 
+  scope controller: 'newflow' do
+    get 'newflow/signin', action: :signin
+    get 'newflow/signup', action: :signup
+  end
+
   scope controller: 'sessions' do
     get 'login', action: :start, as: :login
 
@@ -31,7 +36,7 @@ Rails.application.routes.draw do
 
   mount OpenStax::Salesforce::Engine, at: '/admin/salesforce'
   OpenStax::Salesforce.set_top_level_routes(self)
-  
+
   # Create a named path for links like `/auth/facebook` so that the path prefixer gem
   # will appropriately prefix the path.  https://stackoverflow.com/a/40125738/1664216
   get "/auth/:provider", to: lambda{ |env| [404, {}, ["Not Found"]] }, as: :oauth

--- a/spec/controllers/newflow_controller_spec.rb
+++ b/spec/controllers/newflow_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NewflowController, type: :controller do
+
+end

--- a/spec/helpers/newflow_helper_spec.rb
+++ b/spec/helpers/newflow_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the NewflowHelper. For example:
+#
+# describe NewflowHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe NewflowHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR is the first of many to come for the new Accounts flow 😃 . It creates a new `layout` template and the "skeleton" or basis for the new sign in/sign up form—just the html and css so, not yet functional; they are viewable locally at: http://localhost:2999/newflow/signup and http://localhost:2999/newflow/signin


## Notes
- **Issue: https://github.com/openstax/business-intel/issues/600**
- **I plan to refactor the CSS. For example, I could make the CSS cleaner by separating the styling for the Form With Tabs into its own file and things like that.**
- **No need for a super thorough code review.**
- **I'm requesting a merge onto my own—other—branch.**

# Screenshots of the forms currently added by this PR

## Sign up
![Screen Shot 2019-08-29 at 3 06 54 PM](https://user-images.githubusercontent.com/6620941/63972598-b7c70e80-ca6e-11e9-9e43-a4465873e344.png)

## Log in
![Screen Shot 2019-08-29 at 3 07 03 PM](https://user-images.githubusercontent.com/6620941/63972625-beee1c80-ca6e-11e9-84f3-131a2f5f28ea.png)
