### PR TITLE
Fix exit icon when user goes to the signup page, then back to the login page, and then tries to exit

### DIFF
--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -333,7 +333,7 @@ module Newflow
         else
           raise Lev::SecurityTransgression
         end
-      elsif (redirect_uri = extract_params(stored_url)[:redirect_uri])
+      elsif !signed_in? && (redirect_uri = extract_params(stored_url)[:redirect_uri])
         redirect_to(redirect_uri)
       else
         redirect_back # defined in action_interceptor gem

--- a/app/controllers/newflow/login_signup_controller.rb
+++ b/app/controllers/newflow/login_signup_controller.rb
@@ -327,15 +327,13 @@ module Newflow
     end
 
     def exit_accounts
-      referrer_params = extract_params(request.referrer)
-
-      if (redirect_param = referrer_params[:r])
+      if (redirect_param = extract_params(request.referrer)[:r])
         if Host.trusted?(redirect_param)
           redirect_to(redirect_param)
         else
           raise Lev::SecurityTransgression
         end
-      elsif (redirect_uri = referrer_params[:redirect_uri])
+      elsif (redirect_uri = extract_params(stored_url)[:redirect_uri])
         redirect_to(redirect_uri)
       else
         redirect_back # defined in action_interceptor gem

--- a/spec/controllers/newflow/login_signup_controller_spec.rb
+++ b/spec/controllers/newflow/login_signup_controller_spec.rb
@@ -805,10 +805,10 @@ module Newflow
 
       context 'when the stored url includes `redirect_uri` param' do
         before do
-          allow_any_instance_of(described_class).to receive(:stored_url).and_return(subject)
+          allow_any_instance_of(described_class).to receive(:stored_url).and_return(redirect_uri)
         end
 
-        subject do
+        let(:redirect_uri) do
           "#{host}?redirect_uri=#{target_url}"
         end
 

--- a/spec/controllers/newflow/login_signup_controller_spec.rb
+++ b/spec/controllers/newflow/login_signup_controller_spec.rb
@@ -758,13 +758,13 @@ module Newflow
     end
 
     describe "GET #exit_accounts" do
+      let(:host) { Rails.application.secrets.trusted_hosts.first }
+      let(:target_url) { Faker::Internet.url }
+
       context 'when Referer is present' do
         before do
           request.headers.merge!({ Referer: subject })
         end
-
-        let(:host) { Rails.application.secrets.trusted_hosts.first }
-        let(:target_url) { Faker::Internet.url }
 
         context 'when Referer includes `r` param' do
           subject do
@@ -793,17 +793,6 @@ module Newflow
             end
           end
         end
-
-        context 'when Referer includes `redirect_uri` param' do
-          subject do
-            "#{host}?redirect_uri=#{target_url}"
-          end
-
-          it 'redirects to `redirect_uri`' do
-            get(:exit_accounts)
-            expect(response).to redirect_to(target_url)
-          end
-        end
       end
 
       context 'when Referer is nil' do
@@ -811,6 +800,21 @@ module Newflow
           expect_any_instance_of(described_class).to receive(:redirect_back).and_call_original
           get(:exit_accounts)
           expect(response).to redirect_to(root_url)
+        end
+      end
+
+      context 'when the stored url includes `redirect_uri` param' do
+        before do
+          allow_any_instance_of(described_class).to receive(:stored_url).and_return(subject)
+        end
+
+        subject do
+          "#{host}?redirect_uri=#{target_url}"
+        end
+
+        it 'redirects to `redirect_uri`' do
+          get(:exit_accounts)
+          expect(response).to redirect_to(target_url)
         end
       end
     end

--- a/spec/features/newflow/student_login_flow_spec.rb
+++ b/spec/features/newflow/student_login_flow_spec.rb
@@ -162,6 +162,20 @@ feature 'student login flow', js: true do
               expect(page.current_url).to match(external_public_url)
             end
           end
+
+          context 'when user goes to signup tab, then back to login tab' do
+            scenario 'takes user back to the app' do
+              with_forgery_protection do
+                arrive_from_app(app: app)
+                click_on(I18n.t(:"login_signup_form.sign_up"))
+                click_on(I18n.t(:"login_signup_form.log_in"))
+                find('#exit-icon a').click
+                wait_for_animations
+                wait_for_ajax
+                expect(page.current_url).to match(external_public_url)
+              end
+            end
+          end
         end
 
         context "when user arrived with `r`eturn param" do


### PR DESCRIPTION
When Dev Verify-ing https://github.com/openstax/accounts/pull/813, I found that only checking the referrer for the `redirect_uri` would not work. This PR fixes that.

Before:
- From the login page, user goes away (ie. to the signup page), goes back to the login page, clicks on the `X` exit icon... user is redirected back to the `oauth/authorize` path (although from the user perspective it looks like the page just gets refreshed).

User had to click the `X` exit icon one more time in order to be taken back to the OAuth app (ie. Tutor). This is because `redirect_uri` gets cleared, so `redirect_back` takes user back to the `stored_url` which at that point was the `oauth/authorize` path. **Then**, the second time user click on X icon, `redirect_uri` is present, so user is successfully sent back to the app.

After:
- Always look for the `redirect_uri` in the `stored_url` because if the user arrived from an OAuth app from the beginning, then it was stored on arrival.

Created a feature spec for this scenario :).