### PR TITLE
Patch v3.10.0 with changes from PR: fix TOS button enable/disable

### DIFF
--- a/app/assets/javascripts/newflow/newflow_ui.js.coffee
+++ b/app/assets/javascripts/newflow/newflow_ui.js.coffee
@@ -35,11 +35,8 @@ NewflowUi = do () ->
   enableOnChecked: (targetSelector, sourceSelector) ->
     $(document).ready =>
 
-      enable_disable_continue = () ->
-        if $(sourceSelector).is(':checked')
-          @enableButton(targetSelector)
-        else
-          @disableButton(targetSelector)
+      enable_disable_continue = () =>
+        this.checkCheckedButton(targetSelector, sourceSelector)
 
       setTimeout(enable_disable_continue, 500)
 


### PR DESCRIPTION
Fixes the bug with the TOS using commit 207f12261a1a1f713cced647629dab71af099c79 which we included in v3.9.2 but not v3.10.0. As a result, will create v3.10.1

Did: 
- git fetch
- git co v3.10.0
- git switch -c patch_to_v3.10.0
- git cherry-pick 207f12261a1a1f713cced647629dab71af099c79
- git push -u origin patch_to_v3.10.0
