### PR TITLE
Make SSO cookie authoritative for current user; share session cookie across domains

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
 # Permanent cookie jar also uses 20 years
-Rails.application.config.session_store :cookie_store, key: '_accounts_session',
-                                                      expire_after: 20.years
+
+class SessionStoreCookieName
+  def self.to_s
+    environment_name = Rails.application.secrets.environment_name
+    "_accounts_session#{'_' + environment_name if environment_name != 'prodtutor'}"
+  end
+end
+
+Rails.application.config.session_store :cookie_store, key: SessionStoreCookieName.to_s,
+                                                      expire_after: 20.years,
+                                                      domain: :all

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -148,7 +148,7 @@ test:
       name: ox
       options:
         domain: ''
-        secure: true
+        secure: false
         httponly: true
 
   # The ip-api.com service gives us location data based on user IP address

--- a/spec/config/initializers/session_store_cookie_name_spec.rb
+++ b/spec/config/initializers/session_store_cookie_name_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe SessionStoreCookieName do
+  it 'works for production' do
+    allow(Rails.application.secrets).to receive(:environment_name) { "prodtutor" }
+    expect(described_class.to_s).to eq "_accounts_session"
+  end
+
+  it 'works for non production' do
+    allow(Rails.application.secrets).to receive(:environment_name) { "qa" }
+    expect(described_class.to_s).to eq "_accounts_session_qa"
+  end
+end


### PR DESCRIPTION
* Make the SSO cookie the one place to look for (and set) the current user
* Make the Accounts session cookie shared across domains so that OX sites that proxy Accounts can make use of it
* Make the Accounts session cookie name environment-specific so that cookies from different environments don't clobber each other.