### PR TITLE
Fix: undefined method is_activated? for nil

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@
 
 # Especially useful for debugging, learning our codebase, or development.
 # SSHOTS=true # whether it should take screenshots during features specs (search `screenshot!`)
-# NOT_HEADLESS=true # whether it should run the feature specs in a full browser
+# HEADLESS=true # whether it should run the feature specs in a full browser

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -176,7 +176,7 @@ module Newflow
 
             if !user.activated?
               # not activated means signup
-              unverified_user = EnsureUnverifiedUser.call(user).outputs.user
+              unverified_user = ensure_unverified_user(user)
 
               save_unverified_user(unverified_user)
               @first_name = user.first_name
@@ -356,6 +356,10 @@ module Newflow
         # TODO: when we create the Educator flow, redirect to there.
         redirect_to newflow_signup_student_path(request.query_parameters)
       end
+    end
+
+    def ensure_unverified_user(user)
+      EnsureUnverifiedUser.call(user).outputs.user
     end
 
     def cache_client_app

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -176,7 +176,13 @@ module Newflow
 
             if !user.activated?
               # not activated means signup
-              # NOTE: not necessarily "unverified" user, just not activated 😣. # TODO: refactor
+              # Users could have started signing up in the old flow in which case their state is 'needs_profile'
+              # ... in the new flow, that translates to 'unverified'. So update the user state:
+              if user.state == 'needs_profile'
+                user.update_attributes(state: 'unverified', is_newflow: true)
+                security_log(:user_updated, user: user, state_was: 'needs_profile', state_changed_to: 'unverified')
+              end
+
               save_unverified_user(user)
               @first_name = user.first_name
               @last_name = user.last_name
@@ -369,7 +375,7 @@ module Newflow
       id = session[:unverified_user_id]&.to_i
       return unless id.present?
 
-      @unverified_user ||= User.find_by(id: id)
+      @unverified_user ||= User.find_by(id: id, state: 'unverified')
     end
 
     def exit_newflow_signup_if_logged_in

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -176,6 +176,7 @@ module Newflow
 
             if !user.activated?
               # not activated means signup
+              # NOTE: not necessarily "unverified" user, just not activated 😣. # TODO: refactor
               save_unverified_user(user)
               @first_name = user.first_name
               @last_name = user.last_name
@@ -368,7 +369,7 @@ module Newflow
       id = session[:unverified_user_id]&.to_i
       return unless id.present?
 
-      @unverified_user ||= User.find_by(id: id, state: 'unverified')
+      @unverified_user ||= User.find_by(id: id)
     end
 
     def exit_newflow_signup_if_logged_in

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -176,14 +176,9 @@ module Newflow
 
             if !user.activated?
               # not activated means signup
-              # Users could have started signing up in the old flow in which case their state is 'needs_profile'
-              # ... in the new flow, that translates to 'unverified'. So update the user state:
-              if user.state == 'needs_profile'
-                user.update_attributes(state: 'unverified', is_newflow: true)
-                security_log(:user_updated, user: user, state_was: 'needs_profile', state_changed_to: 'unverified')
-              end
+              unverified_user = EnsureUnverifiedUser.call(user).outputs.user
 
-              save_unverified_user(user)
+              save_unverified_user(unverified_user)
               @first_name = user.first_name
               @last_name = user.last_name
               @email = @handler_result.outputs.email

--- a/app/routines/newflow/ensure_unverified_user.rb
+++ b/app/routines/newflow/ensure_unverified_user.rb
@@ -1,0 +1,25 @@
+# Users who started signing up in the old flow but never filled out their profile information
+# are in the state 'needs_profile'. In the new flow, that translates to 'unverified'.
+# So we update their state to match the new flow.
+module Newflow
+  class EnsureUnverifiedUser
+    lev_routine
+
+    def exec(user)
+      if user.state == 'needs_profile'
+        user.update_attributes(state: 'unverified', is_newflow: true)
+        transfer_errors_from(user, { type: :verbatim }, :fail_if_errors)
+
+        SecurityLog.create(
+          event_type: :user_updated,
+          user: user,
+          event_data: {
+            state_was: 'needs_profile',
+            state_changed_to: 'unverified'
+          }
+        )
+      end
+      outputs.user = user
+    end
+  end
+end

--- a/spec/controllers/newflow/login_signup_controller_spec.rb
+++ b/spec/controllers/newflow/login_signup_controller_spec.rb
@@ -484,23 +484,47 @@ module Newflow
       end
 
       context 'failure' do
-        before do
-          allow_any_instance_of(OauthCallback).to receive(:mismatched_authentication?).and_return(true)
+        context 'with mismatched_authentication' do
+          before do
+            allow_any_instance_of(OauthCallback).to receive(:mismatched_authentication?).and_return(true)
+          end
+
+          let(:params) do
+            { provider: 'facebook', uid: 'nonexistent' }
+          end
+
+          it 'redirects to login' do
+            get(:oauth_callback, params: params)
+            expect(response).to redirect_to(newflow_login_path)
+          end
+
+          it 'saves login failed email' do
+            expect_any_instance_of(described_class).to receive(:save_login_failed_email).and_call_original
+            get(:oauth_callback, params: params)
+            expect(session[:login_failed_email]).to eq(info[:email])
+          end
         end
 
-        let(:params) do
-          { provider: 'facebook', uid: 'nonexistent' }
-        end
+        context 'when no email address is returned' do
+          let(:info) do
+            { email: nil, name: Faker::Name.name }
+          end
 
-        it 'redirects to login' do
-          get(:oauth_callback, params: params)
-          expect(response).to redirect_to(newflow_login_path)
-        end
+          let(:params) do
+            { provider: 'facebook', uid: Faker::Internet.uuid }
+          end
 
-        it 'saves login failed email' do
-          expect_any_instance_of(described_class).to receive(:save_login_failed_email).and_call_original
-          get(:oauth_callback, params: params)
-          expect(session[:login_failed_email]).to eq(info[:email])
+          before do
+            allow_any_instance_of(OauthCallback).to receive(:oauth_response)  do
+              # TODO: refactor this?
+              MockOmniauthRequest.new(params[:provider], params[:uid], info).env['omniauth.auth']
+            end
+          end
+
+          it 'fails gracefully - not returning a 500' do
+            get(:oauth_callback, params: params)
+            expect(response).not_to have_http_status(:server_error)
+          end
         end
       end
     end

--- a/spec/controllers/newflow/login_signup_controller_spec.rb
+++ b/spec/controllers/newflow/login_signup_controller_spec.rb
@@ -433,7 +433,6 @@ module Newflow
 
       before do
         allow_any_instance_of(OauthCallback).to receive(:oauth_response)  do
-          # TODO: refactor this?
           MockOmniauthRequest.new(params[:provider], params[:uid], info).env['omniauth.auth']
         end
       end
@@ -516,7 +515,6 @@ module Newflow
 
           before do
             allow_any_instance_of(OauthCallback).to receive(:oauth_response)  do
-              # TODO: refactor this?
               MockOmniauthRequest.new(params[:provider], params[:uid], info).env['omniauth.auth']
             end
           end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,10 +48,10 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   Capybara::Selenium::Driver.new app, browser: :chrome, options: options
 end
 
-Capybara.javascript_driver = :selenium_chrome_headless
-
 if EnvUtilities.load_boolean(name: 'HEADLESS', default: false)
   # Run the feature specs in a full browser (note, this takes over your computer's focus)
+  Capybara.javascript_driver = :selenium_chrome_headless
+else
   Capybara.javascript_driver = :selenium_chrome
 end
 

--- a/spec/routines/newflow/ensure_unverified_user_spec.rb
+++ b/spec/routines/newflow/ensure_unverified_user_spec.rb
@@ -2,32 +2,35 @@ require 'rails_helper'
 
 module Newflow
   describe Newflow::EnsureUnverifiedUser, type: :routine do
-    let(:subject) do
-      FactoryBot.create(:user, state: 'needs_profile')
+    context 'when success' do
+      subject(:user) do
+        FactoryBot.create(:user, state: User::NEEDS_PROFILE)
+      end
+
+      it 'changes the user state to unverified' do
+        described_class.call(user)
+        expect(user.state).to eq(User::UNVERIFIED)
+      end
+
+      it 'outputs the user' do
+        expect(described_class.call(user).outputs.user).to be_a(User)
+      end
+
+      it 'creates a security log' do
+        expect { described_class.call(user) }.to(
+          change { SecurityLog.where(event_type: :user_updated).count }
+        )
+      end
     end
 
-    it 'changes the user state to unverified' do
-      described_class.call(subject)
-      expect(subject.state).to eq(User::UNVERIFIED)
-    end
+    context 'when user is activated' do
+      subject(:activated_user) { FactoryBot.create(:user, state: User::ACTIVATED) }
 
-    it 'outputs the user' do
-      expect(described_class.call(subject).outputs.user).to be_a(User)
-    end
-
-    it 'creates a security log' do
-      expect {
-        described_class.call(subject)
-      }.to change {
-        SecurityLog.where(event_type: :user_updated).count
-      }
-    end
-
-    it 'doesnt change the state if user is activated' do
-      subject = FactoryBot.create(:user, state: 'activated')
-      described_class.call(subject)
-      subject.reload
-      expect(subject.state).to eq('activated')
+      it 'doesnt change the state' do
+        described_class.call(activated_user)
+        activated_user.reload
+        expect(activated_user.state).to eq(User::ACTIVATED)
+      end
     end
   end
 end

--- a/spec/routines/newflow/ensure_unverified_user_spec.rb
+++ b/spec/routines/newflow/ensure_unverified_user_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+module Newflow
+  describe Newflow::EnsureUnverifiedUser, type: :routine do
+    let(:subject) do
+      FactoryBot.create(:user, state: 'needs_profile')
+    end
+
+    it 'changes the user state to unverified' do
+      described_class.call(subject)
+      expect(subject.state).to eq(User::UNVERIFIED)
+    end
+
+    it 'outputs the user' do
+      expect(described_class.call(subject).outputs.user).to be_a(User)
+    end
+
+    it 'creates a security log' do
+      expect {
+        described_class.call(subject)
+      }.to change {
+        SecurityLog.where(event_type: :user_updated).count
+      }
+    end
+
+    it 'doesnt change the state if user is activated' do
+      subject = FactoryBot.create(:user, state: 'activated')
+      described_class.call(subject)
+      subject.reload
+      expect(subject.state).to eq('activated')
+    end
+  end
+end

--- a/spec/support/newflow_feature_helpers.rb
+++ b/spec/support/newflow_feature_helpers.rb
@@ -118,6 +118,7 @@ def submit_signup_form
   find('#login-signup-form').click # to hide the password tooltip
   wait_for_animations
   check('signup_terms_accepted')
+  wait_for_animations
   screenshot!
   find('[type=submit]').click
 end


### PR DESCRIPTION
Fixes error reported by Sentry https://sentry.cnx.org/openstax/accounts/issues/129080/activity/

The problem was that `save_unverified_user` saves any user regardless of their actual `state` while `unverified_user` does `where(state: 'unverified` therefore returns only actual unverified users. In production, an error gets raised every time a user wants to login or signup but didn't finish the signup process in the old flow – which means that their their `state` is `needs_profile`. 

This PR fixes that by converting `needs_profile` users to `unverified` users. Also added an extra controller test to login_signup_controller to test `'when no email address is returned'` in oauth_callback.


## Issue https://github.com/openstax/business-intel/issues/991