### PR TITLE
Revert "Bump nokogiri from 1.10.5 to 1.10.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.4.0)
-    nokogiri (1.10.8)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.0)
       nenv (~> 0.1)


### PR DESCRIPTION
Reverts openstax/accounts#755 because it created some issues upon merging the new_student_flow branch. I'll merge this one after that one.