### PR TITLE
Removed call to SecurityLog since user_session_management is handling it

### DIFF
--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -30,7 +30,6 @@ module Newflow
         success: lambda {
           clear_newflow_state
           sign_in!(@handler_result.outputs.user)
-          security_log(:sign_in_successful)
           redirect_back # back to `r`eturn parameter. See `before_action :save_redirect`.
         },
         failure: lambda {


### PR DESCRIPTION
user_session_management is adding more data to the SecurityLog than login_signup_controller, so I decided to keep it and remove the duplicate.