### PR TITLE
Fix error reported by Sentry: undefined method 'email_addresses'

### DIFF
--- a/app/access_policies/user_access_policy.rb
+++ b/app/access_policies/user_access_policy.rb
@@ -4,7 +4,7 @@ class UserAccessPolicy
   def self.action_allowed?(action, requestor, user)
     case action
     when :search
-      requestor.is_application? || requestor.is_activated?
+      requestor.is_application? || requestor.activated?
     when :read, :update
       # Self or admin
       requestor.is_human? &&
@@ -12,7 +12,7 @@ class UserAccessPolicy
       (requestor == user || requestor.is_administrator?)
     when :signup
       requestor.is_human? &&
-      (requestor.is_anonymous? || !requestor.is_activated?) &&
+      (requestor.is_anonymous? || !requestor.activated?) &&
       requestor == user # Temp or unclaimed users only
     when :unclaimed
       # find-or-create accounts that are a stand-in for a person who's not yet signed up

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -16,7 +16,8 @@ module Newflow
     before_action :restart_if_missing_unverified_user,
       only: [
         :verify_email_by_pin, :change_your_email, :confirmation_form,
-        :confirmation_form_updated_email, :change_signup_email
+        :confirmation_form_updated_email, :change_signup_email,
+        :confirm_oauth_info, :confirm_social_info_form
       ]
     before_action :exit_newflow_signup_if_logged_in, only: [:student_signup_form, :welcome]
     before_action :set_active_banners

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -6,7 +6,7 @@ module Newflow
     skip_before_action :authenticate_user!
     skip_before_action :check_if_password_expired
     fine_print_skip :general_terms_of_use, :privacy_policy,
-      except: [:profile_newflow, :verify_pin, :signup_done]
+      except: [:profile_newflow, :signup_done, :verify_email_by_code]
 
     before_action :newflow_authenticate_user!, only: [:profile_newflow]
     before_action :save_new_params_in_session, only: [:login_form, :welcome]
@@ -15,7 +15,7 @@ module Newflow
     before_action :known_signup_role_redirect, only: [:login_form]
     before_action :restart_if_missing_unverified_user,
       only: [
-        :verify_email, :verify_pin, :change_your_email, :confirmation_form,
+        :verify_email_by_pin, :change_your_email, :confirmation_form,
         :confirmation_form_updated_email, :change_signup_email
       ]
     before_action :exit_newflow_signup_if_logged_in, only: [:student_signup_form, :welcome]

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -175,7 +175,7 @@ module Newflow
             authentication = @handler_result.outputs.authentication
             user = @handler_result.outputs.user
 
-            if !user.is_activated?
+            if !user.activated?
               # not activated means signup
               save_unverified_user(user)
               @first_name = user.first_name

--- a/app/handlers/faculty_access_apply.rb
+++ b/app/handlers/faculty_access_apply.rb
@@ -36,7 +36,7 @@ class FacultyAccessApply
   end
 
   def authorized?
-    caller.is_activated?
+    caller.activated?
   end
 
   def handle

--- a/app/handlers/newflow/confirm_oauth_info.rb
+++ b/app/handlers/newflow/confirm_oauth_info.rb
@@ -25,7 +25,7 @@ module Newflow
     end
 
     def authorized?
-      !@user.is_activated?
+      !@user.activated?
     end
 
     def handle

--- a/app/handlers/newflow/oauth_callback.rb
+++ b/app/handlers/newflow/oauth_callback.rb
@@ -69,7 +69,7 @@ module Newflow
     def newflow_handle_while_logged_in
       outputs.authentication = authentication = Authentication.find_or_initialize_by(provider: @oauth_provider, uid: @oauth_uid)
 
-      if authentication.user && authentication.user.is_activated?
+      if authentication.user && authentication.user.activated?
         fatal_error(
           code: :authentication_taken,
           message: I18n.t(:"controllers.sessions.sign_in_option_already_used")

--- a/app/handlers/newflow/verify_email_by_code.rb
+++ b/app/handlers/newflow/verify_email_by_code.rb
@@ -14,7 +14,7 @@ module Newflow
 
     def handle
       run(ConfirmByCode, params[:code])
-      run(ActivateUser, outputs.contact_info.user) # TODO: a user could be just adding another email
+      run(ActivateUser, outputs.contact_info.user)
 
       outputs.user = outputs.contact_info.user
     end

--- a/app/handlers/newflow/verify_email_by_pin.rb
+++ b/app/handlers/newflow/verify_email_by_pin.rb
@@ -26,7 +26,7 @@ module Newflow
       end
 
       claiming_user = options[:email_address].user
-      run(ActivateUser, claiming_user) # TODO: a user could be just adding another email
+      run(ActivateUser, claiming_user)
 
       outputs.user = claiming_user
     end

--- a/app/handlers/sessions_create.rb
+++ b/app/handlers/sessions_create.rb
@@ -135,7 +135,7 @@ class SessionsCreate
     # Check if they are trying to add a new authentication to their account
     if request.env['omniauth.params'].try!(:[], 'add') == 'true'
       # Add the new authentication
-      return :authentication_taken if authentication_user && authentication_user.is_activated?
+      return :authentication_taken if authentication_user && authentication_user.activated?
 
       return :same_provider \
         if current_user.authentications.map(&:provider).include?(authentication.provider)

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -21,7 +21,7 @@ class AnonymousUser
     false
   end
 
-  def is_activated?
+  def activated?
     false
   end
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -20,7 +20,7 @@ class Authentication < ActiveRecord::Base
   protected
 
   def check_not_last
-    if user.present? && user.authentications.size <= 1 && user.is_activated?
+    if user.present? && user.authentications.size <= 1 && user.activated?
       throw(:abort)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,7 +126,7 @@ class User < ActiveRecord::Base
   # that were assigned to it in the interm.
   #
   # Once a User model is cleared for use, the state is set to "activated"
-  def is_activated?
+  def activated?
     'activated' == state
   end
 

--- a/app/routines/destroy_user.rb
+++ b/app/routines/destroy_user.rb
@@ -10,7 +10,7 @@ class DestroyUser
     # Make sure object up to date, esp before dependent destroy stuff kicks in
     user.reload
 
-    fatal_error(code: :cannot_destroy_activated_user, data: user) if user.is_activated?
+    fatal_error(code: :cannot_destroy_activated_user, data: user) if user.activated?
 
     user.destroy_original
   end

--- a/app/routines/newflow/activate_user.rb
+++ b/app/routines/newflow/activate_user.rb
@@ -1,3 +1,6 @@
+# Sets the passed-in user's `state` to `'activated'`
+# and pushes the user to salesforce as a new lead
+# If the user is already `activated`, then it does nothing.
 module Newflow
   class ActivateUser
     lev_routine
@@ -5,8 +8,9 @@ module Newflow
     protected ###############
 
     def exec(user)
-      push_lead_to_salesforce(user)
+      return if user.state.is_activated?
 
+      push_lead_to_salesforce(user)
       user.update(state: 'activated')
     end
 

--- a/app/routines/newflow/activate_user.rb
+++ b/app/routines/newflow/activate_user.rb
@@ -8,7 +8,7 @@ module Newflow
     protected ###############
 
     def exec(user)
-      return if user.state.is_activated?
+      return if user.is_activated?
 
       push_lead_to_salesforce(user)
       user.update(state: 'activated')

--- a/app/routines/newflow/activate_user.rb
+++ b/app/routines/newflow/activate_user.rb
@@ -8,7 +8,7 @@ module Newflow
     protected ###############
 
     def exec(user)
-      return if user.is_activated?
+      return if user.activated?
 
       push_lead_to_salesforce(user)
       user.update(state: 'activated')

--- a/app/routines/transfer_authentications.rb
+++ b/app/routines/transfer_authentications.rb
@@ -26,6 +26,6 @@ class TransferAuthentications
 
   # The user must have already tried to signup with the given authentication.
   def can_be_destroyed?(user)
-    !user.is_activated? && user.reload.authentications.empty?
+    !user.activated? && user.reload.authentications.empty?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -238,9 +238,9 @@ RSpec.describe User, type: :model do
       user = FactoryBot.create(:user)
       user.state = 'temp'
       expect(user.is_temp?).to    be_truthy
-      expect(user.is_activated?).to be_falsey
+      expect(user.activated?).to be_falsey
       user.state = 'activated'
-      expect(user.is_activated?).to be_truthy
+      expect(user.activated?).to be_truthy
       expect(user.is_temp?).to    be_falsey
     end
 


### PR DESCRIPTION
Fixes error`NoMethodError: undefined method email_addresses' for nil:NilClass` 
in `/i/verify_email_by_pin` 

https://sentry.cnx.org/openstax/accounts/issues/64952/

Also solves a related error: https://sentry.cnx.org/openstax/accounts/issues/129080/