### PR TITLE
Create missing specs in newflow: spec/features/newflow/add_social_auth_spec.rb, spec/features/newflow/user_claims_account_spec.rb

### DIFF
--- a/spec/features/newflow/add_social_auth_spec.rb
+++ b/spec/features/newflow/add_social_auth_spec.rb
@@ -1,23 +1,27 @@
 require 'rails_helper'
 
 feature 'Add social auth', js: true do
+  before do
+    turn_on_feature_flag
+  end
+
   scenario "email collides with a different existing user's verified email" do
     create_email_address_for(create_user('other_user'), 'user@example.com')
 
     user = create_user 'user'
-    log_in('user', 'password')
+    newflow_log_in_user('user', 'password')
 
-    expect_profile_page
+    expect_newflow_profile_page
 
     click_link (t :"users.edit.enable_other_sign_in_options")
     wait_for_animations
     expect(page).to have_content('Facebook')
 
     with_omniauth_test_mode(email: 'user@example.com') do
-      find('.authentication[data-provider="facebook"] .add').click
+      find('.authentication[data-provider="facebooknewflow"] .add--newflow').click
       wait_for_ajax
       screenshot!
-      expect_profile_page
+      expect_newflow_profile_page
       expect(page).to have_content("already in use")
     end
   end
@@ -26,18 +30,18 @@ feature 'Add social auth', js: true do
     user = create_user 'user'
     create_email_address_for(user, 'user@example.com')
 
-    log_in('user', 'password')
+    newflow_log_in_user('user', 'password')
 
-    expect_profile_page
+    expect_newflow_profile_page
 
     click_link (t :"users.edit.enable_other_sign_in_options")
     wait_for_animations
     expect(page).to have_content('Facebook')
 
     with_omniauth_test_mode(email: 'user@example.com') do
-      find('.authentication[data-provider="facebook"] .add').click
+      find('.authentication[data-provider="facebooknewflow"] .add--newflow').click
       wait_for_ajax
-      expect_profile_page
+      expect_newflow_profile_page
       expect(page).to have_no_content("already in use")
       expect(page).to have_content('Facebook')
     end
@@ -47,19 +51,19 @@ feature 'Add social auth', js: true do
     create_email_address_for(create_user('other_user'), 'user@example.com', 'token')
 
     user = create_user 'user'
-    log_in('user', 'password')
+    newflow_log_in_user('user', 'password')
 
-    expect_profile_page
+    expect_newflow_profile_page
 
     click_link (t :"users.edit.enable_other_sign_in_options")
     wait_for_animations
     expect(page).to have_content('Facebook')
 
     with_omniauth_test_mode(email: 'user@example.com') do
-      find('.authentication[data-provider="facebook"] .add').click
+      find('.authentication[data-provider="facebooknewflow"] .add--newflow').click
       wait_for_ajax
       screenshot!
-      expect_profile_page
+      expect_newflow_profile_page
       expect(page).to have_content('Facebook')
     end
   end

--- a/spec/features/newflow/user_claims_account_spec.rb
+++ b/spec/features/newflow/user_claims_account_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+feature 'User claims an unclaimed account' do
+  before do
+    turn_on_feature_flag
+  end
+
+  background { load 'db/seeds.rb' }
+  let!(:app)   { create_default_application }
+  let(:user_email) { 'unclaimeduser@example.com' }
+  let(:user_options) {
+    {
+      email: user_email,
+      application: app,
+      username: 'therulerofallthings',
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      already_verified: false
+    }
+  }
+
+  def visit_invite_url
+    delivery = ActionMailer::Base.deliveries.last
+    match = delivery.body.encoded.match(/(confirm\/unclaimed\?code=\w+)/)
+    expect(match).to_not be_nil
+    visit '/' + match.captures.first
+  end
+
+
+  describe 'a new user receives an invite' do
+
+    scenario 'without a pre-existing password' do
+      FindOrCreateUnclaimedUser.call(user_options).outputs[:user]
+
+      visit_invite_url
+
+      expect(page).to have_no_missing_translations
+      click_on t 'contact_infos.confirm_unclaimed.you_can_now_sign_in.add_password'
+      expect(page).to have_content(t :"identities.add.page_heading")
+      complete_add_password_screen
+
+      complete_add_password_success_screen
+      complete_terms_screens
+      expect_back_at_app
+    end
+
+    scenario 'and resets the password' do
+      arrive_from_app(do_expect: false)
+
+      FindOrCreateUnclaimedUser.call(
+        user_options.merge(
+          password: "apassword", password_confirmation: "apassword"
+        )
+      )
+
+      visit_invite_url
+      click_on t 'contact_infos.confirm_unclaimed.you_can_now_sign_in.reset_password'
+      expect(page).to have_content(t :"identities.reset.page_heading")
+      complete_reset_password_screen
+      complete_reset_password_success_screen
+      complete_terms_screens
+      expect_back_at_app
+    end
+  end
+end


### PR DESCRIPTION
Create missing specs in newflow: spec/features/newflow/add_social_auth_spec.rb, spec/features/newflow/user_claims_account_spec.rb

It is mostly a copy & paste from spec/features/add_social_auth_spec.rb and spec/features/user_claims_account_spec.rb
