### PR TITLE
Remove domain from sso cookie on dev and test

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -80,7 +80,9 @@ development:
     cookie:
       name: <%= ENV["SSO_COOKIE_NAME"] || 'ox' %>
       options:
-        domain: <%= ENV["SSO_COOKIE_DOMAIN"] || "''" %>
+        <% if ENV.key?("SSO_COOKIE_DOMAIN") %>
+        domain: <%= ENV["SSO_COOKIE_DOMAIN"] %>
+        <% end %>
         secure: <%= ActiveModel::Type::Boolean.new.cast ENV.fetch(
                       "SSO_COOKIE_SECURE", false
                     ) %>
@@ -147,7 +149,6 @@ test:
     cookie:
       name: ox
       options:
-        domain: ''
         secure: false
         httponly: true
 


### PR DESCRIPTION
Sending a cookie with "domain=''" is undefined behavior, according to the spec. Browsers treat it as no domain attribute (which the spec says it SHOULD do). Unfortunately, the python requests library chooses to ignore the cookie completely.  Instead, don't set it at all if it's not defined in the environment.