### PR TITLE
Make entire widget text input clickable

### DIFF
--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -110,6 +110,10 @@ input.has-error {
   // extend the multiselect just for the complete form for now
   .os-multiselect {
     @extend %os-multiselect;
+
+    input[type=text] {
+      min-width: 100%;
+    }
   }
 
   form {


### PR DESCRIPTION
A little improvement on @RoyEJohnson's multi-select widget. Makes entire widget text input clickable. Mentioned it to him in slack. This fix can be replaced in the pattern-library in the future.

https://openstax.slack.com/archives/C6NRD0CCQ/p1589573929137200?thread_ts=1588692774.449100&cid=C6NRD0CCQ