### PR TITLE
Fix: Skip "You're done" signup page for Tutor users

### DIFF
--- a/app/controllers/newflow/educator_signup_controller.rb
+++ b/app/controllers/newflow/educator_signup_controller.rb
@@ -24,6 +24,7 @@ module Newflow
         educator_cs_verification_request
       ]
     )
+    before_action(:cache_client_app, only: :educator_signup_form)
     before_action(:store_if_sheerid_is_unviable_for_user, only: :educator_profile_form)
     before_action(:store_sheerid_verification_for_user, only: :educator_profile_form)
     before_action(:exit_signup_if_steps_complete, only: %i[
@@ -147,8 +148,6 @@ module Newflow
 
           if user.is_educator_pending_cs_verification?
             redirect_to(educator_pending_cs_verification_path)
-          elsif user.is_tutor_user?
-            redirect_back(fallback_location: profile_newflow_path)
           else
             redirect_to(signup_done_path)
           end

--- a/app/controllers/newflow/educator_signup_controller.rb
+++ b/app/controllers/newflow/educator_signup_controller.rb
@@ -24,7 +24,7 @@ module Newflow
         educator_cs_verification_request
       ]
     )
-    before_action(:cache_client_app, only: :educator_signup_form)
+    before_action(:cache_redirect_uri_if_tutor, only: :educator_signup_form)
     before_action(:store_if_sheerid_is_unviable_for_user, only: :educator_profile_form)
     before_action(:store_sheerid_verification_for_user, only: :educator_profile_form)
     before_action(:exit_signup_if_steps_complete, only: %i[

--- a/app/controllers/newflow/login_controller.rb
+++ b/app/controllers/newflow/login_controller.rb
@@ -8,10 +8,11 @@ module Newflow
 
     fine_print_skip :general_terms_of_use, :privacy_policy, except: :profile_newflow
 
-    before_action :redirect_to_signup_if_go_param_present, only: :login_form
-    before_action :known_signup_role_redirect, only: :login_form
+    before_action :cache_redirect_uri_if_tutor, only: :login_form
     before_action :cache_client_app, only: :login_form
+    before_action :known_signup_role_redirect, only: :login_form
     before_action :cache_alternate_signup_url, only: :login_form
+    before_action :redirect_to_signup_if_go_param_present, only: :login_form
     before_action :redirect_back, if: -> { signed_in? }, only: :login_form
 
     def login

--- a/app/controllers/newflow/login_controller.rb
+++ b/app/controllers/newflow/login_controller.rb
@@ -67,11 +67,6 @@ module Newflow
       params[:go]&.strip&.downcase == GO_TO_SIGNUP && (Settings::FeatureFlags.any_newflow_feature_flags?)
     end
 
-    # save (in the seession) or clear the client_app that sent the user here
-    def cache_client_app
-      set_client_app(params[:client_id])
-    end
-
     # Save (in the session) or clear the URL that the "Sign up" button in the FE points to.
     # -- Tutor uses this to send students who want to sign up, back to Tutor which
     # has a message for students just letting them know how to sign up (they must receive an email invitation).

--- a/app/controllers/newflow/signup_controller.rb
+++ b/app/controllers/newflow/signup_controller.rb
@@ -38,20 +38,11 @@ module Newflow
 
     protected ###############
 
+    # Redirect user to redirect uri, stored by `cache_redirect_uri_if_tutor`, if user is a Tutor user
     def skip_signup_done_for_tutor_users
       return if !current_user.is_tutor_user?
 
-      if (redirect_uri = extract_params(stored_url)[:redirect_uri])
-        redirect_to(redirect_uri)
-      elsif get_client_app.present?
-        redirect_to(get_client_app.redirect_uri.lines.first.chomp)
-      elsif (redirect_param = extract_params(request.referrer)[:r])
-        if Host.trusted?(redirect_param)
-          redirect_to(redirect_param)
-        else
-          raise Lev::SecurityTransgression
-        end
-      end
+      redirect_back(fallback_location: signup_done_path)
     end
 
     def exit_newflow_signup_if_logged_in

--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -1,13 +1,15 @@
 module Newflow
   class StudentSignupController < SignupController
 
-    before_action :restart_signup_if_missing_unverified_user, only: %i[
-      student_change_signup_email_form
-      student_change_signup_email
-      student_email_verification_form
-      student_email_verification_form_updated_email
-      student_verify_email_by_pin
-    ]
+    before_action(:restart_signup_if_missing_unverified_user, only: %i[
+        student_change_signup_email_form
+        student_change_signup_email
+        student_email_verification_form
+        student_email_verification_form_updated_email
+        student_verify_email_by_pin
+      ]
+    )
+    before_action(:cache_client_app, only: :student_signup_form)
 
     def student_signup
       handle_with(
@@ -65,12 +67,7 @@ module Newflow
           user = @handler_result.outputs.user
           sign_in!(user)
           security_log(:student_verified_email)
-
-          if user.is_tutor_user?
-            redirect_back(fallback_location: profile_newflow_path)
-          else
-            redirect_to(signup_done_path)
-          end
+          redirect_to(signup_done_path)
         },
         failure: lambda {
           @first_name = unverified_user.first_name

--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -9,7 +9,7 @@ module Newflow
         student_verify_email_by_pin
       ]
     )
-    before_action(:cache_client_app, only: :student_signup_form)
+    before_action(:cache_redirect_uri_if_tutor, only: :student_signup_form)
 
     def student_signup
       handle_with(

--- a/app/helpers/newflow/login_signup_helper.rb
+++ b/app/helpers/newflow/login_signup_helper.rb
@@ -35,5 +35,18 @@ module Newflow
       end
     end
 
+    def cache_redirect_uri_if_tutor
+      uri = params[:redirect_uri]
+      app_id = params[:client_id]
+
+      return if app_id.blank? || uri.blank?
+
+      client_app = Doorkeeper::Application.find_by(uid: app_id)
+
+      if client_app&.name&.downcase&.include?('tutor') && client_app&.is_redirect_url?(URI.decode(uri))
+        store_url(url: uri)
+      end
+    end
+
   end
 end

--- a/app/helpers/newflow/login_signup_helper.rb
+++ b/app/helpers/newflow/login_signup_helper.rb
@@ -1,6 +1,11 @@
 module Newflow
   module LoginSignupHelper
 
+    # save (in the seession) or clear the client_app that sent the user here
+    def cache_client_app
+      set_client_app(params[:client_id])
+    end
+
     def should_show_school_name_field?
       params[:school].present? || current_user&.is_sheerid_unviable? || current_user&.rejected_faculty?
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,7 @@ class User < ActiveRecord::Base
   end
 
   def is_tutor_user?
-    self.applications.where('name ilike ?', '%tutor%').any?
+    source_application&.name&.downcase&.include?('tutor')
   end
 
   def self.username_is_valid?(username)

--- a/spec/features/newflow/require_recent_sign_in_to_change_authentications_spec.rb
+++ b/spec/features/newflow/require_recent_sign_in_to_change_authentications_spec.rb
@@ -92,6 +92,8 @@ feature 'Require recent log in to change authentications', js: true do
 
       expect_reauthenticate_form_page
       fill_in(t(:"login_signup_form.password_label"), with: 'wrongpassword')
+      wait_for_ajax
+      wait_for_animations
       find('[type=submit]').click
       screenshot!
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe User, type: :model do
   describe '#is_tutor_user?' do
     context 'when the app name includes tutor in the name' do
       subject(:user) do
-        FactoryBot.create(:application_user, application: tutor_app).user
+        FactoryBot.create(:user, source_application: tutor_app)
       end
 
       let(:tutor_app) do
@@ -563,7 +563,7 @@ RSpec.describe User, type: :model do
 
     context 'when the app name does not include tutor in the name' do
       subject(:user) do
-        FactoryBot.create(:application_user, application: tutor_app).user
+        FactoryBot.create(:user, source_application: tutor_app)
       end
 
       let(:tutor_app) do


### PR DESCRIPTION
When determining whether a user is a Tutor user or not, look instead in the user's `source_application` not the user's `applications`. Also, simply cache the `redirect_uri` from the source app instead of getting it from the cached client app.