### PR TITLE
Ability to add email when none came from social network

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -32,6 +32,12 @@ class EmailAddress < ContactInfo
     end
   end
 
+  def customize_value_error_message(error:, message:)
+    if self.errors && self.errors.types.fetch(:value, {}).include?(error)
+      self.errors.messages[:value][0] = message
+    end
+  end
+
   protected
 
   def is_domain_trusted?

--- a/app/routines/newflow/create_email_for_user.rb
+++ b/app/routines/newflow/create_email_for_user.rb
@@ -1,0 +1,21 @@
+module Newflow
+  class CreateEmailForUser
+    lev_routine
+
+    protected ###############
+
+    def exec(email:, user:)
+      @email = EmailAddress.create(value: email&.downcase, user_id: user.id)
+
+      # Customize the error message about having an invalid email domain
+      if @email.errors && @email.errors.types.fetch(:value, {}).include?(:missing_mx_records)
+        domain = @email.send(:domain)
+        @email.errors.messages[:value][0] = I18n.t(:"login_signup_form.invalid_email_provider", domain: domain)
+      end
+
+      transfer_errors_from(@email, { scope: :email }, :fail_if_errors)
+
+      NewflowMailer.signup_email_confirmation(email_address: @email).deliver_later
+    end
+  end
+end

--- a/app/routines/newflow/create_email_for_user.rb
+++ b/app/routines/newflow/create_email_for_user.rb
@@ -7,12 +7,10 @@ module Newflow
     def exec(email:, user:)
       @email = EmailAddress.create(value: email&.downcase, user_id: user.id)
 
-      # Customize the error message about having an invalid email domain
-      if @email.errors && @email.errors.types.fetch(:value, {}).include?(:missing_mx_records)
-        domain = @email.send(:domain)
-        @email.errors.messages[:value][0] = I18n.t(:"login_signup_form.invalid_email_provider", domain: domain)
-      end
-
+      @email.customize_value_error_message(
+        error: :missing_mx_records,
+        message: I18n.t(:"login_signup_form.invalid_email_provider", domain: @email.send(:domain))
+      )
       transfer_errors_from(@email, { scope: :email }, :fail_if_errors)
 
       NewflowMailer.signup_email_confirmation(email_address: @email).deliver_later

--- a/app/views/newflow/login_signup/confirm_social_info_form.html.erb
+++ b/app/views/newflow/login_signup/confirm_social_info_form.html.erb
@@ -18,8 +18,8 @@
                     header: I18n.t(:"login_signup_form.confirm_your_info"),
                     current_step: I18n.t(:'login_signup_form.step_counter', current_step: 1, total_steps: 2),
                     banners: @banners) do %>
-            <% lev_form_for :info, url: confirm_oauth_info_path do |f| %>
-                <% fh = NewflowFormHelper::Newflow.new(f: f, context: self) %>
+            <% lev_form_for :signup, url: confirm_oauth_info_path do |f| %>
+                <% fh = NewflowFormHelper::Newflow.new(f: f, context: self, errors: @handler_result&.errors) %>
 
                 <div class="content role-section">
                     <div>
@@ -59,12 +59,14 @@
                                     name: :email,
                                     placeholder: I18n.t(:'login_signup_form.email_label'),
                                     value: @email,
-                                    readonly: true
+                                    readonly: @email.present?
                                 )
                         %>
-                        <div class="tooltip">
-                            <%= I18n.t(:"login_signup_form.confirm_social_info_tooltip").html_safe %>
-                        </div>
+                        <% if @email.present? %>
+                            <div class="tooltip">
+                                <%= I18n.t(:"login_signup_form.confirm_social_info_tooltip").html_safe %>
+                            </div>
+                        <% end %>
                     </div>
                 </div>
 
@@ -100,7 +102,7 @@
 </div>
 
 <script type="text/javascript">
-    NewflowUi.enableOnChecked('#confirm_social_info_submit_button', '#info_terms_accepted');
+    NewflowUi.enableOnChecked('#confirm_social_info_submit_button', '#signup_terms_accepted');
 </script>
 
 <%# TODO: move this to some CSS file %>

--- a/app/views/newflow/login_signup/confirm_social_info_form.html.erb
+++ b/app/views/newflow/login_signup/confirm_social_info_form.html.erb
@@ -62,7 +62,7 @@
                                     readonly: @email.present?
                                 )
                         %>
-                        <% if @email.present? %>
+                        <% if @email %>
                             <div class="tooltip">
                                 <%= I18n.t(:"login_signup_form.confirm_social_info_tooltip").html_safe %>
                             </div>

--- a/spec/features/newflow/add_social_auth_spec.rb
+++ b/spec/features/newflow/add_social_auth_spec.rb
@@ -67,5 +67,4 @@ feature 'Add social auth', js: true do
       expect(page).to have_content('Facebook')
     end
   end
-
 end

--- a/spec/features/newflow/user_signs_up_with_social_network_spec.rb
+++ b/spec/features/newflow/user_signs_up_with_social_network_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+feature 'User signs up with social network', js: true do
+  before do
+    turn_on_student_feature_flag
+    load('db/seeds.rb')
+  end
+
+  let(:email) { 'user@example.com' }
+
+  scenario 'happy path' do
+    visit(newflow_login_path)
+
+    simulate_login_signup_with_social(name: 'Elon Musk', email: email) do
+      click_on('Facebook')
+      wait_for_ajax
+      screenshot!
+      expect(page).to have_content(t(:"login_signup_form.confirm_your_info"))
+      expect(page).to have_field('signup_first_name', with: 'Elon')
+      expect(page).to have_field('signup_last_name', with: 'Musk')
+      expect(page).to have_field('signup_email', with: email)
+      check('signup_terms_accepted')
+      wait_for_animations
+      screenshot!
+      find('[type=submit]').click
+      screenshot!
+      expect(page).to have_content(t(:"login_signup_form.youre_done", first_name: 'Elon'))
+      expect(page).to(
+        have_content(strip_html(t(:"login_signup_form.youre_done_description", email_address: email)))
+      )
+    end
+  end
+
+  context 'user denies us access to their email address, has to enter it manually' do
+    describe 'success' do
+      example do
+        visit(newflow_login_path)
+
+        simulate_login_signup_with_social(name: 'Elon Musk', email: nil) do
+          click_on('Facebook')
+          wait_for_ajax
+          wait_for_animations
+          screenshot!
+          expect(page).to have_content(t(:"login_signup_form.confirm_your_info"))
+          expect(page).to have_field('signup_first_name', with: 'Elon')
+          expect(page).to have_field('signup_last_name', with: 'Musk')
+          expect(page).to have_field('signup_email', with: '')
+          submit_signup_form
+          screenshot!
+
+          expect(page).to have_content(t(:"login_signup_form.confirm_your_info"))
+          expect(page).to have_content(t(:"login_signup_form.email_is_blank"))
+
+          fill_in('signup_email',	with: email)
+          submit_signup_form
+          screenshot!
+          expect(page).to have_content(t(:"login_signup_form.youre_done", first_name: 'Elon'))
+          expect(page).to(
+            have_content(strip_html(t(:"login_signup_form.youre_done_description", email_address: email)))
+          )
+        end
+      end
+    end
+
+    describe 'enters invalid email' do
+      subject(:invalid_email) { 'someinvalidemail' }
+
+      scenario 'the form shows a friendly error message' do
+        visit(newflow_login_path)
+
+        simulate_login_signup_with_social(name: 'Elon Musk', email: nil) do
+          click_on('Facebook')
+          wait_for_ajax
+          wait_for_animations
+          screenshot!
+          expect(page).to have_content(t(:"login_signup_form.confirm_your_info"))
+          expect(page).to have_field('signup_first_name', with: 'Elon')
+          expect(page).to have_field('signup_last_name', with: 'Musk')
+          expect(page).to have_field('signup_email', with: '')
+          submit_signup_form
+          screenshot!
+
+          expect(page).to have_content(t(:"login_signup_form.confirm_your_info"))
+          expect(page).to have_content(t(:"login_signup_form.email_is_blank"))
+
+          fill_in('signup_email',	with: invalid_email)
+          submit_signup_form
+          screenshot!
+          expect(page).to have_content(t(:".activerecord.errors.models.email_address.attributes.value.invalid", value: invalid_email))
+        end
+      end
+    end
+  end
+end

--- a/spec/handlers/newflow/confirm_oauth_info_spec.rb
+++ b/spec/handlers/newflow/confirm_oauth_info_spec.rb
@@ -69,9 +69,7 @@ module Newflow
       it 'creates an email address for the user' do
         expect {
           described_class.call(params: params, user: User.last)
-        }.to(
-          change(EmailAddress, :count)
-        )
+        }.to(change(EmailAddress, :count))
       end
 
       it 'adds the user as a "lead" to salesforce' do
@@ -101,10 +99,15 @@ module Newflow
         described_class.call(params: params, contracts_required: true, user: User.last)
       end
 
-      it 'does NOT sign up user for the newsletter when NOT checked' do
-        expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: false }))
-        params[:signup][:newsletter] = false
-        described_class.call(params: params, contracts_required: true, user: User.last)
+      context 'when newsletter is not checked' do
+        before do
+          params[:signup][:newsletter] = false
+        end
+
+        it 'does not sign up user for the newsletter' do
+          expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: false }))
+          described_class.call(params: params, contracts_required: true, user: User.last)
+        end
       end
     end
   end

--- a/spec/handlers/newflow/confirm_oauth_info_spec.rb
+++ b/spec/handlers/newflow/confirm_oauth_info_spec.rb
@@ -3,19 +3,16 @@ require 'rails_helper'
 module Newflow
   RSpec.describe ConfirmOauthInfo, type: :handler do
     before do
-      load 'db/seeds.rb'
-      FactoryBot.create(:user, state: 'unverified')
-
       disable_sfdc_client
       allow(Settings::Salesforce).to receive(:push_leads_enabled) { true }
     end
 
     let(:params) do
       {
-        info: {
+        signup: {
           first_name: 'Bryan',
           last_name: 'Dimas',
-          email: Faker::Internet.password(min_length: 8),
+          email: Faker::Internet.free_email,
           newsletter: '1',
           terms_accepted: '1',
           contract_1_id: FinePrint::Contract.first.id,
@@ -24,37 +21,91 @@ module Newflow
       }
     end
 
-    it 'adds the user as a "lead" to salesforce' do
-      expect_any_instance_of(PushSalesforceLead).to receive(:exec)
-      described_class.call(params: params, user: User.last)
-    end
+    context 'when user has an email address' do
+      before do
+        user = FactoryBot.create(:user, state: 'unverified')
+        FactoryBot.create(:email_address, value: params[:signup][:email], user: user)
+      end
 
-    it 'changes the user state to "activated"' do
-      expect(User.last.state).to_not eq('activated')
-      described_class.call(params: params, user: User.last)
-      expect(User.last.state).to eq('activated')
-    end
+      it 'adds the user as a "lead" to salesforce' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec)
+        described_class.call(params: params, user: User.last)
+      end
 
-    it 'agrees to terms of use and privacy policy when contracts_required' do
-      # TODO: ideally would do this but it fails with an error:
-      # expect_any_instance_of(AgreeToTerms).to receive(:call).twice.and_call_original
+      it 'changes the user state to "activated"' do
+        expect(User.last.state).to_not eq('activated')
+        described_class.call(params: params, user: User.last)
+        expect(User.last.state).to eq('activated')
+      end
 
-      expect {
+      it 'agrees to terms of use and privacy policy when contracts_required' do
+        # TODO: ideally would do this but it fails with an error:
+        # expect_any_instance_of(AgreeToTerms).to receive(:call).twice.and_call_original
+
+        expect {
+          described_class.call(params: params, contracts_required: true, user: User.last)
+        }.to change {
+          FinePrint::Signature.count
+        }.by(2)
+      end
+
+      it 'signs up user for the newsletter when checked' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: true }))
         described_class.call(params: params, contracts_required: true, user: User.last)
-      }.to change {
-        FinePrint::Signature.count
-      }.by(2)
+      end
+
+      it 'does NOT sign up user for the newsletter when NOT checked' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: false }))
+        params[:signup][:newsletter] = false
+        described_class.call(params: params, contracts_required: true, user: User.last)
+      end
     end
 
-    it 'signs up user for the newsletter when checked' do
-      expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: true }))
-      described_class.call(params: params, contracts_required: true, user: User.last)
-    end
+    context 'when user has NO email address' do
+      before do
+        FactoryBot.create(:user, state: 'unverified')
+      end
 
-    it 'does NOT sign up user for the newsletter when NOT checked' do
-      expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: false }))
-      params[:info][:newsletter] = false
-      described_class.call(params: params, contracts_required: true, user: User.last)
+      it 'creates an email address for the user' do
+        expect {
+          described_class.call(params: params, user: User.last)
+        }.to(
+          change(EmailAddress, :count)
+        )
+      end
+
+      it 'adds the user as a "lead" to salesforce' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec)
+        described_class.call(params: params, user: User.last)
+      end
+
+      it 'changes the user state to "activated"' do
+        expect(User.last.state).to_not eq('activated')
+        described_class.call(params: params, user: User.last)
+        expect(User.last.state).to eq('activated')
+      end
+
+      it 'agrees to terms of use and privacy policy when contracts_required' do
+        # TODO: ideally would do this but it fails with an error:
+        # expect_any_instance_of(AgreeToTerms).to receive(:call).twice.and_call_original
+
+        expect {
+          described_class.call(params: params, contracts_required: true, user: User.last)
+        }.to change {
+          FinePrint::Signature.count
+        }.by(2)
+      end
+
+      it 'signs up user for the newsletter when checked' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: true }))
+        described_class.call(params: params, contracts_required: true, user: User.last)
+      end
+
+      it 'does NOT sign up user for the newsletter when NOT checked' do
+        expect_any_instance_of(PushSalesforceLead).to receive(:exec).with(hash_including({ newsletter: false }))
+        params[:signup][:newsletter] = false
+        described_class.call(params: params, contracts_required: true, user: User.last)
+      end
     end
   end
 end


### PR DESCRIPTION
When user denies us access to their email address from facebook (or a social network), we would like to support the ability for users to add it in the Confirm Your Social Information form.

Solves issue https://github.com/openstax/business-intel/issues/986