### PR TITLE
Handle schools that have been deleted from Salesforce

### DIFF
--- a/app/routines/update_user_salesforce_info.rb
+++ b/app/routines/update_user_salesforce_info.rb
@@ -302,9 +302,11 @@ class UpdateUserSalesforceInfo
       user.is_b_r_i_user = contact.b_r_i_marketing
     end
 
-    warn("User #{user.id} has a school that is in SF but not cached yet #{sf_school.id}") \
-      if school.nil? && !sf_school.nil?
-    user.school = school
+    if school.nil? && !sf_school.nil?
+      warn("User #{user.id} has a school that is in SF but not cached yet #{sf_school.id}")
+    else
+      user.school = school
+    end
 
     if user.faculty_status_changed? && user.confirmed_faculty?
       let_sf_know_to_send_fac_ver_email = true

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :school do
-    salesforce_id       { SecureRandom.urlsafe_base64 }
+    salesforce_id       { "0010v0#{SecureRandom.alphanumeric(9)}" }
     name                { Faker::Company.name }
     city                { Faker::Address.city }
     state               { [ Faker::Address.state, Faker::Address.state_abbr ].sample }


### PR DESCRIPTION
We check only schools with no users so we wait until users have been updated and moved to another school and don't leave the users without a school in-between.