### PR TITLE
Prevent step4 submit if num students not filled out & instructor to admin switch fixes

### DIFF
--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -9,10 +9,10 @@ class NewflowUi.EducatorComplete
     @please_select_role = @findOrLogNotFound(@form, '.completed-role .role.newflow-mustdo-alert')
     @please_select_using = @findOrLogNotFound(@form, '.how-using .using.newflow-mustdo-alert')
     @please_select_chosen = @findOrLogNotFound(@form, '.how-chosen .chosen.newflow-mustdo-alert')
-    @please_fill_out_total_num = @findOrLogNotFound(@form, '.total-num-students .errors.invalid-message')
     @please_fill_out_other = @findOrLogNotFound(@form, '.other.newflow-mustdo-alert')
     @please_select_subjects_interest = @findOrLogNotFound(@form, '.subjects.newflow-mustdo-alert')
     @please_select_books_used = @findOrLogNotFound(@form, '.used.newflow-mustdo-alert')
+    @please_fill_out_total_num = @findOrLogNotFound(@form, '.total-num-students .total-num.newflow-mustdo-alert')
     @findOrLogNotFound(@form, 'form').submit(@onSubmit)
     @how_chosen = @findOrLogNotFound(@form, '.how-chosen')
     @how_chosen_radio = @findOrLogNotFound(@how_chosen, "input")
@@ -43,6 +43,7 @@ class NewflowUi.EducatorComplete
     @how_using.hide()
     @other_specify.hide()
     @please_select_role.hide()
+    @please_fill_out_total_num.hide()
 
   findOrLogNotFound: (parent, selector) ->
     if (found = parent.find(selector))
@@ -155,6 +156,7 @@ class NewflowUi.EducatorComplete
       @please_select_chosen.hide()
       @total_num_students.show()
       @please_fill_out_total_num.hide()
+      @onHowUsingChange()
     else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_admin').is(':checked') )
       @other_specify.hide()
       @books_used.hide()
@@ -163,6 +165,7 @@ class NewflowUi.EducatorComplete
       @please_select_chosen.hide()
       @how_using.show()
       @please_select_using.hide()
+      @onHowUsingChange()
     else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_other').is(':checked') )
       @books_used.hide()
       @how_chosen.hide()
@@ -196,7 +199,6 @@ class NewflowUi.EducatorComplete
 
   onTotalNumChange: ->
     @please_fill_out_total_num.hide()
-    @total_num_students_input.removeClass('has-error')
     @continue.prop('disabled', false)
 
   onOtherChange: ->

--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -60,7 +60,13 @@ class NewflowUi.EducatorComplete
     subjects_interest_valid = @checkSubjectsInterestValid()
     books_used_valid = @checkBooksUsedValid()
 
-    if not (role_valid and chosen_valid and using_valid and other_valid and subjects_interest_valid and books_used_valid)
+    if not (role_valid and
+            chosen_valid and
+            using_valid and
+            other_valid and
+            total_num_valid and
+            subjects_interest_valid and
+            books_used_valid)
       ev.preventDefault()
 
   checkRoleValid: () ->

--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -9,7 +9,7 @@ class NewflowUi.EducatorComplete
     @please_select_role = @findOrLogNotFound(@form, '.completed-role .role.newflow-mustdo-alert')
     @please_select_using = @findOrLogNotFound(@form, '.how-using .using.newflow-mustdo-alert')
     @please_select_chosen = @findOrLogNotFound(@form, '.how-chosen .chosen.newflow-mustdo-alert')
-    @please_fill_out_total_num = @findOrLogNotFound(@form, '.total-num.newflow-mustdo-alert')
+    @please_fill_out_total_num = @findOrLogNotFound(@form, '.total-num-students .errors.invalid-message')
     @please_fill_out_other = @findOrLogNotFound(@form, '.other.newflow-mustdo-alert')
     @please_select_subjects_interest = @findOrLogNotFound(@form, '.subjects.newflow-mustdo-alert')
     @please_select_books_used = @findOrLogNotFound(@form, '.used.newflow-mustdo-alert')
@@ -196,6 +196,7 @@ class NewflowUi.EducatorComplete
 
   onTotalNumChange: ->
     @please_fill_out_total_num.hide()
+    @total_num_students_input.removeClass('has-error')
     @continue.prop('disabled', false)
 
   onOtherChange: ->

--- a/app/views/newflow/login_signup/educator_profile_form.html.erb
+++ b/app/views/newflow/login_signup/educator_profile_form.html.erb
@@ -162,6 +162,9 @@
                             I18n.t(:"educator_complete_form.num_students_taught"),
                             class: 'field-label'
               %>
+              <div class="total-num newflow-mustdo-alert">
+                <%= I18n.t(:"educator_complete_form.fill_out") %>
+              </div>
               <%=
                 fh.text_field(
                   name: :num_students_per_semester_taught,

--- a/app/views/newflow/login_signup/educator_profile_form.html.erb
+++ b/app/views/newflow/login_signup/educator_profile_form.html.erb
@@ -162,9 +162,6 @@
                             I18n.t(:"educator_complete_form.num_students_taught"),
                             class: 'field-label'
               %>
-              <div class="total-num newflow-mustdo-alert">
-                <%= I18n.t(:"educator_complete_form.fill_out") %>
-              </div>
               <%=
                 fh.text_field(
                   name: :num_students_per_semester_taught,


### PR DESCRIPTION
Fixed a few UI problems (trello cards below)

1. num students needs to be filled out before continuing
1. subjects disappearing when switching between instructor and admin

![instructor to admin](https://user-images.githubusercontent.com/352161/83679593-80a10300-a594-11ea-944b-10bdf5d6012d.gif)

https://trello.com/c/2X2bNyOB/34-form-progresses-even-when-a-field-is-incomplete-seems-to-occur-only-on-the-total-number-of-students-question

https://trello.com/c/6x21z3I8/36-subjects-book-options-disappearing-when-switching-between-instructor-and-admin-even-though-the-selection-is-still-in-place-it-do