### PR TITLE
Prevent users that still need a profile from being sent to OAuth apps

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -12,6 +12,7 @@ Doorkeeper.configure do
       newflow_authenticate_user!
     else
       authenticate_user!
+      redirect_to '/signup/profile' if current_user.is_needs_profile?
     end
 
     current_user

--- a/db/migrate/20200331192627_assign_names_to_users_that_bypassed_profile_creation.rb
+++ b/db/migrate/20200331192627_assign_names_to_users_that_bypassed_profile_creation.rb
@@ -1,9 +1,16 @@
 class AssignNamesToUsersThatBypassedProfileCreation < ActiveRecord::Migration[5.2]
   def up
     User.joins(:application_users).where(state: :needs_profile).distinct.find_each do |user|
-      user.first_name ||= 'Unknown'
-      user.last_name ||= user.email_addresses.verified.first&.value || 'Unknown'
-      user.save!
+      next unless user.username.blank?
+
+      email = user.email_addresses.verified.first
+      username = if email.nil?
+        SecureRandom.urlsafe_base64
+      else
+        email.value.split('@').first.gsub(/[^a-zA-Z\d]+/, '_')
+      end
+
+      user.update_attribute :username, username
     end
   end
 

--- a/db/migrate/20200331192627_assign_names_to_users_that_bypassed_profile_creation.rb
+++ b/db/migrate/20200331192627_assign_names_to_users_that_bypassed_profile_creation.rb
@@ -1,0 +1,12 @@
+class AssignNamesToUsersThatBypassedProfileCreation < ActiveRecord::Migration[5.2]
+  def up
+    User.joins(:application_users).where(state: :needs_profile).distinct.find_each do |user|
+      user.first_name ||= 'Unknown'
+      user.last_name ||= user.email_addresses.verified.first&.value || 'Unknown'
+      user.save!
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_16_154958) do
+ActiveRecord::Schema.define(version: 2020_03_31_192627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
+  before { controller.sign_in! user }
+
+  context '#create' do
+    context 'user without a profile' do
+      let(:user) { FactoryBot.create :user, state: :needs_profile }
+
+      it 'redirects to /signup/profile' do
+        post :create, params: { response_type: :code }
+        expect(response).to redirect_to signup_profile_url
+      end
+    end
+
+    context 'user with a profile' do
+      let(:user) { FactoryBot.create :user }
+
+      it 'does not redirect' do
+        post :create, params: { response_type: :code }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also adds a name to users that already escaped profile creation.