### PR TITLE
Add password tooltip with instant validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/openstax/pattern-library.git
-  revision: 68befb92b322dd41c61a802ee89ad9f8d6d45bff
+  revision: 15e400c7717ee99bb08812ac38103bbd6d5cff86
   branch: master
   specs:
     pattern-library (1.1.0)

--- a/app/assets/stylesheets/newflow_layout.scss
+++ b/app/assets/stylesheets/newflow_layout.scss
@@ -683,3 +683,23 @@ input.has-error {
         }
     }
 }
+
+// Tooltip on form inputs
+
+.input-with-tooltip {
+    @include input-with-tooltip();
+
+    input:focus {
+        @extend %active;
+    }
+
+    .tooltip {
+        @extend %tooltip;
+
+        max-width: 25rem;
+
+        @include width-up-to($phone-max) {
+            max-width: 100%;
+        }
+    }
+}

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -3,12 +3,14 @@ class Identity < OmniAuth::Identity::Models::ActiveRecord
   DEFAULT_PASSWORD_EXPIRATION_PERIOD = \
     Rails.configuration.accounts.default_password_expiration_period
 
+  MIN_PASSWOROD_LENGTH = 8
+
   belongs_to :user, inverse_of: :identity
 
   # We need these validations because
   # omniauth-identity does not provide them by default
   # These attributes are (obviously) not saved in the database
-  validates :password, presence: true, length: { minimum: 8, maximum: 50 }
+  validates :password, presence: true, length: { minimum: MIN_PASSWOROD_LENGTH, maximum: 50 }
   validates :user, presence: true
   validates :user_id, uniqueness: true
 

--- a/app/views/login_signup/signup_form.html.erb
+++ b/app/views/login_signup/signup_form.html.erb
@@ -7,6 +7,8 @@
         # TODO: show them in a modal instead of new tab
         # link_to contract.title, term_path(contract), remote: true
     }
+
+    @min_passw_length ||= Identity::MIN_PASSWOROD_LENGTH
 %>
 
 <div id="login-signup-form">
@@ -87,10 +89,26 @@
                     <%= label_tag :password, I18n.t(:"login_signup_form.password_label"),
                                 class: 'field-label required'
                     %>
-                    <%= fh.text_field name: :password,
-                                type: :password,
-                                placeholder: I18n.t(:"login_signup_form.password_label")
-                    %>
+                    <div class="input-with-tooltip">
+                        <%
+                            # Note the f.text_field instead of fh.text_field – to not create a wrapper div
+                            # which would break the tooltip
+                        %>
+                        <%= f.text_field :password,
+                                                     type: :password,
+                                                     placeholder: I18n.t(:"login_signup_form.password_label")
+                        %>
+                        <div class="tooltip">
+                            <h4>Password requirements</h4>
+                            <div>
+                                <i id="password-requirements-check"
+                                    class="fa fa-check-circle"
+                                    style="font-size: 2rem; color: #c1c1c1">
+                                </i>
+                                <%= @min_passw_length&.to_s %> characters minimum
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="content control-group checkboxes-section">
@@ -125,6 +143,17 @@
 
 <script type="text/javascript">
     Accounts.Ui.enableOnChecked('#signup_form_submit_button', '#signup_terms_accepted');
+
+    var pwd_input = document.getElementById('signup_password');
+    var pwd_checkmark = document.getElementById('password-requirements-check');
+
+    pwd_input.oninput = function(event){
+        if (pwd_input.value.length >= <%= @min_passw_length %>) {
+            pwd_checkmark.style.color = 'green';
+        } else {
+            pwd_checkmark.style.color = '#c1c1c1';
+        }
+    }
 </script>
 
 <%# TODO: move this to some CSS file %>


### PR DESCRIPTION
Uses the tooltip from the pattern-library and adds it to the Sign up form's password field, with instant validation of password length requirements using javascript.