### PR TITLE
Tutor students also skip You're Done signup page

### DIFF
--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -66,7 +66,11 @@ module Newflow
           sign_in!(user)
           security_log(:student_verified_email)
 
-          redirect_to(signup_done_path)
+          if user.is_tutor_user?
+            redirect_back(fallback_location: profile_newflow_path)
+          else
+            redirect_to(signup_done_path)
+          end
         },
         failure: lambda {
           @first_name = unverified_user.first_name


### PR DESCRIPTION
Part of https://github.com/openstax/business-intel/issues/1391 but for students in addition to Educators.

Tutor users should not see the "You're done" signup page. They should just be redirected back to Tutor.