### PR TITLE
Update Lead source to faculty

### DIFF
--- a/app/routines/newflow/educator_signup/update_salesforce_lead.rb
+++ b/app/routines/newflow/educator_signup/update_salesforce_lead.rb
@@ -56,7 +56,8 @@ module Newflow
           who_chooses_books: user.who_chooses_books,
           subject: user.which_books,
           finalize_educator_signup: user.is_profile_complete?,
-          needs_cs_review: user.is_educator_pending_cs_verification?
+          needs_cs_review: user.is_educator_pending_cs_verification?,
+          source: CreateSalesforceLead::SALESFORCE_INSTRUCTOR_ROLE
         )
       end
 


### PR DESCRIPTION
When a user signs up as a student but then requests faculty access, and they get access, their salesforce lead is updated. The problem is that their Lead's `source` (which is like their role) remains set to Student. The fix is to update the lead's `source` field to `OSC Faculty` as it does get set when the lead is first created (so just use that constant `CreateSalesforceLead::SALESFORCE_INSTRUCTOR_ROLE`).