### PR TITLE
change name validations to allow foreign names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -422,8 +422,8 @@ class User < ActiveRecord::Base
 
   def remove_special_chars
     if first_name && last_name
-      first_name.parameterize(preserve_case: true)
-      last_name.parameterize(preserve_case: true)
+      first_name.gsub(/[^\p{L}\s]/,'')
+      last_name.gsub(/[^\p{L}\s]/,'')
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -422,8 +422,8 @@ class User < ActiveRecord::Base
 
   def remove_special_chars
     if first_name && last_name
-      first_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
-      last_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
+      first_name.parameterize(preserve_case: true)
+      last_name.parameterize(preserve_case: true)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,6 +75,7 @@ class User < ActiveRecord::Base
   )
 
   before_validation(:strip_fields)
+  before_validation(:remove_special_chars)
 
   before_validation(
     :generate_uuid, :generate_support_identifier,
@@ -417,6 +418,13 @@ class User < ActiveRecord::Base
     self.username = nil if username.blank?
     self_reported_school.try(:strip!)
     true
+  end
+
+  def remove_special_chars
+    if first_name && last_name
+      first_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
+      last_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
+    end
   end
 
   # there are existing users without names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,8 +75,6 @@ class User < ActiveRecord::Base
   )
 
   before_validation(:strip_fields)
-  before_validation(:convert_accents)
-  before_validation(:remove_special_chars)
 
   before_validation(
     :generate_uuid, :generate_support_identifier,
@@ -419,20 +417,6 @@ class User < ActiveRecord::Base
     self.username = nil if username.blank?
     self_reported_school.try(:strip!)
     true
-  end
-
-  def convert_accents
-    if first_name && last_name
-      self.first_name=I18n.transliterate(first_name)
-      self.last_name=I18n.transliterate(last_name)
-    end
-  end
-
-  def remove_special_chars
-    if first_name && last_name
-      first_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
-      last_name.gsub!(/[^0-9A-Za-z.'\- ]/, '')
-    end
   end
 
   # there are existing users without names

--- a/app/routines/newflow/create_salesforce_lead.rb
+++ b/app/routines/newflow/create_salesforce_lead.rb
@@ -14,38 +14,40 @@ module Newflow
 
       referring_app_name = user&.source_application&.lead_application_source || DEFAULT_REFERRING_APP_NAME
 
-      lead = OpenStax::Salesforce::Remote::Lead.new(
-        first_name: user.first_name,
-        last_name: user.last_name,
-        phone: user.phone_number,
-        email: user.best_email_address_for_CS_verification,
-        source: SALESFORCE_INSTRUCTOR_ROLE,
-        application_source: referring_app_name,
-        role: user.role,
-        other_role_name: user.other_role_name,
-        who_chooses_books: user.who_chooses_books,
-        subject: user.which_books,
-        num_students: user.how_many_students,
-        os_accounts_id: user.id,
-        accounts_uuid: user.uuid,
-        school: user.most_accurate_school_name,
-        verification_status: user.faculty_status == User::NO_FACULTY_INFO ? nil : user.faculty_status,
-        finalize_educator_signup: user.is_profile_complete?,
-        needs_cs_review: user.is_educator_pending_cs_verification?,
-        b_r_i_marketing: user.is_b_r_i_user?,
-        title_1_school: user.title_1_school?,
-        newsletter: user.receive_newsletter?,
-        newsletter_opt_in: user.receive_newsletter?,
-      )
+      if Settings::Salesforce.push_leads_enabled
+        lead = OpenStax::Salesforce::Remote::Lead.new(
+          first_name: user.first_name,
+          last_name: user.last_name,
+          phone: user.phone_number,
+          email: user.best_email_address_for_CS_verification,
+          source: SALESFORCE_INSTRUCTOR_ROLE,
+          application_source: referring_app_name,
+          role: user.role,
+          other_role_name: user.other_role_name,
+          who_chooses_books: user.who_chooses_books,
+          subject: user.which_books,
+          num_students: user.how_many_students,
+          os_accounts_id: user.id,
+          accounts_uuid: user.uuid,
+          school: user.most_accurate_school_name,
+          verification_status: user.faculty_status == User::NO_FACULTY_INFO ? nil : user.faculty_status,
+          finalize_educator_signup: user.is_profile_complete?,
+          needs_cs_review: user.is_educator_pending_cs_verification?,
+          b_r_i_marketing: user.is_b_r_i_user?,
+          title_1_school: user.title_1_school?,
+          newsletter: user.receive_newsletter?,
+          newsletter_opt_in: user.receive_newsletter?,
+        )
 
-      outputs.lead = lead
-      outputs.user = user
+        outputs.lead = lead
+        outputs.user = user
 
-      if lead.save
-        store_salesforce_lead_id(user, lead.id) && log_success(lead, user)
-        transfer_errors_from(user, {type: :verbatim}, :fail_if_errors)
-      else
-        handle_lead_errors(lead, user)
+        if lead.save
+          store_salesforce_lead_id(user, lead.id) && log_success(lead, user)
+          transfer_errors_from(user, {type: :verbatim}, :fail_if_errors)
+        else
+          handle_lead_errors(lead, user)
+        end
       end
     end
 

--- a/app/routines/newflow/create_salesforce_lead.rb
+++ b/app/routines/newflow/create_salesforce_lead.rb
@@ -14,40 +14,38 @@ module Newflow
 
       referring_app_name = user&.source_application&.lead_application_source || DEFAULT_REFERRING_APP_NAME
 
-      if Settings::Salesforce.push_leads_enabled
-        lead = OpenStax::Salesforce::Remote::Lead.new(
-          first_name: user.first_name,
-          last_name: user.last_name,
-          phone: user.phone_number,
-          email: user.best_email_address_for_CS_verification,
-          source: SALESFORCE_INSTRUCTOR_ROLE,
-          application_source: referring_app_name,
-          role: user.role,
-          other_role_name: user.other_role_name,
-          who_chooses_books: user.who_chooses_books,
-          subject: user.which_books,
-          num_students: user.how_many_students,
-          os_accounts_id: user.id,
-          accounts_uuid: user.uuid,
-          school: user.most_accurate_school_name,
-          verification_status: user.faculty_status == User::NO_FACULTY_INFO ? nil : user.faculty_status,
-          finalize_educator_signup: user.is_profile_complete?,
-          needs_cs_review: user.is_educator_pending_cs_verification?,
-          b_r_i_marketing: user.is_b_r_i_user?,
-          title_1_school: user.title_1_school?,
-          newsletter: user.receive_newsletter?,
-          newsletter_opt_in: user.receive_newsletter?,
-        )
+      lead = OpenStax::Salesforce::Remote::Lead.new(
+        first_name: user.first_name,
+        last_name: user.last_name,
+        phone: user.phone_number,
+        email: user.best_email_address_for_CS_verification,
+        source: SALESFORCE_INSTRUCTOR_ROLE,
+        application_source: referring_app_name,
+        role: user.role,
+        other_role_name: user.other_role_name,
+        who_chooses_books: user.who_chooses_books,
+        subject: user.which_books,
+        num_students: user.how_many_students,
+        os_accounts_id: user.id,
+        accounts_uuid: user.uuid,
+        school: user.most_accurate_school_name,
+        verification_status: user.faculty_status == User::NO_FACULTY_INFO ? nil : user.faculty_status,
+        finalize_educator_signup: user.is_profile_complete?,
+        needs_cs_review: user.is_educator_pending_cs_verification?,
+        b_r_i_marketing: user.is_b_r_i_user?,
+        title_1_school: user.title_1_school?,
+        newsletter: user.receive_newsletter?,
+        newsletter_opt_in: user.receive_newsletter?,
+      )
 
-        outputs.lead = lead
-        outputs.user = user
+      outputs.lead = lead
+      outputs.user = user
 
-        if lead.save
-          store_salesforce_lead_id(user, lead.id) && log_success(lead, user)
-          transfer_errors_from(user, {type: :verbatim}, :fail_if_errors)
-        else
-          handle_lead_errors(lead, user)
-        end
+      if lead.save
+        store_salesforce_lead_id(user, lead.id) && log_success(lead, user)
+        transfer_errors_from(user, {type: :verbatim}, :fail_if_errors)
+      else
+        handle_lead_errors(lead, user)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,12 +68,6 @@ RSpec.describe User, type: :model do
   end
 
   it 'removes certain unallowed special characters from first and last name' do
-    user = FactoryBot.create :user, first_name: "J(o)hn"
-    expect(user.first_name).to eq "John"
-
-    user = FactoryBot.create :user, last_name: "Smit&h"
-    expect(user.last_name).to eq "Smith"
-
     user = FactoryBot.create :user, last_name: "D'Amore"
     expect(user.last_name).to eq "D'Amore"
 
@@ -81,12 +75,18 @@ RSpec.describe User, type: :model do
     expect(user.first_name).to eq "Mary-Ann"
   end
 
-  it 'allows accented characters in first and last name' do
+  it 'allows accented and non-english characters in first and last name' do
     user = FactoryBot.create :user, last_name: "Maève"
-    expect(user.last_name).to eq "Maeve"
+    expect(user.last_name).to eq "Maève"
 
     user = FactoryBot.create :user, first_name: "Brièle"
-    expect(user.first_name).to eq "Briele"
+    expect(user.first_name).to eq "Brièle"
+
+    user = FactoryBot.create :user, first_name: "Адам"
+    expect(user.first_name).to eq "Адам"
+
+    user = FactoryBot.create :user, last_name: "Екатерина"
+    expect(user.last_name).to eq "Екатерина"
   end
 
   context 'full_name' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -81,12 +81,12 @@ RSpec.describe User, type: :model do
     expect(user.first_name).to eq "Mary-Ann"
   end
 
-  it 'transliterates accented characters to ascii in first and last name' do
+  it 'allows accented characters in first and last name' do
     user = FactoryBot.create :user, last_name: "Maève"
-    expect(user.last_name).to eq "Maeve"
+    expect(user.last_name).to eq "Maève"
 
     user = FactoryBot.create :user, first_name: "Brièle"
-    expect(user.first_name).to eq "Briele"
+    expect(user.first_name).to eq "Brièle"
   end
 
   context 'full_name' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe User, type: :model do
 
   it 'allows accented characters in first and last name' do
     user = FactoryBot.create :user, last_name: "Maève"
-    expect(user.last_name).to eq "Maève"
+    expect(user.last_name).to eq "Maeve"
 
     user = FactoryBot.create :user, first_name: "Brièle"
-    expect(user.first_name).to eq "Brièle"
+    expect(user.first_name).to eq "Briele"
   end
 
   context 'full_name' do


### PR DESCRIPTION
this needs some good testing with SheerID - change the gsubs to remove non-words and special characters. This was causing some users to signup with a blank first/last name