### PR TITLE
Narrow list to only unverified Contacts in Signup States view

### DIFF
--- a/app/controllers/admin/pre_auth_states_controller.rb
+++ b/app/controllers/admin/pre_auth_states_controller.rb
@@ -10,9 +10,10 @@ module Admin
         @unverified_contacts = ContactInfo.where(verified: 'false')
       else
         since = (params[:since] || 1).to_i
-        @pre_auth_states = PreAuthState.where.has{ |t| t.created_at > since.days.ago}
-        @unverified_contacts = ContactInfo.where.has{ |t| t.created_at > since.days.ago}
+        @pre_auth_states = PreAuthState.where.has { |t| t.created_at > since.days.ago }
+        @unverified_contacts = ContactInfo.where.has { |t| (t.verified == false) & (t.created_at > since.days.ago) }
       end
+
       @pre_auth_states = @pre_auth_states.order(created_at: :desc)
       @unverified_contacts = @unverified_contacts.order(created_at: :desc)
     end


### PR DESCRIPTION
Fixes the query for the "Signup States" admin view which is supposed to show only users' email addresses that have not verified their email address. Previously, it was showing ALL email address created in the last [X number of] days.