### PR TITLE
Expand Terms of Use clickable area

### DIFF
--- a/app/views/newflow/login_signup/confirm_social_info_form.html.erb
+++ b/app/views/newflow/login_signup/confirm_social_info_form.html.erb
@@ -78,15 +78,18 @@
                     </div>
 
                     <div class="terms">
-                        <%= f.check_box :terms_accepted %>
+                        <label>
+                            <%= f.check_box :terms_accepted %>
+                            <span>
+                                <%= I18n.t(:"login_signup_form.agree_to_terms_of_use",
+                                            terms_of_use: contract_links.first,
+                                            privacy_policy: contract_links.second).html_safe
+                                %>
+                            </span>
+                        </label>
                         <%= f.hidden_field :contract_1_id, value: contracts.first.id %>
                         <%= f.hidden_field :contract_2_id, value: contracts.second.id %>
-                        <span>
-                            <%= I18n.t(:"login_signup_form.agree_to_terms_of_use",
-                                        terms_of_use: contract_links.first,
-                                        privacy_policy: contract_links.second).html_safe
-                            %>
-                        </span>
+                        <%= f.hidden_field :role, value: :student %>
                     </div>
                 </div>
 


### PR DESCRIPTION
Noticed this was wrong with the Confirm Your [social] Information form. At one point I made this fix to the signup form but not to this form.