### PR TITLE
Activated school issued users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,10 +56,17 @@ class User < ActiveRecord::Base
   enum(school_type: VALID_SCHOOL_TYPES)
 
   scope(
+    :activated, -> {
+      where(state: ACTIVATED)
+    }
+  )
+
+  scope(
     :by_unverified, -> {
       where(state: UNVERIFIED)
     }
   )
+
   scope(
     :older_than_one_year, -> {
       where("created_at < ?", 1.year.ago)

--- a/app/routines/newflow/educator_signup/create_salesforce_lead.rb
+++ b/app/routines/newflow/educator_signup/create_salesforce_lead.rb
@@ -4,7 +4,6 @@ module Newflow
 
       lev_routine active_job_enqueue_options: { queue: :educator_signup_queue }
 
-      SALESFORCE_STUDENT_ROLE = 'Student'
       SALESFORCE_INSTRUCTOR_ROLE =  'OSC Faculty'
       DEFAULT_REFERRING_APP_NAME = 'Accounts'
 
@@ -14,7 +13,6 @@ module Newflow
         status.set_job_name(self.class.name)
         status.set_job_args(user: user.to_global_id.to_s)
 
-        salesforce_role_name = user.student? ? SALESFORCE_STUDENT_ROLE : SALESFORCE_INSTRUCTOR_ROLE
         referring_app_name = user&.source_application&.lead_application_source || DEFAULT_REFERRING_APP_NAME
 
         lead = OpenStax::Salesforce::Remote::Lead.new(
@@ -22,7 +20,7 @@ module Newflow
           last_name: user.last_name,
           phone: user.phone_number,
           email: user.best_email_address_for_CS_verification,
-          source: salesforce_role_name,
+          source: SALESFORCE_INSTRUCTOR_ROLE,
           application_source: referring_app_name,
           role: user.role,
           os_accounts_id: user.id,

--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -55,11 +55,11 @@ class UpdateUserSalesforceInfo
       # eager_load by default produces a LEFT OUTER JOIN
       # But we can use an INNER JOIN here since we have a WHERE condition on contact_infos
       # So we use joins to convert the LEFT OUTER JOIN to an INNER JOIN
-      User.joins(:contact_infos)
+      User.activated.joins(:contact_infos)
           .eager_load(:contact_infos)
           .where(salesforce_contact_id: nil)
-          .where.has{ |t| t.contact_infos.value.lower.in emails}
-          .where(contact_infos: { verified: true })
+          .where.has{ |t| t.contact_infos.value.lower.in emails }
+          .where.has{ |t| t.contact_infos.verified.eq(true).or(t.contact_infos.is_school_issued.eq(true)) }
           .each do |user|
 
         begin


### PR DESCRIPTION
Only sometimes, when a user has not yet verified the email address that they typed in to the new CS verification form, the salesforce sync will not be able to find the user by that email. With this PR, the salesforce sync WILL be able to find that user as long as they have any other verified email address (this is an "activated" user) and if approved, give that user faculty access. This is an improvement that I didn't realize before could be a problem until I tested in QA server and didn't verify my user's _new_ email address, so in other words, until further testing... before QA reported the problem.

Also, in app/routines/newflow/educator_signup/create_salesforce_lead.rb, always set the user's role to instructor in case that for ANY reason, their account role is set to student. Minor improvement.