### PR TITLE
Add confirmation pin and code to user admin view

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -40,6 +40,13 @@
       <% if email.verified %>
         (Confirmed)
       <% else %>
+        <br>
+        Confirmation PIN: <%= email.confirmation_pin %>
+        <br>
+        Confirmation URL: <%= verify_email_by_code_url(email.confirmation_code) %>
+        <br>
+        OR
+        <br>
         <%= link_to 'Mark this email address as confirmed', admin_verify_contact_info_path(email),
                     remote: true, method: :post,
                     class: 'btn btn-default btn-xs verify-email',


### PR DESCRIPTION
Our Customer Service team requested this feature: show the users' PIN so that they can give it to the user when the user is not receiving the confirmation email in their inbox and decide to reach out to CS. 

Most importantly, I also show the user's confirmation URL.

## What it looks like:

![Screen Shot 2020-10-02 at 11 51 27 AM](https://user-images.githubusercontent.com/6620941/94951482-f7e69500-04a9-11eb-87d4-cb4a0531f6c7.png)
