### PR TITLE
remove forecasting from blazer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,7 +187,6 @@ gem 'cookiejar', git: 'https://github.com/MissionCapital/cookiejar.git'
 gem 'faye', '0.8.9'
 
 gem 'blazer'
-gem 'prophet-rb'
 
 group :development, :test do
   # Run specs in parallel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,6 @@ GEM
     choice (0.2.0)
     chronic (0.10.2)
     chunky_png (1.4.0)
-    cmdstan (0.1.7)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.1)
@@ -437,7 +436,6 @@ GEM
     notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    numo-narray (0.9.2.0)
     oauth (0.5.6)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -510,10 +508,6 @@ GEM
     premailer-rails (1.9.4)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    prophet-rb (0.2.5)
-      cmdstan (>= 0.1.2)
-      numo-narray (>= 0.9.1.7)
-      rover-df
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -626,8 +620,6 @@ GEM
       roar (~> 1.1.0)
       test_xml (>= 0.1.6)
       uber (< 0.2.0)
-    rover-df (0.2.4)
-      numo-narray (>= 0.9.1.9)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -842,7 +834,6 @@ DEPENDENCIES
   pattern-library!
   pg
   premailer-rails
-  prophet-rb
   puma
   puma_worker_killer
   rack-cors

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -165,10 +165,10 @@ check_schedules:
 # enable anomaly detection
 # note: with trend, time series are sent to https://trendapi.org
 # anomaly_checks: prophet / trend / r
-anomaly_checks: prophet
+# anomaly_checks: prophet
 
 # enable forecasting
 # note: with trend, time series are sent to https://trendapi.org
 # forecasting: prophet / trend
-forecasting: prophet
+# forecasting: prophet
 


### PR DESCRIPTION
While cool, this took a lot of resources and install time.
Perhaps something to look into when we can have a separate instance of Blazer running (coming soon to a BIT near you)