### PR TITLE
create lead in background job

### DIFF
--- a/app/handlers/newflow/educator_signup/complete_profile.rb
+++ b/app/handlers/newflow/educator_signup/complete_profile.rb
@@ -76,7 +76,7 @@ module Newflow
       private #################
 
       def create_salesforce_lead
-        run(CreateSalesforceLead, user: user)
+        CreateSalesforceLead.perform_later(user: user)
       end
 
       def other_role_name


### PR DESCRIPTION
There was a long, blocking delay after the last step of signup due to the lead being created. This moves it to a background job.