### PR TITLE
Add support for country code in user

### DIFF
--- a/app/assets/javascripts/newflow/index.js
+++ b/app/assets/javascripts/newflow/index.js
@@ -48,6 +48,8 @@ $(document).ready(function(){
     function step1_submit(event) {
       let phone_num = telInput.getNumber();
       $(".int-country-code").val(phone_num);
+      let country_code = telInput.getSelectedCountryData().dialCode;
+      $('#signup_country_code').val(country_code)
       return true;
     }
     form.addEventListener('submit', step1_submit);

--- a/app/handlers/newflow/user_signup.rb
+++ b/app/handlers/newflow/user_signup.rb
@@ -15,6 +15,7 @@ module Newflow
         attribute :contract_2_id, type: Integer
         attribute :role, type: String
         attribute :phone_number, type: String
+        attribute :country_code, type: String
       }))
     end
 
@@ -89,6 +90,7 @@ module Newflow
         first_name: signup_params.first_name,
         last_name: signup_params.last_name,
         phone_number: signup_params.phone_number,
+        country_code: signup_params.country_code,
         receive_newsletter: signup_params.newsletter,
         source_application: options[:client_app],
         is_newflow: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,7 +152,7 @@ class User < ActiveRecord::Base
     by_unverified.older_than_one_year.destroy_all
   end
 
-  def sheer_supported?
+  def sheerid_supported?
     {
       '1'   => 'United States & Canada',
       '27'  => 'South Africa',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,6 +152,17 @@ class User < ActiveRecord::Base
     by_unverified.older_than_one_year.destroy_all
   end
 
+  def sheer_supported?
+    {
+      '1'   => 'United States & Canada',
+      '27'  => 'South Africa',
+      '44'  => 'United Kingdom',
+      '61'  => 'Australia',
+      '64'  => 'New Zealand',
+      '353' => 'Ireland',
+    }.key?(country_code&.strip)
+  end
+
   def is_test?
     !!is_test
   end

--- a/app/views/newflow/login_signup/educator_signup_form.html.erb
+++ b/app/views/newflow/login_signup/educator_signup_form.html.erb
@@ -70,6 +70,7 @@
                            onkeyup: 'javascript:backspacerUP(this,event);'
 
           %>
+          <%= f.hidden_field :country_code%>
         </div>
 
         <div class="content control-group email-input-group newflow">

--- a/db/migrate/20200520214028_add_country_to_users.rb
+++ b/db/migrate/20200520214028_add_country_to_users.rb
@@ -1,0 +1,5 @@
+class AddCountryToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :country_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_14_211443) do
+ActiveRecord::Schema.define(version: 2020_05_20_214028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 2020_05_14_211443) do
     t.boolean "is_newflow", default: false, null: false
     t.string "phone_number"
     t.boolean "is_kip", comment: "is the User-s school a Key Institutional Partner?"
+    t.string "country_code"
     t.index "lower((first_name)::text)", name: "index_users_on_first_name"
     t.index "lower((last_name)::text)", name: "index_users_on_last_name"
     t.index "lower((username)::text)", name: "index_users_on_username_case_insensitive"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -408,4 +408,36 @@ RSpec.describe User, type: :model do
       expect(user.activated_at).not_to be_nil
     end
   end
+
+  describe '#sheer_supported?' do
+    context 'is sheer supported' do
+      subject(:user) do
+        FactoryBot.create(:user, country_code: '1')
+      end
+
+      it 'returns sheer supported' do
+        expect(user.sheer_supported?).to be_truthy
+      end
+    end
+
+    context 'is not sheer supported' do
+      subject(:user) do
+        FactoryBot.create(:user, country_code: '111')
+      end
+
+      it 'returns not sheer supported' do
+        expect(user.sheer_supported?).to be_falsey
+      end
+    end
+
+    context 'country code not set' do
+      subject(:user) do
+        FactoryBot.create(:user, country_code: nil)
+      end
+
+      it 'returns not sheer supported' do
+        expect(user.sheer_supported?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -409,14 +409,14 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#sheer_supported?' do
+  describe '#sheerid_supported?' do
     context 'is sheer supported' do
       subject(:user) do
         FactoryBot.create(:user, country_code: '1')
       end
 
       it 'returns sheer supported' do
-        expect(user.sheer_supported?).to be_truthy
+        expect(user.sheerid_supported?).to be_truthy
       end
     end
 
@@ -426,7 +426,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'returns not sheer supported' do
-        expect(user.sheer_supported?).to be_falsey
+        expect(user.sheerid_supported?).to be_falsey
       end
     end
 
@@ -436,7 +436,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'returns not sheer supported' do
-        expect(user.sheer_supported?).to be_falsey
+        expect(user.sheerid_supported?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Add support for country code in user.  One reason is so that we can see if the user is supported by sheer.  

https://app.zenhub.com/workspaces/openstax-bit-5bacfe3f4b5806bc2bea3764/issues/openstax/business-intel/1092