### PR TITLE
Fix tutor redirect back

### DIFF
--- a/app/controllers/newflow/educator_signup_controller.rb
+++ b/app/controllers/newflow/educator_signup_controller.rb
@@ -24,7 +24,6 @@ module Newflow
         educator_cs_verification_request
       ]
     )
-    before_action(:cache_redirect_uri_if_tutor, only: :educator_signup_form)
     before_action(:store_if_sheerid_is_unviable_for_user, only: :educator_profile_form)
     before_action(:store_sheerid_verification_for_user, only: :educator_profile_form)
     before_action(:exit_signup_if_steps_complete, only: %i[

--- a/app/controllers/newflow/login_controller.rb
+++ b/app/controllers/newflow/login_controller.rb
@@ -8,7 +8,6 @@ module Newflow
 
     fine_print_skip :general_terms_of_use, :privacy_policy, except: :profile_newflow
 
-    before_action :cache_redirect_uri_if_tutor, only: :login_form
     before_action :cache_client_app, only: :login_form
     before_action :known_signup_role_redirect, only: :login_form
     before_action :cache_alternate_signup_url, only: :login_form

--- a/app/controllers/newflow/signup_controller.rb
+++ b/app/controllers/newflow/signup_controller.rb
@@ -38,7 +38,6 @@ module Newflow
 
     protected ###############
 
-    # Redirect user to redirect uri, stored by `cache_redirect_uri_if_tutor`, if user is a Tutor user
     def skip_signup_done_for_tutor_users
       return if !current_user.is_tutor_user?
 

--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -9,7 +9,6 @@ module Newflow
         student_verify_email_by_pin
       ]
     )
-    before_action(:cache_redirect_uri_if_tutor, only: :student_signup_form)
 
     def student_signup
       handle_with(

--- a/app/helpers/newflow/login_signup_helper.rb
+++ b/app/helpers/newflow/login_signup_helper.rb
@@ -35,18 +35,5 @@ module Newflow
       end
     end
 
-    def cache_redirect_uri_if_tutor
-      uri = params[:redirect_uri]
-      app_id = params[:client_id]
-
-      return if app_id.blank? || uri.blank?
-
-      client_app = Doorkeeper::Application.find_by(uid: app_id)
-
-      if client_app&.name&.downcase&.include?('tutor') && client_app&.is_redirect_url?(URI.decode(uri))
-        store_url(url: uri)
-      end
-    end
-
   end
 end


### PR DESCRIPTION
Fixes a problem: when we redirect to Tutor, the user is not logged in until the user clicks on Login again. That is because I was redirecting to the callback `uri`. Instead, I should redirect to the complete "oauth authorize url".

In other words, there was actually no need to cache the uri. We can just redirect back to the authorize url.