### PR TITLE
Change student to faculty role when faculty verified

### DIFF
--- a/app/routines/newflow/educator_signup/verify_educator.rb
+++ b/app/routines/newflow/educator_signup/verify_educator.rb
@@ -19,8 +19,8 @@ module Newflow
         transfer_errors_from(verification_record, {type: :verbatim}, :fail_if_errors)
         return if !verification_record.verified?
 
-        # If the user is already faculty verified, nothing to do. If they're a student, don't faculty verify.
-        return if user.confirmed_faculty? || user.student?
+        # If the user is already faculty verified, nothing to do.
+        return if user.confirmed_faculty?
 
         email = EmailAddress.verified.find_by(value: verification_record.email)
 

--- a/app/routines/newflow/student_signup/activate_student.rb
+++ b/app/routines/newflow/student_signup/activate_student.rb
@@ -35,9 +35,8 @@ module Newflow
             newsletter: user.receive_newsletter?,
             source_application: user.source_application,
             phone_number: user.phone_number,
-            # params req'd by `PushSalesforceLead` but  which we don't have yet
-            # (consider changing the method signature instead, set defaults):
-            school: nil, using_openstax: nil, subject: nil, num_students: nil, url: nil
+            school: User::UNKNOWN_SCHOOL_NAME,
+            using_openstax: nil, subject: nil, num_students: nil, url: nil
           )
         end
       end


### PR DESCRIPTION
When a user signs up as a student (usually unknowingly), we want to allow them to request faculty access, but previously, we didn't actually update their role from student to instructor. This commit fixes that.

Also, `school` is now a required field for salesforce leads. Without a default, a lead does not get created and it fails silently.