### PR TITLE
Create rake task for sending PIN confirmation emails

### DIFF
--- a/app/mailers/signup_confirmation_mailer.rb
+++ b/app/mailers/signup_confirmation_mailer.rb
@@ -11,4 +11,16 @@ class SignupConfirmationMailer < ApplicationMailer
 
     pre_auth_state.update_column(:confirmation_sent_at, Time.now)
   end
+
+# primarily used for testing the deliverability of the PIN confirmation emails
+  def pin_confirmation_email(email_address:, confirmation_pin:, confirmation_token:, user_full_name:)
+    @email_address = email_address
+    @user_full_name = user_full_name
+    @confirmation_pin = confirmation_pin
+    @confirmation_token = confirmation_token
+
+    mail(to: "\"#{@user_full_name}\" <#{@email_address}>",
+      subject: "Use PIN #{@confirmation_pin} to confirm your email address"
+    )
+  end
 end

--- a/app/views/signup_confirmation_mailer/pin_confirmation_email.html.erb
+++ b/app/views/signup_confirmation_mailer/pin_confirmation_email.html.erb
@@ -1,0 +1,18 @@
+<p>Welcome!</p>
+
+  <p>Enter your 6-digit PIN in your browser to confirm your email address:</p>
+
+  <p>Your PIN: <b><%= @confirmation_pin %></b></p>
+
+  <p>If you have any trouble using this PIN, you can also click the link below to confirm your email address:</p>
+
+<%
+  token_url = signup_verify_by_token_url(code: @confirmation_token)
+%>
+
+<p><%= link_to token_url, token_url %></p>
+
+<p>We sent this message because someone is trying to use '<%= @email_address %>' to create an OpenStax account.  If this wasn't you, please disregard this message.</p>
+
+
+<%= render :partial => 'shared/email_closing' %>

--- a/lib/tasks/send_pin_confirmation_emails.rake
+++ b/lib/tasks/send_pin_confirmation_emails.rake
@@ -1,0 +1,18 @@
+require 'csv'
+require 'faker'
+
+desc "Send PIN confirmation emails, needs EMAILS_CSV_PATH var"
+# primarily used for testing the deliverability of the PIN confirmation emails
+task :send_pin_confirmation_emails => [:environment] do
+  CSV.foreach(ENV['EMAILS_CSV_PATH']) do |row|
+
+    SignupConfirmationMailer.pin_confirmation_email(
+        email_address: row[0],
+        confirmation_pin: TokenMaker.contact_info_confirmation_pin,
+        confirmation_token: TokenMaker.contact_info_confirmation_code,
+        user_full_name: Faker::Name.name
+    ).deliver_later
+
+  end
+  puts 'Done.'
+end


### PR DESCRIPTION
Used for testing the deliverability of PIN confirmation emails.

Creates the rake command `rake send_pin_confirmation_emails`

It can be run this way:

`EMAILS_CSV_PATH='emails_list.csv' rake send_pin_confirmation_emails`

Needs a CSV file with only one column and no headers, for example: 

[emails_list.csv](#)
```
bryan@me.com
eli@me.com
bryaneli@me.com
```