### PR TITLE
New accounts flow / Add the ability to login with google

### DIFF
--- a/app/handlers/oauth_callback.rb
+++ b/app/handlers/oauth_callback.rb
@@ -23,7 +23,15 @@ class OauthCallback
   def setup
     @data = parse_oauth_data(request.env['omniauth.auth'])
     # TODO: undo the following line when we deploy to production
-    @oauth_provider = @data.provider == 'facebooknewflow' ? 'facebook' : @data.provider
+    @oauth_provider = case @data.provider
+                      when 'facebooknewflow'
+                        'facebook'
+                      when 'googlenewflow'
+                        'google_oauth2'
+                      else
+                        @data.provider
+                      end
+
     outputs.email = @data.email
   end
 

--- a/app/models/omniauth_data.rb
+++ b/app/models/omniauth_data.rb
@@ -2,7 +2,7 @@
 class OmniauthData
 
   VALID_PROVIDERS = [
-    'identity', 'facebook', 'twitter', 'google_oauth2', 'facebooknewflow'
+    'identity', 'facebook', 'twitter', 'google_oauth2', 'facebooknewflow', 'googlenewflow'
   ]
 
   def initialize(auth_data)

--- a/app/views/login_signup/login_form.html.erb
+++ b/app/views/login_signup/login_form.html.erb
@@ -26,7 +26,7 @@
                             </div>
 
                             <div class="google-share-button">
-                                <%= link_to newflow_auth_path(:google), class: 'google btn' do %>
+                                <%= link_to newflow_auth_path(:googlenewflow), class: 'google btn' do %>
                                     <i class="social-icon fa fa-google"></i>
                                     <span>Google</span>
                                 <% end %>

--- a/app/views/login_signup/reset_password_email_sent.html.erb
+++ b/app/views/login_signup/reset_password_email_sent.html.erb
@@ -7,10 +7,11 @@
                     header: I18n.t(:"login_signup_form.password_reset_email_sent")) do %>
             <form>
                 <div class="content" style="text-align: center">
+                    <br />
                     <div>
                       <i class="fa fa-check-circle" style="font-size: 12rem; color: #63a524"></i>
                     </div>
-                    <br />
+                    <br /><br />
 
                     <div class="info-message">
                       <%=

--- a/app/views/login_signup/signup_form.html.erb
+++ b/app/views/login_signup/signup_form.html.erb
@@ -43,7 +43,7 @@
                         </div>
 
                         <div class="google-share-button">
-                            <%= link_to '#TODO', class: 'google btn' do %>
+                            <%= link_to newflow_auth_path(:googlenewflow), class: 'google btn' do %>
                                 <i class="social-icon fa fa-google"></i>
                                 <span>Google</span>
                             <% end %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -15,6 +15,7 @@ require 'lookup_users'
 require 'rate_limiting'
 require 'omniauth/strategies/custom_identity'
 require "omniauth/strategies/facebooknewflow"
+require "omniauth/strategies/googlenewflow"
 require 'email_address_validations'
 require 'subjects_utils'
 require 'host'

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,8 @@
 secrets = Rails.application.secrets
 
 Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :custom_identity
+
   provider :facebook, secrets[:facebook_app_id], secrets[:facebook_app_secret],
            client_options: {
              site: 'https://graph.facebook.com/v3.3',
@@ -20,9 +22,11 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     }
   )
 
-  provider :twitter, secrets[:twitter_consumer_key], secrets[:twitter_consumer_secret]
   provider :google_oauth2, secrets[:google_client_id], secrets[:google_client_secret]
-  provider :custom_identity
+
+  provider 'googlenewflow', secrets[:google_client_id], secrets[:google_client_secret]
+
+  provider :twitter, secrets[:twitter_consumer_key], secrets[:twitter_consumer_secret]
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/lib/omniauth/strategies/googlenewflow.rb
+++ b/lib/omniauth/strategies/googlenewflow.rb
@@ -1,0 +1,4 @@
+class Googlenewflow < OmniAuth::Strategies::GoogleOauth2
+  option :path_prefix, '/i/auth'
+  option :name, 'googlenewflow'
+end


### PR DESCRIPTION
My implementation strategy is to create a new `omniauth` strategy called `googlenewflow` that works the same way as our `google` strategy but redirects instead to the newflow controller's callback action. 

I found that this is much easier and straightforward than the alternative—which, if I recall correctly, is to _somehow_ detect that the request came from the `NewflowController` and redirect back to the correct action.