### PR TITLE
Fix bundler error: scout_apm gem pre- version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ gem 'rails-settings-ui'
 gem 'rails-settings-cached', '0.7.2'
 gem 'dry-validation', '0.12.3'
 
-gem 'scout_apm', '~> 3.0.x'
+gem 'scout_apm', '~> 3.0.0.pre28'
 
 # Respond to ELB healthchecks in /ping and /ping/
 gem 'openstax_healthcheck'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,7 +702,7 @@ DEPENDENCIES
   rspec-instafail
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
-  scout_apm (~> 3.0.x)
+  scout_apm (~> 3.0.0.pre28)
   selenium-webdriver (>= 3.141.0)
   sentry-raven
   shoulda-matchers (~> 3.1)


### PR DESCRIPTION
Fixes unable to deploy because bundler complains about invalid gem version `3.0.x`, changed it to `3.0.0.pre28` instead.