### PR TITLE
Remove noise from rspec run output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ gem 'oj_mimic_json'
 # Admin toggles
 gem 'rails-settings-ui'
 gem 'rails-settings-cached', '0.7.2'
-gem 'dry-validation', '0.12.0'
+gem 'dry-validation', '0.12.3'
 
 gem 'scout_apm', '~> 3.0.x'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.6.0)
       execjs
-    awesome_print (1.7.0)
+    awesome_print (1.8.0)
     aws-ses (0.6.0)
       builder
       mail (> 2.2.5)
@@ -179,12 +179,12 @@ GEM
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.8)
+    dry-core (0.4.9)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.2)
     dry-inflector (0.1.2)
-    dry-logic (0.6.1)
-      concurrent-ruby (~> 1.0)
+    dry-logic (0.4.2)
+      dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
     dry-types (0.13.4)
@@ -194,12 +194,12 @@ GEM
       dry-equalizer (~> 0.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 0.4, >= 0.4.2)
-    dry-validation (0.12.0)
+    dry-validation (0.12.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
       dry-core (~> 0.2, >= 0.2.1)
       dry-equalizer (~> 0.2)
-      dry-logic (~> 0.4, >= 0.4.0)
+      dry-logic (~> 0.4.2)
       dry-types (~> 0.13.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -656,7 +656,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.3)
   doorkeeper
   dotenv-rails (= 2.7.2)
-  dry-validation (= 0.12.0)
+  dry-validation (= 0.12.3)
   factory_bot_rails
   faker
   fakeredis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,12 +238,12 @@ class User < ActiveRecord::Base
       manual_emails = verified_emails.reject { |email| email.confirmation_sent_at.nil? }
       manual_emails.any? ? manual_emails.max_by(&:created_at) : verified_emails.min_by(&:created_at)
     else
-      email_addresses.verified.order(
+      email_addresses.verified.order(Arel.sql(
         <<-SQL.strip_heredoc
           CASE WHEN "confirmation_sent_at" IS NULL THEN '-infinity' ELSE "created_at" END DESC,
           "created_at" ASC
         SQL
-      ).first
+      )).first
     end.try!(:value)
   end
 

--- a/spec/controllers/contact_infos_controller_spec.rb
+++ b/spec/controllers/contact_infos_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ContactInfosController, type: :controller do
 
     it "returns success if code matches" do
       get(:confirm, params: { code: @email.confirmation_code })
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to have_no_missing_translations
       expect(response.body).to have_content(t :"contact_infos.confirm.page_heading.success")
       expect(response.body).to(
@@ -103,7 +103,7 @@ RSpec.describe ContactInfosController, type: :controller do
 
     it "returns success if code matches" do
       get(:confirm_unclaimed, params: { code: email.confirmation_code })
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.body).to have_no_missing_translations
       expect(response.body).to(
         have_content(t :"contact_infos.confirm_unclaimed.thanks_for_validating")

--- a/spec/mailers/dev_mailer_spec.rb
+++ b/spec/mailers/dev_mailer_spec.rb
@@ -12,7 +12,7 @@ describe DevMailer, type: :mailer do
       expect(mail.from).to eq(['sender@localhost'])
       expect(mail.subject).to eq "[OpenStax] [Accounts] (test) Howdy"
       expect(mail.body.encoded).to eq(
-        "[\r\n  [0] {\r\n    :a => 2\r\n  },\r\n  [1] {\r\n    :b => \"yo yo yo\"\r\n  }\r\n]\r\n"
+        "[\r\n  [0] {\r\n    a: 2\r\n  },\r\n  [1] {\r\n    b: \"yo yo yo\"\r\n  }\r\n]\r\n"
       )
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,6 +52,8 @@ Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.asset_host = 'http://localhost:2999'
 
+Capybara.server = :puma, { Silent: true } # To clean up your test output
+
 # Normalize whitespaces
 Capybara.default_normalize_ws = true
 


### PR DESCRIPTION
The rspec logs had gotten a bit noisy with deprecation warnings, output from bugs in old versions of gems, capybara server messages, etc.  This PR makes updates so that those go away and get back to rows of green dots.

Old noisy output example: https://travis-ci.org/openstax/accounts/builds/585308493