### PR TITLE
Add Brazil to GDPR list to geofence it easily

### DIFF
--- a/lib/set_gdpr_data.rb
+++ b/lib/set_gdpr_data.rb
@@ -127,6 +127,7 @@ module SetGdprData
     'ES', # Spain
     'SE', # Sweden
     'GB', # United Kingdom
+    'BR', # Brazil, hack to geofence it
   ];
 
 end


### PR DESCRIPTION
We need to geofence Brazil for their new legislation, this is the fastest way to do that.

https://www.iso.org/obp/ui/#iso:code:3166:BR