### PR TITLE
add migration to remove newflow_feature_flag

### DIFF
--- a/db/migrate/20200311202045_update_settings_value_to_student_flow.rb
+++ b/db/migrate/20200311202045_update_settings_value_to_student_flow.rb
@@ -1,0 +1,8 @@
+class UpdateSettingsValueToStudentFlow < ActiveRecord::Migration[5.2]
+  def up
+    ActiveRecord::Base.connection.execute("delete from Settings where var = 'newflow_feature_flag'")
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,11 +268,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_165835) do
     t.text "return_to"
     t.jsonb "signed_data"
     t.boolean "is_partial_info_allowed", default: false, null: false
-    t.string "first_name", default: ""
-    t.string "last_name", default: ""
-    t.bigint "user_id"
     t.index ["contact_info_kind"], name: "index_pre_auth_states_on_contact_info_kind"
-    t.index ["user_id"], name: "index_pre_auth_states_on_user_id"
   end
 
   create_table "security_logs", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
The newflow_feature_flag has been renamed (to studentflow_feature_flag).   The older flag (newflow) needed to be removed from the db as well due to use of rails_settings_cache gem. 