### PR TITLE
Prevent 403 error when email blank on forgot password form

### DIFF
--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -271,9 +271,10 @@ module Newflow
         },
         failure: lambda {
           user = @handler_result.outputs.user
+          email = @handler_result.outputs.email
           code = @handler_result.errors.first.code
-          security_log :reset_password_failed, user: user, reason: code
-          redirect_to newflow_login_path
+          security_log :reset_password_failed, user: user, email: email, reason: code
+          render :forgot_password_form
         }
       )
     end

--- a/app/handlers/newflow/send_reset_password_email.rb
+++ b/app/handlers/newflow/send_reset_password_email.rb
@@ -20,7 +20,7 @@ module Newflow
     def handle
       outputs.email = forgot_password_form_params.email
 
-      fatal_error(code: :blank,
+      fatal_error(code: :email_is_blank,
         offending_inputs: :email,
         message: I18n.t(:"login_signup_form.email_is_blank")
       ) unless outputs.email.present? || logged_in_user

--- a/app/handlers/newflow/send_reset_password_email.rb
+++ b/app/handlers/newflow/send_reset_password_email.rb
@@ -14,11 +14,17 @@ module Newflow
     protected #################
 
     def authorized?
-      forgot_password_form_params.email.present? || logged_in_user
+      true
     end
 
     def handle
       outputs.email = forgot_password_form_params.email
+
+      fatal_error(code: :blank,
+        offending_inputs: :email,
+        message: I18n.t(:"login_signup_form.email_is_blank")
+      ) unless outputs.email.present? || logged_in_user
+
       user = logged_in_user || LookupUsers.by_verified_email(outputs.email).first
 
       fatal_error(code: :cannot_find_user,

--- a/spec/controllers/newflow/login_signup_controller_spec.rb
+++ b/spec/controllers/newflow/login_signup_controller_spec.rb
@@ -595,7 +595,7 @@ module Newflow
 
       context 'failure' do
           let(:params) do
-            { forgot_password_form: { email: 'rubbish' } }
+            { forgot_password_form: { email: '' } }
           end
 
           it 'creates a Security Log' do
@@ -606,9 +606,9 @@ module Newflow
             }
           end
 
-          it 'redirects to login path' do
+          it 'renders forgot password form' do
             post('send_reset_password_email', params: params)
-            expect(response).to redirect_to(newflow_login_path)
+            expect(response).to render_template(:forgot_password_form)
           end
       end
     end

--- a/spec/features/newflow/reset_password_spec.rb
+++ b/spec/features/newflow/reset_password_spec.rb
@@ -116,7 +116,7 @@ feature 'Password reset', js: true do
     end
   end
 
-  scenario 'failure to send reset email sends user back to authenticate page' do
+  scenario 'failure to send reset email (re-) renders the forgot password form' do
     create_newflow_user('user@openstax.org', 'password')
     visit newflow_login_path
     newflow_log_in_user('user@openstax.org', 'WRONGpassword')
@@ -130,7 +130,7 @@ feature 'Password reset', js: true do
 
     click_on(I18n.t(:"login_signup_form.reset_my_password_button"))
 
-    expect(page.current_path).to eq(newflow_login_path)
+    expect(page.current_path).to eq(send_reset_password_email_path)
     # expect a security log as well
     expect(SecurityLog.where(reason: :reset_password_failed, user: User.last))
   end

--- a/spec/handlers/newflow/send_reset_password_email_spec.rb
+++ b/spec/handlers/newflow/send_reset_password_email_spec.rb
@@ -54,5 +54,23 @@ module Newflow
         expect(result).to have_routine_error(:cannot_find_user)
       end
     end
+
+    context 'when no email present and no logged in user' do
+      let(:params) do
+        {
+          forgot_password_form: {
+            email: ''
+          }
+        }
+      end
+
+      let(:subject) do
+        described_class.call(params: params, caller: AnonymousUser.instance)
+      end
+
+      it 'returns fatal error email is blank' do
+        expect(subject).to have_routine_error(:email_is_blank)
+      end
+    end
   end
 end

--- a/spec/handlers/newflow/send_reset_password_email_spec.rb
+++ b/spec/handlers/newflow/send_reset_password_email_spec.rb
@@ -59,17 +59,17 @@ module Newflow
       let(:params) do
         {
           forgot_password_form: {
-            email: ''
+            email: nil
           }
         }
       end
 
-      let(:subject) do
+      subject(:result) do
         described_class.call(params: params, caller: AnonymousUser.instance)
       end
 
       it 'returns fatal error email is blank' do
-        expect(subject).to have_routine_error(:email_is_blank)
+        expect(result).to have_routine_error(:email_is_blank)
       end
     end
   end


### PR DESCRIPTION
## Part of https://github.com/openstax/business-intel/issues/951