### PR TITLE
Export user uuid instead of email address

### DIFF
--- a/app/routines/export_users_last_login_date.rb
+++ b/app/routines/export_users_last_login_date.rb
@@ -12,9 +12,9 @@ class ExportUsersLastLoginDate
 
   def info
     output_users = []
-    User.preload(:contact_infos).find_each do |user|
+    User.find_each do |user|
       output_users << Hashie::Mash.new({
-        emails: user.contact_infos.verified.map(&:value).join(", "),
+        id: user.uuid,
         last_login_at: SecurityLog.sign_in_successful
                                     .where(user_id: user.id)
                                     .first&.created_at&.strftime("%m/%d/%Y %I:%M%p %Z")
@@ -26,13 +26,13 @@ class ExportUsersLastLoginDate
   def generate_csv
     CSV.open(filename, 'w') do |file|
       file.add_row ([
-          "Email(s)",
+          "ID",
           "Last login date",
       ])
 
       info.each do |hashie|
         file.add_row([
-          hashie.emails,
+          hashie.id,
           hashie.last_login_at,
         ])
       end

--- a/spec/lib/tasks/export_users_last_login_date_spec.rb
+++ b/spec/lib/tasks/export_users_last_login_date_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ExportUsersLastLoginDate, type: :routine do
     end
 
     it "includes user's verified email addresses" do
-      expect(first_output.emails.split(', ')).to match_array [email_1.value, email_2.value]
+      expect(first_output.id).to eq user_1.uuid
     end
 
     context "as csv file with student information" do
@@ -37,8 +37,8 @@ RSpec.describe ExportUsersLastLoginDate, type: :routine do
           data = Hash[headers.zip(values)]
 
           expect(rows.count).to eq 2
-          expect(data["Email(s)"].split(', ')).to match_array [email_1.value, email_2.value]
-          expect(data["Last login date"]).to eq security_log_entry.created_at.strftime("%m/%d/%Y %I:%M%p %Z")
+          expect(data['ID']).to eq user_1.uuid
+          expect(data['Last login date']).to eq security_log_entry.created_at.strftime("%m/%d/%Y %I:%M%p %Z")
         end
       end
     end


### PR DESCRIPTION
For security reasons, we've decided that it's better to not include Personally Identifiable Information in a CSV (namely, email addresses). Instead, we can work with Unique User IDs.