### PR TITLE
Track device ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ruby:2.6.3
 
-# Options: vscode, byebug
-ARG DEBUGGER=vscode
-
 WORKDIR /code
 
 COPY Gemfile Gemfile.lock ./
@@ -12,8 +9,7 @@ ENV BUNDLE_PATH="/bundle_cache"\
         BUNDLE_APP_CONFIG="/bundle_cache"\
         GEM_HOME="/bundle_cache"\
         PATH=/bundle_cache/bin:/bundle_cache/gems/bin:$PATH\
-        PORT=2999\
-        DEBUGGER=${DEBUGGER}
+        PORT=2999
 
 RUN gem install bundler:2.1.4 && \
     bundle config set path '/bundle_cache' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.6.3
 
+# Options: vscode, byebug
+ARG DEBUGGER=vscode
+
 WORKDIR /code
 
 COPY Gemfile Gemfile.lock ./
@@ -9,10 +12,13 @@ ENV BUNDLE_PATH="/bundle_cache"\
         BUNDLE_APP_CONFIG="/bundle_cache"\
         GEM_HOME="/bundle_cache"\
         PATH=/bundle_cache/bin:/bundle_cache/gems/bin:$PATH\
-        PORT=2999
+        PORT=2999\
+        DEBUGGER=${DEBUGGER}
 
-RUN gem install bundler:2.0.2 \
-        && bundle _2.0.2_ install --without production --path /bundle_cache
+RUN gem install bundler:2.1.4 && \
+    bundle config set path '/bundle_cache' && \
+    bundle config set without 'production' && \
+    bundle _2.1.4_ install
 
 EXPOSE 2999
 

--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,9 @@ gem 'oj', '~> 3.7.12'
 gem 'oj_mimic_json'
 
 group :development, :test do
+  # See updates in development to reload rails
+  gem 'listen'
+
   # Get env variables from .env file
   gem 'dotenv-rails', '2.7.2'
 
@@ -170,12 +173,14 @@ group :development, :test do
   # Development server
   gem 'puma', '~> 3.12'
 
-  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-
-  # Debug in VS Code
-  gem 'ruby-debug-ide'
-  gem 'debase'
+  if ENV['DEBUGGER'] == 'byebug'
+    # Call 'debugger' anywhere in the code to stop execution and get a debugger console
+    gem 'byebug'
+  else
+    # Debug in VS Code
+    gem 'ruby-debug-ide'
+    gem 'debase'
+  end
 
   # Use RSpec for tests
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile
+++ b/Gemfile
@@ -173,14 +173,13 @@ group :development, :test do
   # Development server
   gem 'puma', '~> 3.12'
 
-  if ENV['DEBUGGER'] == 'byebug'
-    # Call 'debugger' anywhere in the code to stop execution and get a debugger console
-    gem 'byebug'
-  else
-    # Debug in VS Code
-    gem 'ruby-debug-ide'
-    gem 'debase'
-  end
+  # See config/initializers/04-debugger.rb
+  #
+  # Call 'debugger' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', require: false
+  # Debug in VS Code
+  gem 'ruby-debug-ide', require: false
+  gem 'debase', require: false
 
   # Use RSpec for tests
   gem 'rspec-rails', '~> 3.8'
@@ -241,10 +240,11 @@ group :test do
 
   gem 'db-query-matchers'
 
-# Run feature tests with Capybara + Selenium
+  # Run feature tests with Capybara + Selenium; choose which driver gems to use
+  # based on test environment.
   gem 'capybara'
-  gem 'selenium-webdriver', '>= 3.141.0'
-  gem 'webdrivers', '~> 4.0'
+  gem 'selenium-webdriver', '>= 3.141.0', require: false
+  gem 'webdrivers', '~> 4.0', require: false
 
   # Testing emails
   gem 'capybara-email'

--- a/Gemfile
+++ b/Gemfile
@@ -158,9 +158,6 @@ gem 'oj', '~> 3.7.12'
 gem 'oj_mimic_json'
 
 group :development, :test do
-  # See updates in development to reload rails
-  gem 'listen'
-
   # Get env variables from .env file
   gem 'dotenv-rails', '2.7.2'
 
@@ -219,6 +216,9 @@ group :development, :test do
 end
 
 group :development do
+  # See updates in development to reload rails
+  gem 'listen'
+
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 3.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,6 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.4)
-    byebug (9.0.6)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -178,7 +177,7 @@ GEM
     db-query-matchers (0.6.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.5)
+    debase-ruby_core_source (0.10.11)
     declarative (0.0.10)
     declarative-option (0.1.0)
     delayed_job (4.1.7)
@@ -573,7 +572,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-rspec (1.36.0)
       rubocop (>= 0.68.1)
-    ruby-debug-ide (0.7.0)
+    ruby-debug-ide (0.7.2)
       rake (>= 0.8.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.10.1)
@@ -682,7 +681,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   bootstrap-sass (~> 3.4.1)
-  byebug
   capybara
   capybara-email
   capybara-screenshot
@@ -717,6 +715,7 @@ DEPENDENCIES
   knockoutjs-rails
   launchy
   lev (~> 9.0.3)
+  listen
   lograge
   maruku
   meta_request

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -681,6 +682,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   bootstrap-sass (~> 3.4.1)
+  byebug
   capybara
   capybara-email
   capybara-screenshot

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ Accounts can be run as a normal Rails app on your machine or in a Docker contain
 ```bash
 # build the image
 $> docker-compose build
-# build the image selecting the byebug debugger; remember to rebuild without this before pushing
-# or run `DEBUGGER=vscode bundle install` so that the Gemfile.lock is in the default debugger config
-$> docker-compose build --build-arg DEBUGGER=byebug
 # run it; Accounts available at localhost:2999
 $> docker-compose up -d
 # run it allowing for debugging
@@ -112,6 +109,30 @@ and then start the `delayed_job` daemon:
 
 ## Running Specs (Automated Tests)
 
+Using Docker, you can
+
+```sh
+$> docker-compose run --rm app /bin/bash
+```
+
+to drop into a container with everything installed. Then before your first test run
+
+```sh
+$ /code> rake db:create
+$ /code> rake db:migrate # run again if add migrations later
+```
+
+Then to run tests...
+
+```sh
+$ /code> rspec
+$ /code> rspec ./spec/features
+$ /code> rspec ./spec/some/specific_spec.rb
+$ /code> rspec ./spec/some/specific_spec.rb:42 # the spec at line 42
+```
+
+Or if you want to install directly on your machine...
+
 Specs require phantomjs. On Mac:
 ```sh
 $ brew install phantomjs
@@ -130,6 +151,10 @@ $ RAISE=true rspec
 ```
 
 If you encounter issues running features specs, check the version of chromedriver you have installed.  Version 2.38 is known to work.
+
+## Debugging
+
+Set `DEBUGGER=byebug` to use byebug (e.g. in `.env`), otherwise defaults to the VS Code debugger.
 
 # Usage — topics
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,25 @@ The app behavior changes depending on the value of these parameters.
 
 ## Dev Environment Setup
 
-Accounts can be run as a normal Rails app on your machine, in a Docker container, or in a Vagrant virtual machine that mimics our production setup.
+Accounts can be run as a normal Rails app on your machine or in a Docker container.
 
-### Database setup
+### Docker
+
+```bash
+# build the image
+$> docker-compose build
+# build the image selecting the byebug debugger; remember to rebuild without this before pushing
+# or run `DEBUGGER=vscode bundle install` so that the Gemfile.lock is in the default debugger config
+$> docker-compose build --build-arg DEBUGGER=byebug
+# run it; Accounts available at localhost:2999
+$> docker-compose up -d
+# run it allowing for debugging
+$> docker-compose up -d && docker attach accounts_app_1
+```
+
+### Directly on your machine
+
+#### Database setup
 
 If you don't have postgresql already installed, on Mac:
 
@@ -53,7 +69,7 @@ ALTER USER ox_accounts WITH SUPERUSER;
 \q
 ```
 
-### Running as a normal Rails app on your machine
+#### Running as a normal Rails app on your machine
 
 First, ensure you have a Ruby version manager installed, such as [rbenv](https://github.com/rbenv/rbenv#installation) or RVM to manage your ruby versions. Then, install the Ruby version specified in the `.ruby-version` file (2.3.3 at the time of this writing, or above).
 
@@ -83,7 +99,7 @@ $ rails server
 
 which will start Accounts up on port 2999. Visit http://localhost:2999.
 
-### Running background jobs
+#### Running background jobs
 
 Accounts in production runs background jobs using `delayed_job`.
 In the development environment, however, background jobs are run "inline", i.e. in the foreground.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -30,5 +30,7 @@ PAGE_TITLE_SUFFIX = SITE_NAME
 TEAM_NAME = 'OpenStax' # used when talking about our team
 COPYRIGHT_HOLDER = 'Rice University'
 
+UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
 # Initialize the Rails application
 Rails.application.initialize!

--- a/config/initializers/04-debugger.rb
+++ b/config/initializers/04-debugger.rb
@@ -1,0 +1,11 @@
+unless Rails.env.production?
+  # Let environment variables dictate which debugger to use; they are not compatible
+  if ENV['DEBUGGER'] == 'byebug'
+    # Call 'debugger' anywhere in the code to stop execution and get a debugger console
+    require 'byebug'
+  else
+    # Debug in VS Code
+    require 'ruby-debug-ide'
+    require 'debase'
+  end
+end

--- a/config/initializers/controllers.rb
+++ b/config/initializers/controllers.rb
@@ -20,8 +20,6 @@ ActionController::Base.class_exec do
 
   fine_print_require :general_terms_of_use, :privacy_policy, unless: :disable_fine_print
 
-  UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-
   protected
 
   def complete_signup_profile
@@ -74,19 +72,21 @@ ActionController::Base.class_exec do
   end
 
   def set_device_id
-    cookies.delete(:oxdid) if cookies[:oxdid] && !(cookies[:oxdid] =~ UUID_REGEX)
+    cookies.delete(:oxdid) if device_id_invalid?
 
-    if cookies[:oxdid].nil?
-      cookies[:oxdid] = {
-        value: SecureRandom.uuid,
-        expires: 20.years.from_now,
-        domain: :all,
-        secure: Rails.env.production?
-      }
-    end
+    cookies[:oxdid] ||= {
+      value: SecureRandom.uuid,
+      expires: 20.years.from_now,
+      domain: :all,
+      secure: Rails.env.production?
+    }
   end
 
   def get_device_id
     cookies[:oxdid]
+  end
+
+  def device_id_invalid?
+    cookies[:oxdid] && !(cookies[:oxdid] =~ UUID_REGEX)
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,11 @@ services:
     depends_on:
       - postgres
       - bundler
+      - chrome
     environment:
       - OXA_DB_HOST=postgres
       - GEM_HOME=/bundle_cache
+      - HUB_URL=http://chrome:4444/wd/hub
   postgres:
     image: "postgres:9.5"
     volumes:
@@ -37,6 +39,15 @@ services:
     image: busybox
     volumes:
       - bundle_cache:/bundle_cache
+  chrome:
+    # this version should match that of the selenium-webdriver gem (see Gemfile)
+    image: selenium/standalone-chrome:3.141.59-zirconium
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - openstax
+    ports:
+      - "4444:4444"
 networks:
   openstax:
     name: openstax

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     image: accounts
     ports:
       - "2999:2999"
+    command: bash -c "rm -f tmp/pids/server.pid && rake about && rake db:migrate && bin/rails server -b '0.0.0.0' -p 2999"
+    stdin_open: true  # allow for debugger
+    tty: true         # interaction
     volumes:
       - .:/code
       - /code/tmp/pids

--- a/lib/host.rb
+++ b/lib/host.rb
@@ -1,6 +1,6 @@
 module Host
-  TRUSTED_HOST_REGEXES = Rails.application.secrets.trusted_hosts.map do |host|
-    /\A(.*\.)?#{host.gsub('.', '\.')}\z/
+  def self.trusted_hosts
+    Rails.application.secrets.trusted_hosts
   end
 
   def self.trusted?(url)
@@ -8,6 +8,10 @@ module Host
 
     return true if not uri.host and url.chr == '/'
 
-    TRUSTED_HOST_REGEXES.any? { |regex| regex.match uri.host }
+    trusted_host_regexes = trusted_hosts.map do |host|
+      /\A(.*\.)?#{host.gsub('.', '\.')}\z/
+    end
+
+    trusted_host_regexes.any? { |regex| regex.match uri.host }
   end
 end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -38,6 +38,7 @@ feature 'Admin user pages', js: true do
         it 'searches users and does not explode' do
           visit '/'
           click_link 'Popup Console'
+          wait_for_ajax(10) # for some reason this is slow
           click_link 'Users'
           click_button 'Search'
 

--- a/spec/requests/api/v1/device_id_spec.rb
+++ b/spec/requests/api/v1/device_id_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'device ID tracking',
+               type: :request, api: true, version: :v1 do
+
+  let!(:user) do
+    FactoryBot.create :user_with_emails,
+                       first_name: 'Bob',
+                       last_name: 'Michaels'
+  end
+
+  let!(:user_token) do
+    FactoryBot.create :doorkeeper_access_token,
+                       application: FactoryBot.create(:doorkeeper_application),
+                       resource_owner_id: user.id
+  end
+
+  context "not logged in" do
+    it "sets the device ID cookie" do
+      api_get "/api/user"
+      expect(response.cookies["oxdid"]).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    end
+
+    it "does not change" do
+      original = cookies["oxdid"] = SecureRandom.uuid
+      api_get "/api/user"
+      expect(response.cookies["oxdid"]).to eq nil # because it isn't being changed (set)
+    end
+
+    it "gets fixed if messed up" do
+      cookies["oxdid"] = "foo"
+      api_get "/api/user"
+      expect(response.cookies["oxdid"]).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    end
+  end
+
+  context "logged in" do
+    it "sets the device ID cookie" do
+      api_get "/api/user", user_token
+      expect(response.cookies["oxdid"]).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -308,3 +308,11 @@ def options(*args)
     copy_session_variables!
   end
 end
+
+def in_travis?
+  ENV['CI']
+end
+
+def in_docker?
+  ENV['HUB_URL'].present?
+end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -39,10 +39,18 @@ VCR.configure do |c|
   c.configure_rspec_metadata!
   c.allow_http_connections_when_no_cassette = false
   c.ignore_localhost = true
-  # To avoid issues with the gem `webdrivers`, we must ignore the driver hosts
-  # See https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
-  driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
-  c.ignore_hosts(*driver_hosts)
+
+  if in_docker?
+    # Within docker, localhost can be different so add it here explicitly; also add
+    # 'chrome' for selenium via docker
+    c.ignore_hosts(IPSocket.getaddress(Socket.gethostname), "chrome")
+  else
+    require 'webdrivers'
+    # To avoid issues with the gem `webdrivers`, we must ignore the driver hosts
+    # See https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
+    driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
+    c.ignore_hosts(*driver_hosts)
+  end
 
   %w(
     instance_url


### PR DESCRIPTION
Track a device ID for anonymous users so that we can save some temporary state for them.

* Sets a device ID cookie ("oxdid")
* The cookie is not encrypted because if a user messes with it, that is like us giving them a new one (we expect they may change over time).
* The cookie is accessible to Javascript (not sensitive)

Also fixed some other things:
* Added the `listen` gem so that changes in the source are reflected without restarting the rails server (in development).
* Fixed up the docker compose file and added Docker instructions to the readme.  
* Added a way to choose to which kind of debugging gems to install.  byebug is not compatible with the VS Code options, and trying to use it when both options are installed leads to segmentation faults.  