### PR TITLE
[hotfix] revert back to therubyracer 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'compass-rails'
 gem 'coffee-rails', '5.0.0'
 
 # JavaScript asset compiler
-gem 'mini_racer'
+gem 'therubyracer', platforms: :ruby
 
 # JavaScript asset compressor
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,6 @@ GEM
       transaction_isolation
       transaction_retry
     libv8 (3.16.14.19)
-    libv8 (3.16.14.19-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -845,9 +844,7 @@ DEPENDENCIES
   smarter_csv
   spring
   spring-commands-rspec
-  therubyracer (0.12.3)
-        libv8 (~> 3.16.14.15)
-        ref
+  therubyracer
   timecop
   uglifier (>= 1.3.0)
   unicorn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,9 +368,7 @@ GEM
       hashie
       transaction_isolation
       transaction_retry
-    libv8-node (15.14.0.1)
-    libv8-node (15.14.0.1-x86_64-darwin-20)
-    libv8-node (15.14.0.1-x86_64-linux)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -398,8 +396,6 @@ GEM
       rake
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
     msgpack (1.3.0)
     multi_json (1.15.0)
@@ -578,6 +574,7 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.4.1)
       redis (>= 2.2, < 5)
+    ref (2.0.0)
     regexp_parser (2.1.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -694,6 +691,9 @@ GEM
     test_xml (0.1.8)
       diffy (~> 3.0)
       nokogiri (>= 1.3.2)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -800,7 +800,6 @@ DEPENDENCIES
   lograge
   maruku
   meta_request
-  mini_racer
   oj (~> 3.7.12)
   oj_mimic_json
   omniauth
@@ -845,6 +844,7 @@ DEPENDENCIES
   smarter_csv
   spring
   spring-commands-rspec
+  therubyracer
   timecop
   uglifier (>= 1.3.0)
   unicorn

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
       transaction_isolation
       transaction_retry
     libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -844,7 +845,9 @@ DEPENDENCIES
   smarter_csv
   spring
   spring-commands-rspec
-  therubyracer
+  therubyracer (0.12.3)
+        libv8 (~> 3.16.14.15)
+        ref
   timecop
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
`552ca52a51e4fa3810946bd753a7a70ed13295c9` was deployed to production to fix an error with mini_racer

this still might be needed because we didn't see any issues on testing environments with low load. If you see any V8 errors on testing environments, will need to migrate back to therubyracer gem.