### PR TITLE
Update inconsistent schema for oauth_applications

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,10 +246,10 @@ ActiveRecord::Schema.define(version: 2019_09_15_203826) do
     t.string "scopes", default: "", null: false
     t.string "lead_application_source", default: "", null: false
     t.boolean "confidential", default: true, null: false
-    t.boolean "can_access_private_user_data", default: false
-    t.boolean "can_find_or_create_accounts", default: false
-    t.boolean "can_message_users", default: false
-    t.boolean "can_skip_oauth_screen", default: false
+    t.boolean "can_access_private_user_data", default: false, null: false
+    t.boolean "can_find_or_create_accounts", default: false, null: false
+    t.boolean "can_message_users", default: false, null: false
+    t.boolean "can_skip_oauth_screen", default: false, null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end


### PR DESCRIPTION
Somehow this db constraint never made it into the schema and I just noticed. So, fix it.

The not null constraint _was_ added to the migration, here: https://github.com/openstax/accounts/blob/f9aafd4e6da30e1586703ff1e1cc47af0955f573/db/migrate/20190911171944_add_fine_grained_access_to_oauth_applications.rb#L3-L6