### PR TITLE
Fix salesforce login callback

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'static_pages#home'
 
+  mount OpenStax::Salesforce::Engine, at: '/admin/salesforce'
+  OpenStax::Salesforce.set_top_level_routes(self)
+
   scope controller: 'sessions' do
     get 'login', action: :start, as: :login
 
@@ -28,9 +31,6 @@ Rails.application.routes.draw do
   end
 
   mount OpenStax::Api::Engine, at: '/'
-
-  mount OpenStax::Salesforce::Engine, at: '/admin/salesforce'
-  OpenStax::Salesforce.set_top_level_routes(self)
 
   # Create a named path for links like `/auth/facebook` so that the path prefixer gem
   # will appropriately prefix the path.  https://stackoverflow.com/a/40125738/1664216


### PR DESCRIPTION
During the Rails 5 upgrade, a change to `config/routes.rb` moved the Salesforce mounting and routes below the `sessions` routes.  The Salesforce engine, like Accounts, uses Omniauth to provide OAuth callbacks.  The Salesforce engine has an `/auth/salesforce/callback` route that was being occluded by the `SessionsController`'s `/auth/:provider/callback`.  This PR moves the Salesforce routes back near the top of the routes file so that this occlusion doesn't happen.

Note that there's still some slightly weird behavior.  When you login as the Salesforce user, you get redirected to the Accounts root URL whereas we used to get redirected to the _Salesforce engine_ root URL.  The relevant redirect is https://github.com/openstax/openstax_salesforce/blob/master/app/controllers/openstax/salesforce/settings_controller.rb#L10 and I don't know why it changed to the Accounts root instead of the engine root.  This isn't a deal breaker but it is a little annoying.