### PR TITLE
Submit role in educator signup form

### DIFF
--- a/app/views/newflow/login_signup/educator_signup_form.html.erb
+++ b/app/views/newflow/login_signup/educator_signup_form.html.erb
@@ -137,6 +137,7 @@
             </label>
             <%= f.hidden_field :contract_1_id, value: contracts.first.id %>
             <%= f.hidden_field :contract_2_id, value: contracts.second.id %>
+            <%= f.hidden_field :role, value: :instructor %>
           </div>
         </div>
 


### PR DESCRIPTION
Bug fix: the educator signup form is not submitting. It's missing the role. This PR fixes it.