### PR TITLE
Speed up search by verified on contact infos

### DIFF
--- a/db/migrate/20191119210310_add_index_to_contact_infos.rb
+++ b/db/migrate/20191119210310_add_index_to_contact_infos.rb
@@ -1,0 +1,5 @@
+class AddIndexToContactInfos < ActiveRecord::Migration[5.2]
+  def change
+    add_index :contact_infos, :verified
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_15_203826) do
+ActiveRecord::Schema.define(version: 2019_11_19_210310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2019_09_15_203826) do
     t.index ["confirmation_pin"], name: "index_contact_infos_on_confirmation_pin"
     t.index ["user_id"], name: "index_contact_infos_on_user_id"
     t.index ["value", "user_id", "type"], name: "index_contact_infos_on_value_user_id_type", unique: true
+    t.index ["verified"], name: "index_contact_infos_on_verified"
   end
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Add a DB index to speed up search by verified on contact infos so that queries like this one we tried to run works in a reasonable amount of time:

```
SecurityLog.where(event_type: :sign_in_successful, user: User.left_joins(:contact_infos).where.not(contact_infos: ContactInfo.verified)).count
```