### PR TITLE
Fix 1320

### DIFF
--- a/app/controllers/newflow/educator_signup_controller.rb
+++ b/app/controllers/newflow/educator_signup_controller.rb
@@ -26,7 +26,12 @@ module Newflow
     )
     before_action(:store_if_sheerid_is_unviable_for_user, only: :educator_profile_form)
     before_action(:store_sheerid_verification_for_user, only: :educator_profile_form)
-    before_action(:exit_signup_if_steps_complete, only: %i[educator_sheerid_form educator_profile_form])
+    before_action(:exit_signup_if_steps_complete, only: %i[
+        educator_sheerid_form
+        educator_profile_form
+        educator_cs_verification_form
+      ]
+    )
 
     def educator_signup
       handle_with(
@@ -199,6 +204,10 @@ module Newflow
       return if !current_user.is_newflow?
 
       case true
+      when current_user.is_educator_pending_cs_verification && current_user.pending_faculty?
+        redirect_to(educator_pending_cs_verification_path)
+      when current_user.is_educator_pending_cs_verification && !current_user.pending_faculty?
+        redirect_back(fallback_location: profile_newflow_path)
       when action_name == 'educator_sheerid_form' && current_user.step_3_complete?
         redirect_to(educator_profile_form_path)
       when action_name == 'educator_profile_form' && current_user.is_profile_complete?

--- a/app/handlers/newflow/educator_signup/cs_verification_request.rb
+++ b/app/handlers/newflow/educator_signup/cs_verification_request.rb
@@ -69,7 +69,7 @@ module Newflow
         outputs.user = user
 
         if !users_existing_email.present?
-          run(CreateEmailForUser, email: email_address_value, user: user)
+          run(CreateEmailForUser, email: email_address_value, user: user, is_school_issued: true)
         end
 
         UpsertSalesforceInfoForCsVerification.perform_later(user: user)

--- a/app/routines/newflow/create_email_for_user.rb
+++ b/app/routines/newflow/create_email_for_user.rb
@@ -4,8 +4,8 @@ module Newflow
 
     protected ###############
 
-    def exec(email:, user:)
-      @email = EmailAddress.create(value: email&.downcase, user_id: user.id)
+    def exec(email:, user:, is_school_issued: nil)
+      @email = EmailAddress.create(value: email&.downcase, user_id: user.id, is_school_issued: is_school_issued)
 
       @email.customize_value_error_message(
         error: :missing_mx_records,

--- a/lib/educator_signup_flow_decorator.rb
+++ b/lib/educator_signup_flow_decorator.rb
@@ -12,7 +12,7 @@ class EducatorSignupFlowDecorator
   def newflow_edu_incomplete_step_3?
     if !user.is_newflow? || user.is_sheerid_unviable?
       return false
-    elsif user.sheerid_verification_id.blank? && user.pending_faculty?
+    elsif user.sheerid_verification_id.blank? && user.pending_faculty? && !user.is_educator_pending_cs_verification
       return true
     end
   end

--- a/spec/features/legacy/user_signs_up_spec.rb
+++ b/spec/features/legacy/user_signs_up_spec.rb
@@ -131,6 +131,7 @@ feature 'User signs up', js: true, vcr: VCR_OPTS do
     expect_sign_up_page # students default to sign-up vs the standard sign-in
     expect(page).to have_no_field('signup_role') # no changing the role
 
+    find('#signup_email').execute_script('this.value = ""')
     fill_in (t :"legacy.signup.start.email_placeholder"), with: 'my-personal-email@gmail.com'
     click_button(t :"legacy.signup.start.next")
     open_email("my-personal-email@gmail.com")

--- a/spec/features/newflow/educators/educator_signed_params_flow_spec.rb
+++ b/spec/features/newflow/educators/educator_signed_params_flow_spec.rb
@@ -36,9 +36,16 @@ module Newflow
       it 'prefills email on sign in when there is a match AND links user account to external user account' do
         arrive_from_app(params: signed_params, do_expect: false)
         expect(page).to have_field('login_form_email', with: payload[:email])
-        find('#login_form_email').execute_script('this.value = ""')
+        fill_in('login_form_password', with: 'password')
+        expect(page).to have_no_missing_translations
+        wait_for_animations
+        wait_for_ajax
         screenshot!
-        newflow_log_in_user(payload[:email], 'password')
+        click_button(I18n.t(:"login_signup_form.continue_button"))
+        wait_for_animations
+        wait_for_ajax
+        screenshot!
+        expect(page).to have_no_missing_translations
         expect_back_at_app
         expect(user.external_uuids.where(uuid: payload[:uuid])).to exist
       end


### PR DESCRIPTION
First issue: after requesting manual CS Verification, users were still able to view and submit the SheerID form (step 3) and step 4. Instead, they should be sent to the screen that says they are pending CS verification.

Second issue seems related to Salesforce, reported by QA in staging. This, I'll be testing manually in the server. My guess, as it has become common recently in the past, is that there's an incosistency between what Accounts expects in Salesforce and what is actually there is the corresponding instance/server.

> so the first thing i noticed is that i never got access. i looked at my lead in sf and it didnt have a subject, as well as the student number was incorrect. when i selected other on the form, the role came back as other in sf, not what was input. even after changing it manually in sf, i never got the access to resources.

