### PR TITLE
Fix: not saving updated info from social provider

### DIFF
--- a/app/handlers/newflow/authenticate_user.rb
+++ b/app/handlers/newflow/authenticate_user.rb
@@ -77,7 +77,7 @@ module Newflow
       # link email from signed params
       run(AddEmailToUser, sp['email'], user, already_verified: false)
       user.save
-      transfer_errors_from(user, {type: :verbatim}, true)
+      transfer_errors_from(user, {type: :verbatim}, :fail_if_errors)
 
       # delete the user_from_signed_params (aka.  unverified user) which was created initially
     end


### PR DESCRIPTION
as I was fixing a bug, I noticed another bug: it turns out that the form where you Confirm your [social] info is not saving the first name + last name IF you change it from what we got from the social provider. This only affects new users signing up with a social provider who wanted to change their first name and/or last name to something different than what is stored in their social network provider. 


## Fixes issue https://github.com/openstax/business-intel/issues/985