### PR TITLE
Fix step 4 not validating books presence

### DIFF
--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -24,7 +24,7 @@ class NewflowUi.EducatorComplete
     @total_num_students_input = @findOrLogNotFound(@total_num_students, "input")
     @other_input = @findOrLogNotFound(@other_specify, "input")
 
-    # book selecitions
+    # book selections
     @books_used_select = @findOrLogNotFound(@books_used, "select")
     @books_of_interest_select = @findOrLogNotFound(@books_of_interest, "select")
 
@@ -51,6 +51,9 @@ class NewflowUi.EducatorComplete
 
     # Continue button
     @continue = @findOrLogNotFound(@form, '#signup_form_submit_button')
+
+    # Disable submitting initially
+    @continue.prop('disabled', true)
 
     # Hide these fields initially because they only show up depending on the form's state
     @other_specify.hide()
@@ -85,7 +88,6 @@ class NewflowUi.EducatorComplete
     role_valid = @checkRoleValid()
     chosen_valid = @checkChosenValid()
     books_using_valid = @checkBooksUsingValid()
-    books_interested_valid = @checkBooksInterestedValid()
     total_num_valid = @checkTotalNumValid()
     other_valid = @checkOtherValid()
     books_used_valid = @checkBooksUsedValid()
@@ -94,11 +96,11 @@ class NewflowUi.EducatorComplete
     if not (role_valid and
             chosen_valid and
             books_using_valid and
-            books_interested_valid and
             other_valid and
             school_name_valid and
             total_num_valid and
-            books_used_valid)
+            books_used_valid and
+            books_of_interest_valid)
       ev.preventDefault()
 
   checkSchoolNameValid: () ->
@@ -149,16 +151,6 @@ class NewflowUi.EducatorComplete
       @please_select_using.show()
       false
 
-  checkBooksInterestedValid: () ->
-    return true if @how_using_radio.is(":hidden")
-
-    if @how_using_radio.is(":checked")
-      @please_select_using.hide()
-      true
-    else
-      @please_select_using.show()
-      false
-
   checkOtherValid: () ->
     return true if @other_input.is(":hidden")
 
@@ -191,7 +183,6 @@ class NewflowUi.EducatorComplete
 
   onSchoolNameChange: ->
     @please_fill_out_school.hide()
-    @continue.prop('disabled', false)
     @onRoleChange()
 
   onRoleChange: ->
@@ -225,16 +216,12 @@ class NewflowUi.EducatorComplete
       @how_using.hide()
       @please_fill_out_other.hide()
 
-    if @checkSchoolNameValid()
-      @continue.prop('disabled', false)
-
   onOtherChange: ->
     @please_fill_out_other.hide()
     @continue.prop('disabled', false)
 
   onHowChosenChange: ->
     @please_select_chosen.hide()
-    @continue.prop('disabled', false)
 
   onHowUsingChange: ->
     @please_select_using.hide()
@@ -254,11 +241,9 @@ class NewflowUi.EducatorComplete
       @books_used.hide()
       @please_select_books_used.hide()
       @please_select_books_of_interest.hide()
-    @continue.prop('disabled', false)
 
   onTotalNumChange: ->
     @please_fill_out_total_num.hide()
-    @continue.prop('disabled', false)
 
   onBooksUsedChange: ->
     return false if !@checkTotalNumValid()

--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -1,7 +1,7 @@
 class NewflowUi.EducatorComplete
 
   constructor: ->
-    _.bindAll(@, 'onSchoolNameChange', 'onRoleChange', 'onHowUsingChange', 'onHowChosenChange', 'onTotalNumChange', 'onOtherChange', 'onBooksUsedChange', 'onBooksOfInterestChange', 'onSubmit')
+    _.bindAll(@, 'onSchoolNameChange', 'onRoleChange', 'onHowUsingChange', 'onHowChosenChange', 'onTotalNumChange', 'onOtherInputChange', 'onBooksUsedChange', 'onBooksOfInterestChange', 'onSubmit')
     @initBooksUsedMultiSelect()
     @initBooksOfInterestMultiSelect()
     @form = $('.signup-page.completed-step')
@@ -40,11 +40,11 @@ class NewflowUi.EducatorComplete
 
     # event listeners
     @school_name_input.on('input', @onSchoolNameChange)
-    @other_input.on('input', @onOtherChange)
+    @other_input.on('input', @onOtherInputChange)
     @completed_role_radio.change(@onRoleChange)
     @how_chosen_radio.change(@onHowChosenChange)
     @how_using_radio.change(@onHowUsingChange)
-    @total_num_students_input.change(@onTotalNumChange)
+    @total_num_students_input.on('input', @onTotalNumChange)
     @books_used_select.change(@onBooksUsedChange)
     @books_of_interest_select.change(@onBooksOfInterestChange)
     @findOrLogNotFound(@form, 'form').submit(@onSubmit)
@@ -83,22 +83,21 @@ class NewflowUi.EducatorComplete
   onSubmit: (ev) ->
     school_name_valid = @checkSchoolNameValid()
     role_valid = @checkRoleValid()
-    chosen_valid = @checkChosenValid()
-    books_using_valid = @checkBooksUsingValid()
-    books_interested_valid = @checkBooksInterestedValid()
+    other_role_name_valid = @checkOtherRoleInputValid()
+    how_chosen_valid = @checkHowChosenValid()
+    how_using_valid = @checkHowUsingValid()
     total_num_valid = @checkTotalNumValid()
-    other_valid = @checkOtherValid()
     books_used_valid = @checkBooksUsedValid()
     books_of_interest_valid = @checkBooksOfInterestValid()
 
-    if not (role_valid and
-            chosen_valid and
-            books_using_valid and
-            books_interested_valid and
-            other_valid and
-            school_name_valid and
+    if not (school_name_valid and
+            role_valid and
+            other_role_name_valid and
+            how_chosen_valid and
+            how_using_valid and
             total_num_valid and
-            books_used_valid)
+            books_used_valid and
+            books_of_interest_valid)
       ev.preventDefault()
 
   checkSchoolNameValid: () ->
@@ -119,6 +118,36 @@ class NewflowUi.EducatorComplete
       @please_select_role.show()
       false
 
+  checkOtherRoleInputValid: () ->
+    return true if @other_input.is(":hidden")
+
+    if @other_input.val()
+      @please_fill_out_other.hide()
+      true
+    else
+      @please_fill_out_other.show()
+      false
+
+  checkHowChosenValid: () ->
+    return true if @how_chosen_radio.is(":hidden")
+
+    if @how_chosen_radio.is(":checked")
+      @please_select_chosen.hide()
+      true
+    else
+      @please_select_chosen.show()
+      false
+
+  checkHowUsingValid: () ->
+    return true if @how_using_radio.is(":hidden")
+
+    if @how_using_radio.is(":checked")
+      @please_select_using.hide()
+      true
+    else
+      @please_select_using.show()
+      false
+
   checkTotalNumValid: () ->
     return true if @total_num_students_input.is(":hidden")
 
@@ -129,46 +158,6 @@ class NewflowUi.EducatorComplete
       @please_fill_out_total_num.show()
       false
 
-  checkChosenValid: () ->
-    return true if @how_chosen_radio.is(":hidden")
-
-    if @how_chosen_radio.is(":checked")
-      @please_select_chosen.hide()
-      true
-    else
-      @please_select_chosen.show()
-      false
-
-  checkBooksUsingValid: () ->
-    return true if @how_using_radio.is(":hidden")
-
-    if @how_using_radio.is(":checked")
-      @please_select_using.hide()
-      true
-    else
-      @please_select_using.show()
-      false
-
-  checkBooksInterestedValid: () ->
-    return true if @how_using_radio.is(":hidden")
-
-    if @how_using_radio.is(":checked")
-      @please_select_using.hide()
-      true
-    else
-      @please_select_using.show()
-      false
-
-  checkOtherValid: () ->
-    return true if @other_input.is(":hidden")
-
-    if @other_input.val()
-      @please_fill_out_other.hide()
-      true
-    else
-      @please_fill_out_other.show()
-      false
-
   checkBooksUsedValid: () ->
     return true if @books_used.is(":hidden")
 
@@ -177,6 +166,7 @@ class NewflowUi.EducatorComplete
       true
     else
       @please_select_books_used.show()
+      @continue.prop('disabled', true)
       false
 
   checkBooksOfInterestValid: () ->
@@ -187,35 +177,36 @@ class NewflowUi.EducatorComplete
       true
     else
       @please_select_books_of_interest.show()
+      @continue.prop('disabled', true)
       false
 
   onSchoolNameChange: ->
-    @please_fill_out_school.hide()
-    @continue.prop('disabled', false)
-    @onRoleChange()
+    @checkSchoolNameValid()
+
+    if @completed_role_radio.is(":checked")
+      @onRoleChange()
+      @checkBooksUsedValid()
+      @checkBooksOfInterestValid()
 
   onRoleChange: ->
-    @please_select_role.hide()
+    @checkRoleValid()
+    @checkSchoolNameValid()
 
     if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_instructor').is(':checked') && @checkSchoolNameValid() )
-      @other_specify.hide()
-      @books_used.hide()
       @how_using.show()
-      @please_select_using.hide()
       @how_chosen.show()
-      @please_select_chosen.hide()
       @total_num_students.show()
-      @please_fill_out_total_num.hide()
-      @onHowUsingChange()
-    else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_administrator').is(':checked') && @checkSchoolNameValid() )
       @other_specify.hide()
-      @books_used.hide()
-      @total_num_students.hide()
-      @how_chosen.show()
-      @please_select_chosen.hide()
-      @how_using.show()
       @please_select_using.hide()
-      @onHowUsingChange()
+      @please_select_chosen.hide()
+      @please_fill_out_total_num.hide()
+    else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_administrator').is(':checked') && @checkSchoolNameValid() )
+      @how_chosen.show()
+      @how_using.show()
+      @other_specify.hide()
+      @total_num_students.hide()
+      @please_select_chosen.hide()
+      @please_select_using.hide()
     else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_other').is(':checked') )
       @other_specify.show()
       @books_used.hide()
@@ -224,20 +215,27 @@ class NewflowUi.EducatorComplete
       @total_num_students.hide()
       @how_using.hide()
       @please_fill_out_other.hide()
+      @continue.prop('disabled', true)
 
-    if @checkSchoolNameValid()
-      @continue.prop('disabled', false)
+    if @how_using_radio.is(":checked") && !( @findOrLogNotFound($(document), '#signup_educator_specific_role_other').is(':checked') )
+      @onHowUsingChange()
 
-  onOtherChange: ->
+  onOtherInputChange: ->
     @please_fill_out_other.hide()
-    @continue.prop('disabled', false)
+
+    if @checkOtherRoleInputValid() && @checkSchoolNameValid()
+      @continue.prop('disabled', false)
+    else
+      @continue.prop('disabled', true)
 
   onHowChosenChange: ->
-    @please_select_chosen.hide()
-    @continue.prop('disabled', false)
+    @checkHowChosenValid()
+    @checkBooksUsedValid()
+    @checkBooksOfInterestValid()
 
   onHowUsingChange: ->
-    @please_select_using.hide()
+    @checkHowUsingValid()
+    @checkHowChosenValid()
 
     if ( @findOrLogNotFound($(document), '#signup_using_openstax_how_as_primary').is(':checked') )
       @books_used.show()
@@ -254,20 +252,23 @@ class NewflowUi.EducatorComplete
       @books_used.hide()
       @please_select_books_used.hide()
       @please_select_books_of_interest.hide()
-    @continue.prop('disabled', false)
 
   onTotalNumChange: ->
-    @please_fill_out_total_num.hide()
-    @continue.prop('disabled', false)
+    @checkTotalNumValid()
+    @onHowUsingChange()
 
   onBooksUsedChange: ->
-    return false if !@checkTotalNumValid()
+    @checkTotalNumValid()
 
-    @please_select_books_used.hide()
-    @continue.prop('disabled', false)
+    if @checkBooksUsedValid()
+      @continue.prop('disabled', false)
+    else
+      @continue.prop('disabled', true)
 
   onBooksOfInterestChange: ->
-    return false if !@checkTotalNumValid()
+    @checkTotalNumValid()
 
-    @please_select_books_of_interest.hide()
-    @continue.prop('disabled', false)
+    if @checkBooksOfInterestValid()
+      @continue.prop('disabled', false)
+    else
+      @continue.prop('disabled', true)

--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -1,7 +1,7 @@
 class NewflowUi.EducatorComplete
 
   constructor: ->
-    _.bindAll(@, 'onSchoolNameChange', 'onRoleChange', 'onHowUsingChange', 'onHowChosenChange', 'onTotalNumChange', 'onOtherInputChange', 'onBooksUsedChange', 'onBooksOfInterestChange', 'onSubmit')
+    _.bindAll(@, 'onSchoolNameChange', 'onRoleChange', 'onHowUsingChange', 'onHowChosenChange', 'onTotalNumChange', 'onOtherChange', 'onBooksUsedChange', 'onBooksOfInterestChange', 'onSubmit')
     @initBooksUsedMultiSelect()
     @initBooksOfInterestMultiSelect()
     @form = $('.signup-page.completed-step')
@@ -40,11 +40,11 @@ class NewflowUi.EducatorComplete
 
     # event listeners
     @school_name_input.on('input', @onSchoolNameChange)
-    @other_input.on('input', @onOtherInputChange)
+    @other_input.on('input', @onOtherChange)
     @completed_role_radio.change(@onRoleChange)
     @how_chosen_radio.change(@onHowChosenChange)
     @how_using_radio.change(@onHowUsingChange)
-    @total_num_students_input.on('input', @onTotalNumChange)
+    @total_num_students_input.change(@onTotalNumChange)
     @books_used_select.change(@onBooksUsedChange)
     @books_of_interest_select.change(@onBooksOfInterestChange)
     @findOrLogNotFound(@form, 'form').submit(@onSubmit)
@@ -83,21 +83,22 @@ class NewflowUi.EducatorComplete
   onSubmit: (ev) ->
     school_name_valid = @checkSchoolNameValid()
     role_valid = @checkRoleValid()
-    other_role_name_valid = @checkOtherRoleInputValid()
-    how_chosen_valid = @checkHowChosenValid()
-    how_using_valid = @checkHowUsingValid()
+    chosen_valid = @checkChosenValid()
+    books_using_valid = @checkBooksUsingValid()
+    books_interested_valid = @checkBooksInterestedValid()
     total_num_valid = @checkTotalNumValid()
+    other_valid = @checkOtherValid()
     books_used_valid = @checkBooksUsedValid()
     books_of_interest_valid = @checkBooksOfInterestValid()
 
-    if not (school_name_valid and
-            role_valid and
-            other_role_name_valid and
-            how_chosen_valid and
-            how_using_valid and
+    if not (role_valid and
+            chosen_valid and
+            books_using_valid and
+            books_interested_valid and
+            other_valid and
+            school_name_valid and
             total_num_valid and
-            books_used_valid and
-            books_of_interest_valid)
+            books_used_valid)
       ev.preventDefault()
 
   checkSchoolNameValid: () ->
@@ -118,36 +119,6 @@ class NewflowUi.EducatorComplete
       @please_select_role.show()
       false
 
-  checkOtherRoleInputValid: () ->
-    return true if @other_input.is(":hidden")
-
-    if @other_input.val()
-      @please_fill_out_other.hide()
-      true
-    else
-      @please_fill_out_other.show()
-      false
-
-  checkHowChosenValid: () ->
-    return true if @how_chosen_radio.is(":hidden")
-
-    if @how_chosen_radio.is(":checked")
-      @please_select_chosen.hide()
-      true
-    else
-      @please_select_chosen.show()
-      false
-
-  checkHowUsingValid: () ->
-    return true if @how_using_radio.is(":hidden")
-
-    if @how_using_radio.is(":checked")
-      @please_select_using.hide()
-      true
-    else
-      @please_select_using.show()
-      false
-
   checkTotalNumValid: () ->
     return true if @total_num_students_input.is(":hidden")
 
@@ -158,6 +129,46 @@ class NewflowUi.EducatorComplete
       @please_fill_out_total_num.show()
       false
 
+  checkChosenValid: () ->
+    return true if @how_chosen_radio.is(":hidden")
+
+    if @how_chosen_radio.is(":checked")
+      @please_select_chosen.hide()
+      true
+    else
+      @please_select_chosen.show()
+      false
+
+  checkBooksUsingValid: () ->
+    return true if @how_using_radio.is(":hidden")
+
+    if @how_using_radio.is(":checked")
+      @please_select_using.hide()
+      true
+    else
+      @please_select_using.show()
+      false
+
+  checkBooksInterestedValid: () ->
+    return true if @how_using_radio.is(":hidden")
+
+    if @how_using_radio.is(":checked")
+      @please_select_using.hide()
+      true
+    else
+      @please_select_using.show()
+      false
+
+  checkOtherValid: () ->
+    return true if @other_input.is(":hidden")
+
+    if @other_input.val()
+      @please_fill_out_other.hide()
+      true
+    else
+      @please_fill_out_other.show()
+      false
+
   checkBooksUsedValid: () ->
     return true if @books_used.is(":hidden")
 
@@ -166,7 +177,6 @@ class NewflowUi.EducatorComplete
       true
     else
       @please_select_books_used.show()
-      @continue.prop('disabled', true)
       false
 
   checkBooksOfInterestValid: () ->
@@ -177,36 +187,35 @@ class NewflowUi.EducatorComplete
       true
     else
       @please_select_books_of_interest.show()
-      @continue.prop('disabled', true)
       false
 
   onSchoolNameChange: ->
-    @checkSchoolNameValid()
-
-    if @completed_role_radio.is(":checked")
-      @onRoleChange()
-      @checkBooksUsedValid()
-      @checkBooksOfInterestValid()
+    @please_fill_out_school.hide()
+    @continue.prop('disabled', false)
+    @onRoleChange()
 
   onRoleChange: ->
-    @checkRoleValid()
-    @checkSchoolNameValid()
+    @please_select_role.hide()
 
     if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_instructor').is(':checked') && @checkSchoolNameValid() )
+      @other_specify.hide()
+      @books_used.hide()
       @how_using.show()
+      @please_select_using.hide()
       @how_chosen.show()
+      @please_select_chosen.hide()
       @total_num_students.show()
-      @other_specify.hide()
-      @please_select_using.hide()
-      @please_select_chosen.hide()
       @please_fill_out_total_num.hide()
+      @onHowUsingChange()
     else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_administrator').is(':checked') && @checkSchoolNameValid() )
-      @how_chosen.show()
-      @how_using.show()
       @other_specify.hide()
+      @books_used.hide()
       @total_num_students.hide()
+      @how_chosen.show()
       @please_select_chosen.hide()
+      @how_using.show()
       @please_select_using.hide()
+      @onHowUsingChange()
     else if ( @findOrLogNotFound($(document), '#signup_educator_specific_role_other').is(':checked') )
       @other_specify.show()
       @books_used.hide()
@@ -215,27 +224,20 @@ class NewflowUi.EducatorComplete
       @total_num_students.hide()
       @how_using.hide()
       @please_fill_out_other.hide()
-      @continue.prop('disabled', true)
 
-    if @how_using_radio.is(":checked") && !( @findOrLogNotFound($(document), '#signup_educator_specific_role_other').is(':checked') )
-      @onHowUsingChange()
-
-  onOtherInputChange: ->
-    @please_fill_out_other.hide()
-
-    if @checkOtherRoleInputValid() && @checkSchoolNameValid()
+    if @checkSchoolNameValid()
       @continue.prop('disabled', false)
-    else
-      @continue.prop('disabled', true)
+
+  onOtherChange: ->
+    @please_fill_out_other.hide()
+    @continue.prop('disabled', false)
 
   onHowChosenChange: ->
-    @checkHowChosenValid()
-    @checkBooksUsedValid()
-    @checkBooksOfInterestValid()
+    @please_select_chosen.hide()
+    @continue.prop('disabled', false)
 
   onHowUsingChange: ->
-    @checkHowUsingValid()
-    @checkHowChosenValid()
+    @please_select_using.hide()
 
     if ( @findOrLogNotFound($(document), '#signup_using_openstax_how_as_primary').is(':checked') )
       @books_used.show()
@@ -252,23 +254,20 @@ class NewflowUi.EducatorComplete
       @books_used.hide()
       @please_select_books_used.hide()
       @please_select_books_of_interest.hide()
+    @continue.prop('disabled', false)
 
   onTotalNumChange: ->
-    @checkTotalNumValid()
-    @onHowUsingChange()
+    @please_fill_out_total_num.hide()
+    @continue.prop('disabled', false)
 
   onBooksUsedChange: ->
-    @checkTotalNumValid()
+    return false if !@checkTotalNumValid()
 
-    if @checkBooksUsedValid()
-      @continue.prop('disabled', false)
-    else
-      @continue.prop('disabled', true)
+    @please_select_books_used.hide()
+    @continue.prop('disabled', false)
 
   onBooksOfInterestChange: ->
-    @checkTotalNumValid()
+    return false if !@checkTotalNumValid()
 
-    if @checkBooksOfInterestValid()
-      @continue.prop('disabled', false)
-    else
-      @continue.prop('disabled', true)
+    @please_select_books_of_interest.hide()
+    @continue.prop('disabled', false)

--- a/app/handlers/newflow/educator_signup/complete_profile.rb
+++ b/app/handlers/newflow/educator_signup/complete_profile.rb
@@ -79,9 +79,9 @@ module Newflow
       end
 
       def which_books
-        if signup_params.books_used.present?
+        if books_used.present?
           format_books_for_salesforce_string(signup_params.books_used)
-        elsif signup_params.books_of_interest.present?
+        elsif books_of_interest.present?
           format_books_for_salesforce_string(signup_params.books_of_interest)
         end
       end
@@ -105,15 +105,13 @@ module Newflow
         end
 
         if signup_params.educator_specific_role.strip.downcase  == INSTRUCTOR &&
-          signup_params.using_openstax_how == AS_PRIMARY &&
-          signup_params.books_used.blank?
+          signup_params.using_openstax_how == AS_PRIMARY && books_used.blank?
 
           param_error(:books_used, :books_used_must_be_entered)
         end
 
         if signup_params.educator_specific_role.strip.downcase  == INSTRUCTOR &&
-          signup_params.using_openstax_how != AS_PRIMARY &&
-          signup_params.books_of_interest.blank?
+          signup_params.using_openstax_how != AS_PRIMARY && books_of_interest.blank?
 
           param_error(:books_of_interest, :books_of_interest_must_be_entered)
         end
@@ -123,6 +121,14 @@ module Newflow
 
           param_error(:num_students_per_semester_taught, :num_students_must_be_entered)
         end
+      end
+
+      def books_used
+        signup_params.books_used.reject{ |b| b.blank? }
+      end
+
+      def books_of_interest
+        signup_params.books_of_interest.reject{ |b| b.blank? }
       end
 
       def param_error(field, error_key)

--- a/app/routines/newflow/educator_signup/update_salesforce_lead.rb
+++ b/app/routines/newflow/educator_signup/update_salesforce_lead.rb
@@ -91,7 +91,7 @@ module Newflow
         Rails.logger.warn(message)
         Raven.capture_message(message, extra: {
           user_id: user.id,
-          lead_id: lead.id,
+          lead_id: lead&.id,
           leader_errors_full_message: lead&.errors&.full_messages,
           error_code: code
         })

--- a/app/routines/newflow/educator_signup/update_salesforce_lead.rb
+++ b/app/routines/newflow/educator_signup/update_salesforce_lead.rb
@@ -74,19 +74,27 @@ module Newflow
       end
 
       def log_success(user, lead)
-        message = "#{self.class.name} SUCCESS (#{lead.id}) for user (#{user.id})"
-        Rails.logger.info(message)
+        logger_message = "#{self.class.name} SUCCESS (#{lead.id}) for user (#{user.id})"
+        Rails.logger.info(logger_message)
         SecurityLog.create!(
             user: user,
             event_type: :user_updated,
-            event_data: { message: "User's lead updated: #{lead.inspect}" }
+            event_data: {
+              message: "User's lead updated: #{lead.inspect}",
+              success_from: "#{self.class.name}"
+            }
         )
       end
 
       def log_error(user, lead, code=nil)
-        message = "#{self.class.name} ERROR; Lead (#{lead&.id}) for user (#{user.id}); Error: #{lead&.errors&.full_messages}; Code: #{code}"
+        message = "ERROR FROM #{self.class.name}"
         Rails.logger.warn(message)
-        Raven.capture_message(message)
+        Raven.capture_message(message, extra: {
+          user_id: user.id,
+          lead_id: lead.id,
+          leader_errors_full_message: lead&.errors&.full_messages,
+          error_code: code
+        })
       end
 
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
     school_name_must_be_entered: Please enter school name
     other_must_be_entered: Please enter other role name
     books_used_must_be_entered: Please enter books used
-    subjects_of_interest_must_be_entered: Please enter subjects of interest
+    books_of_interest_must_be_entered: Please enter books of interest
     num_students_must_be_entered: Please enter number of students taught
 
   login_signup_form:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -22,7 +22,7 @@ pl:
     school_name_must_be_entered: Proszę podać nazwę szkoły
     other_must_be_entered: Wpisz inną nazwę roli
     books_used_must_be_entered: Wpisz używane książki
-    subjects_of_interest_must_be_entered: Wpisz interesujące cię tematy
+    books_of_interest_must_be_entered: Wprowadź interesujące książki
     num_students_must_be_entered: Podaj liczbę uczniów nauczanych
 
   login_signup_form:

--- a/spec/features/newflow/educators/educator_signup_flow_spec.rb
+++ b/spec/features/newflow/educators/educator_signup_flow_spec.rb
@@ -105,7 +105,7 @@ module Newflow
           # Step 4
           expect_educator_step_4_page
           find('#signup_educator_specific_role_other').click
-          fill_in('Other (please specify)', with: 'President')
+          fill_in(I18n.t(:"educator_profile_form.other_please_specify"), with: 'President')
           click_on('Continue')
           expect(page.current_path).to eq(signup_done_path)
           click_on('Finish')


### PR DESCRIPTION
- Fix step 4 not validating books presence. There's a backend component, a frontend component, and a couple of translations.
- Also group the Sentry errors from app/routines/newflow/educator_signup/update_salesforce_lead.rb into one with a counter so that we don't receive an email every time that background job fails.

Meant to be a patch to v6.0.4