### PR TITLE
Block creation or update of emails that create any duplicates

### DIFF
--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -8,9 +8,7 @@ class ContactInfo < ActiveRecord::Base
   validates :type, presence: true
   validates :value,
             presence: true,
-            uniqueness: {scope: [:user_id, :type], case_sensitive: false}
-
-  validate :check_for_verified_collision
+            uniqueness: { scope: :type, case_sensitive: false }
 
   belongs_to :user, inverse_of: :contact_infos
 
@@ -69,17 +67,5 @@ class ContactInfo < ActiveRecord::Base
       errors.add(:user, :last_verified)
       throw(:abort)
     end
-  end
-
-  def check_for_verified_collision
-    errors.add(:value, :already_confirmed) \
-      if value.present? &&
-         verified? &&
-         ContactInfo.verified
-                    .where('lower(value) = ?', value.downcase)
-                    .where.not(id: id)
-                    .any?
-
-    errors.none?
   end
 end

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -30,21 +30,10 @@ feature 'Confirm email address', js: true do
   end
 
   context 'when another user has the email' do
-    scenario 'fails when the other email is verified' do
-      create_email_address_for(create_user('other_user'), 'user@example.com')
-      visit '/confirm?code=1111'
-      expect(page).to have_no_missing_translations
-      expect(page).to have_content(t :"contact_infos.confirm.page_heading.error")
-      expect(page).to have_content(t :"contact_infos.confirm.email_already_in_use")
-    end
-
-    scenario 'succeeds when the other email is UNverified' do
-      create_email_address_for(create_user('other_user'), 'user@example.com', '98988')
-      visit '/confirm?code=1111'
-      expect(page).to have_no_missing_translations
-      expect(page).to have_content(t :"contact_infos.confirm.page_heading.success")
-      expect(page).to have_content(t :"contact_infos.confirm.you_may_now_close_this_window")
+    scenario 'cannot create duplicate email' do
+      expect {
+        create_email_address_for(create_user('other_user'), 'user@example.com', '989188')
+      }.to raise_error(ActiveRecord::RecordInvalid, /already been taken/)
     end
   end
-
 end

--- a/spec/features/newflow/confirm_email_spec.rb
+++ b/spec/features/newflow/confirm_email_spec.rb
@@ -34,21 +34,10 @@ feature 'Confirm email address', js: true do
   end
 
   context 'when another user has the email' do
-    scenario 'fails when the other email is verified' do
-      create_email_address_for(create_user('other_user'), 'user@example.com')
-      visit '/confirm?code=1111'
-      expect(page).to have_no_missing_translations
-      expect(page).to have_content(t :"contact_infos.confirm.page_heading.error")
-      expect(page).to have_content(t :"contact_infos.confirm.email_already_in_use")
-    end
-
-    scenario 'succeeds when the other email is UNverified' do
-      create_email_address_for(create_user('other_user'), 'user@example.com', '98988')
-      visit '/confirm?code=1111'
-      expect(page).to have_no_missing_translations
-      expect(page).to have_content(t :"contact_infos.confirm.page_heading.success")
-      expect(page).to have_content(t :"contact_infos.confirm.you_may_now_close_this_window")
+    scenario 'cannot create duplicate email' do
+      expect {
+        create_email_address_for(create_user('other_user'), 'user@example.com', '989188')
+      }.to raise_error(ActiveRecord::RecordInvalid, /already been taken/)
     end
   end
-
 end

--- a/spec/features/user_profile_management/add_social_auth_spec.rb
+++ b/spec/features/user_profile_management/add_social_auth_spec.rb
@@ -59,8 +59,8 @@ feature 'Add social auth', js: true do
       find('.authentication[data-provider="facebook"] .add').click
       wait_for_ajax
       screenshot!
-      expect_profile_page
-      expect(page).to have_content('Facebook')
+      expect(page).to have_content('already been taken')
+      expect(page).not_to have_content('Facebook')
     end
   end
 

--- a/spec/handlers/newflow/oauth_callback_spec.rb
+++ b/spec/handlers/newflow/oauth_callback_spec.rb
@@ -180,13 +180,13 @@ module Newflow
       end
 
       context 'when the email address is already taken' do
-        before do
-          u = FactoryBot.create(:user)
-          FactoryBot.create(:email_address, user: u, value: oauth_user_info[:email], verified: true)
-        end
-
         it 'results in an error' do
-          expect(process_request).to have_routine_error(:email_already_in_use)
+          expect {
+            u = FactoryBot.create(:user)
+            FactoryBot.create(:email_address, user: u, value: oauth_user_info[:email], verified: true)
+            process_request
+            create_email_address_for(create_user('other_user'), 'user@example.com', '989188')
+          }.to raise_error(ActiveRecord::RecordInvalid, /already been taken/)
         end
       end
 

--- a/spec/lib/lookup_users_spec.rb
+++ b/spec/lib/lookup_users_spec.rb
@@ -8,22 +8,6 @@ describe LookupUsers, type: :lib do
       expect(described_class.by_verified_email_or_username(nil)).to eq []
     end
 
-    context 'when two of the same email with different case, both verified' do
-      before(:each) {
-        @email1 = FactoryBot.create(:email_address, value: 'bob@example.com', verified: true)
-        @email2 = FactoryBot.create(:email_address, value: 'bob@EXAMPLE.com')
-        # No longer allowed to have same address different case both verified, but used to be able
-        # to, so update `verified` without validations to simulate old data.
-        @email2.update_attribute(:verified, true)
-      }
-
-      it 'finds both email users when no case sensitive matches' do
-        expect(described_class.by_verified_email_or_username('BOB@example.com')).to contain_exactly(@email1.user, @email2.user)
-      end
-
-
-    end
-
     context '#by_verfied_email' do
       let!(:email) {
         FactoryBot.create(:email_address, value: 'bob@example.com', verified: true)
@@ -62,18 +46,4 @@ describe LookupUsers, type: :lib do
       expect(described_class.by_verified_email_or_username('bob')).to eq [@user]
     end
   end
-
-  context '#by_email_or_username' do
-    context 'when two of the same email one verified and one not' do
-      before(:each) {
-        @email1 = FactoryBot.create(:email_address, value: 'bob@example.com', verified: true)
-        @email2 = FactoryBot.create(:email_address, value: 'bob@EXAMPLE.com', verified: false)
-      }
-
-      it 'returns both users' do
-        expect(described_class.by_email_or_username('BOB@example.com')).to contain_exactly(@email1.user, @email2.user)
-      end
-    end
-  end
-
 end

--- a/spec/models/contact_info_spec.rb
+++ b/spec/models/contact_info_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
-describe ContactInfo do
+RSpec.describe ContactInfo, type: :model do
+  subject(:contact_info) { FactoryBot.create :email_address }
+
+  it { is_expected.to validate_presence_of(:value) }
+  it { is_expected.to validate_uniqueness_of(:value).scoped_to(:type).case_insensitive }
 
   context 'validation' do
     it 'strips values before validation' do
@@ -27,30 +31,14 @@ describe ContactInfo do
   end
 
   context 'verified user emails' do
-    let(:user1){ FactoryBot.create :user }
-    let(:user2){ FactoryBot.create :user }
+    let(:user1) { FactoryBot.create :user }
+    let(:user2) { FactoryBot.create :user }
 
-    let!(:email1) { FactoryBot.build(:email_address, user: user1,
-                                      verified: true, value: 'my1@email.com') }
-    let!(:email2) { FactoryBot.build(:email_address, user: user2,
-                                      verified: true, value: 'my2@email.com') }
-
-    it 'does not allow the same user to have a repeated email address regardless of verification and case' do
-      email1.save!
-      expect(email2).to be_valid
-      email2.user = email1.user
-      email2.value = email1.value.upcase
-      expect(email2).not_to be_valid
-      expect(email2).to have_error(:value, :taken)
-      email2.verified = false
-      expect(email2).not_to be_valid
-      expect(email2).to have_error(:value, :taken)
+    let!(:email1) do
+      FactoryBot.build :email_address, user: user1, verified: true, value: 'my1@email.com'
     end
-
-    it 'does not allow two users to have the same verified email with different case' do
-      email1.save!
-      email2.value = email1.value.upcase
-      expect(email2).not_to be_valid
+    let!(:email2) do
+      FactoryBot.build :email_address, user: user2, verified: true, value: 'my2@email.com'
     end
 
     it 'does not allow removing the last verified email address' do
@@ -59,55 +47,34 @@ describe ContactInfo do
       email2.save!
       email1.save!
       email1.destroy
-      expect(email1.destroyed?).to be true
+      expect(email1.destroyed?).to eq true
       email2.destroy
-      expect(email2.destroyed?).to be false
+      expect(email2.destroyed?).to eq false
       expect(email2).to have_error(:user, :last_verified)
     end
 
     context 'when altering email value' do
-      before(:each){
+      before(:each) do
         email1.save
         email2.save
-      }
-
-      it 'does allow a user to add an already used verified email but not to verify it' do
-        email1.verified = true
-        email1.save
-        newemail = user2.email_addresses.build value: email1.value
-        expect(newemail.save).to be true
-        newemail.verified = true
-        expect(newemail.save).to be false
-        expect(newemail).to have_error(:value, :already_confirmed)
       end
 
-      it 'does allow a user to add an already used unverified email and to verify it' do
+      it 'does not allow a user to add an already used email' do
         email1.verified = false
         email1.save
         newemail = user2.email_addresses.build value: email1.value
-        expect(newemail.save).to be true
-        newemail.verified = true
-        expect(newemail.save).to be true
-        expect(newemail.errors).to be_empty
+        expect(newemail.valid?).to eq false
+        expect(newemail).to have_error(:value, :taken)
       end
 
-      it 'does not allow a user to update their email to be a duplicate of a verified email' do
-        email1.save!
-        email2.save!
-        email1.value = email2.value
-        expect(email1.save).to be false
-        expect(email1).to have_error(:value, :already_confirmed)
-      end
-
-      it 'does allow a user to update their email to be a dupe of an unverified email' do
+      it 'does not allow a user to update their email to be a duplicate of another email' do
         email1.save!
         email2.verified = false
         email2.save!
         email1.value = email2.value
-        expect(email1.save).to be true
-        expect(email1.errors).to be_empty
+        expect(email1.valid?).to eq false
+        expect(email1).to have_error(:value, :taken)
       end
     end
   end
-
 end


### PR DESCRIPTION
Completely blocks adding emails that have been used to an account, even if they have not been verified.

After releasing this, we can probably clean up the data and add a unique index in a follow up release.