### PR TITLE
During scheduled salesforce sync, rename to salesforce Contact id in security log event

### DIFF
--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -297,7 +297,7 @@ class UpdateUserSalesforceInfo
           application: nil,
           remote_ip: nil,
           event_type: :faculty_verified,
-          event_data: { user_id: user.id, salesforce_id: contact.id }
+          event_data: { user_id: user.id, salesforce_contact_id: contact.id }
       )
     end
 


### PR DESCRIPTION
In the scheduled SF sync, when a user is faculty verifed via salesforce, a security log is created. That security log includes the salesforce contact id in the event data. The problem is that it calls it `salesforce_id` which is inaccurate; it should say `salesforce_contact_id` because that's what it is. Just improves the security logs stream.