### PR TITLE
Updated the JS engine to mini_racer, added darwin-20 (OS X) to the lockfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'compass-rails'
 gem 'coffee-rails', '5.0.0'
 
 # JavaScript asset compiler
-gem 'therubyracer', platforms: :ruby
+gem 'mini_racer'
 
 # JavaScript asset compressor
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,8 +378,9 @@ GEM
       hashie
       transaction_isolation
       transaction_retry
-    libv8 (3.16.14.19)
-    libv8 (3.16.14.19-x86_64-linux)
+    libv8-node (15.14.0.1)
+    libv8-node (15.14.0.1-x86_64-darwin-20)
+    libv8-node (15.14.0.1-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -407,6 +408,8 @@ GEM
       rake
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
     msgpack (1.3.0)
     multi_json (1.15.0)
@@ -416,6 +419,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
@@ -579,7 +584,6 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.4.1)
       redis (>= 2.2, < 5)
-    ref (2.0.0)
     regexp_parser (2.1.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -696,9 +700,6 @@ GEM
     test_xml (0.1.8)
       diffy (~> 3.0)
       nokogiri (>= 1.3.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -748,6 +749,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -804,6 +806,7 @@ DEPENDENCIES
   lograge
   maruku
   meta_request
+  mini_racer
   oj (~> 3.7.12)
   oj_mimic_json
   omniauth
@@ -848,7 +851,6 @@ DEPENDENCIES
   smarter_csv
   spring
   spring-commands-rspec
-  therubyracer
   timecop
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
The gem `therubyracer` hasn't had a release in a long time so Accounts was using a really old version of libv8 that does not install properly on newer OS X.

- Updated to mini_racer to use more recent versions of libv8
- Added x86_64-darwin-20 to the lockfile so we can use prebuilt OS X binaries during development

Please verify that you can `bundle install` without issues with those updates.