### PR TITLE
Fix the URL of "Finish" button in signup done page

### DIFF
--- a/app/views/newflow/login_signup/signup_done.html.erb
+++ b/app/views/newflow/login_signup/signup_done.html.erb
@@ -6,7 +6,7 @@
                     classes: "signup-page",
                     header: I18n.t(:"login_signup_form.youre_done", first_name: @first_name),
                     show_exit_icon: true) do %>
-            <form action="<%= redirect_back_path %>">
+            <form action="<%= exit_accounts_path %>">
                 <div class="content control-group info-message">
                     <%= I18n.t(:"login_signup_form.youre_done_description",
                                     email_address: @email_address).html_safe


### PR DESCRIPTION
I missed this in PR https://github.com/openstax/accounts/pull/813 — for issue https://github.com/openstax/business-intel/issues/968.

I just noticed that the Finish button is still pointing to `/redirect_back`. It should point to `exit_accounts_path`. This PR fixes that.