### PR TITLE
Fixed some issues with parallel:spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ cucumber_rerun.txt
 # Ignore byebug history files
 .byebug_history
 
+# Ignore webdrivers lock file
+.webdrivers_update
+
 # Ignore Coverage reports
 coverage/*
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+ENV['RAILS_ENV'] = 'test' if ARGV[0] == 'parallel:spec'
+
 begin
   require 'rspec/core/rake_task'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,24 @@ if in_docker?
 else
   require 'webdrivers/chromedriver'
 
+  # Use a lockfile so we don't get errors due to downloading webdrivers multiple times concurrently
+  File.open('.webdrivers_update', File::RDWR|File::CREAT, 0640) do |file|
+    file.flock File::LOCK_EX
+    update_time = Time.parse(file.read) rescue nil
+    current_time = Time.current
+
+    if update_time.nil? || current_time - update_time > 60
+      Webdrivers::Chromedriver.update
+
+      file.rewind
+      file.write current_time.iso8601
+      file.flush
+      file.truncate file.pos
+    end
+  ensure
+    file.flock File::LOCK_UN
+  end
+
   if EnvUtilities.load_boolean(name: 'HEADLESS', default: true)
     # Run the feature specs in a full browser (note, this takes over your computer's focus)
     Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
- Fixed error when running `rake parallel:spec` due to development-only gems being loaded in the test environment (web-console gem throws an error)
- Download Chromedriver only once to try to prevent intermittent errors due to multiple processes trying to update it