### PR TITLE
Set a timeout on the check for continue

### DIFF
--- a/app/assets/javascripts/newflow/newflow_ui.js.coffee
+++ b/app/assets/javascripts/newflow/newflow_ui.js.coffee
@@ -34,7 +34,14 @@ NewflowUi = do () ->
 
   enableOnChecked: (targetSelector, sourceSelector) ->
     $(document).ready =>
-      @disableButton(targetSelector) if !$(sourceSelector).is(':checked')
+
+      enable_disable_continue = () ->
+        if $(sourceSelector).is(':checked')
+          @enableButton(targetSelector)
+        else
+          @disableButton(targetSelector)
+
+      setTimeout(enable_disable_continue, 500)
 
       $(sourceSelector).on 'click', =>
         this.checkCheckedButton(targetSelector, sourceSelector)


### PR DESCRIPTION
This is needed because the arrival from a back button press creates a race between the browser refilling the form fields, UJS doing it's disabling of form submit.  This allows the code to check to be run after all this.

https://trello.com/c/g6OAWk2X/37-when-using-the-browser-back-arrow-the-continue-button-is-set-back-to-a-disabled-state-even-when-the-appropriate-information-is-i


![backbutton](https://user-images.githubusercontent.com/352161/83817844-a9032d00-a67a-11ea-8f99-a11fbcdb6f7b.gif)
