### PR TITLE
Fix: undefined method downcase for nil

### DIFF
--- a/app/handlers/newflow/oauth_callback.rb
+++ b/app/handlers/newflow/oauth_callback.rb
@@ -61,7 +61,7 @@ module Newflow
     # so we want to prevent the hacker from logging in with the stolen social provider auth.
     def mismatched_authentication?
       incoming_auth_uid = Authentication.where(provider: @oauth_provider, uid: @oauth_uid).first&.uid
-      existing_email_owner_id = LookupUsers.by_verified_email(oauth_data.email).first&.id
+      existing_email_owner_id = LookupUsers.by_email_or_username(oauth_data.email).first&.id
       existing_auth_uid = Authentication.where(user_id: existing_email_owner_id, provider: @oauth_provider).pluck(:uid).first
       existing_auth_uid != incoming_auth_uid
     end

--- a/spec/handlers/newflow/oauth_callback_spec.rb
+++ b/spec/handlers/newflow/oauth_callback_spec.rb
@@ -73,5 +73,18 @@ module Newflow
         end
       end
     end
+
+    context 'when authentication found, but the response from social provider does not include email' do
+      let(:request) {
+        create_newflow_user(email)
+        info = { email: nil, name: Faker::Name.name }
+        MockOmniauthRequest.new 'facebook', Faker::Internet.uuid, info
+      }
+
+      it 'doesn\'t blow up' do
+        result = described_class.call(request: request)
+        expect(result.outputs.user).to eq User.last
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes [this error](https://sentry.cnx.org/openstax/accounts/issues/126859/) found by Sentry.

Solution: do what the old flow did — instead of `by_verified_email`, use `LookupUsers.by_email_or_username` which is smarter and handles the cases when the email from social provider is `nil` but also, it looks up users by username 🤷‍♂.