### PR TITLE
Fix osweb URLs in secrets yml

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -177,6 +177,9 @@ test:
   # The ip-api.com service gives us location data based on user IP address
   ip_api_key: the_ip_api_key
 
+  cms_url: https://cms-dev.openstax.org
+  openstax_url: https://dev.openstax.org
+
 production:
   # Used to encrypt and sign cookies
   # Changing this will invalidate all cookies
@@ -274,5 +277,6 @@ production:
     dsn: ssm(sentry_dsn)
   scout:
     license_key: ssm(scout_license_key)
-  cms_url: https://cms-dev.openstax.org
-  openstax_url: https://dev.openstax.org
+
+  cms_url: https://cms-prod.openstax.org
+  openstax_url: https://openstax.org

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -84,6 +84,9 @@ development:
   # The ip-api.com service gives us location data based on user IP address
   ip_api_key: the_ip_api_key
 
+  cms_url: https://cms-dev.openstax.org
+  openstax_url: https://dev.openstax.org
+
 test:
   # Used to encrypt and sign cookies
   # Changing this will invalidate all cookies

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -274,3 +274,5 @@ production:
     dsn: ssm(sentry_dsn)
   scout:
     license_key: ssm(scout_license_key)
+  cms_url: https://cms-dev.openstax.org
+  openstax_url: https://dev.openstax.org


### PR DESCRIPTION
These were apparently missing from the secrets.yml.example file