### PR TITLE
Add step 2 to activejob educator queue

### DIFF
--- a/app/routines/newflow/educator_signup/activate_educator.rb
+++ b/app/routines/newflow/educator_signup/activate_educator.rb
@@ -4,7 +4,7 @@
 module Newflow
   module EducatorSignup
     class ActivateEducator
-      lev_routine
+      lev_routine active_job_enqueue_options: { queue: :educator_signup_queue }, use_jobba: true
       uses_routine CreateSalesforceLead
 
       protected ###############


### PR DESCRIPTION
Meant to be a patch to v6.0.3 — so, v6.0.4

https://github.com/openstax/accounts/compare/v6.0.3...v6.0.4