### PR TITLE
Fix URI encoding/parsing error for redirect (back) URI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
   end
 
   def return_url_specified_and_allowed?
-    # This returns true iff `save_redirect` actually saved the URL
+    # This returns true if `save_redirect` actually saved the URL
     params[:r] && params[:r] == stored_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
 
   def return_url_specified_and_allowed?
     # This returns true if `save_redirect` actually saved the URL
-    params[:r] && params[:r] == stored_url
+    params[:r] && URI.encode(params[:r]) == stored_url
   end
 
   def verify_signed_params

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -48,7 +48,7 @@ ActionController::Base.class_exec do
 
     return true if url.blank? || !Host.trusted?(url)
 
-    store_url(url: url)
+    store_url(url: URI.encode(url))
   end
 
   def disable_fine_print

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -74,6 +74,11 @@ RSpec.describe SessionsController, type: :controller do
       expect(response).to redirect_to("https://something.openstax.org/howdy?blah=true")
     end
 
+    it 'redirect accepts non-ascii URIs' do
+      delete(:destroy, params: { r: "https://something.openstax.org/errata/form?book=Biology for AP\u00AE Courses" })
+      expect(response).to redirect_to("https://something.openstax.org/errata/form?book=Biology for AP\u00AE Courses")
+    end
+
     it 'does not redirect to a caller-specified URL if not in whitelist' do
       delete(:destroy, params: { r: "http://www.google.com" })
       expect(response).to redirect_to("/")


### PR DESCRIPTION
This PR _should_ fix the issue: https://sentry.cnx.org/openstax/accounts/issues/7518/

`URI::InvalidURIError: URI must be ascii only "https://cms-qa.openstax.org/errata/form?book=Biology for AP\u00AE Courses"`

## Proof (since this error comes from an interaction with an app outside of accounts)

### Before
```
irb(main):018:0> URI.parse("https://cms-qa.openstax.org/errata/form?book=Biology for AP\u00AE Courses")Traceback (most recent call last):
        1: from (irb):18
URI::InvalidURIError (URI must be ascii only "https://cms-qa.openstax.org/errata/form?book=Biology for AP\u00AE Courses")
```

### After
```
irb(main):019:0> URI.parse(URI.encode("https://cms-qa.openstax.org/errata/form?book=Biology for AP\u00AE Courses"))
=> #<URI::HTTPS https://cms-qa.openstax.org/errata/form?book=Biology%20for%20AP%C2%AE%20Courses>
```