### PR TITLE
create account object after lead, so they get linked

### DIFF
--- a/app/handlers/newflow/educator_signup/complete_profile.rb
+++ b/app/handlers/newflow/educator_signup/complete_profile.rb
@@ -119,7 +119,6 @@ module Newflow
         end
 
         # Now we create the lead for the user... because we returned above if they did... again SheeridWebhook
-        Newflow::AddAccountToSalesforce.perform_later(user_id: @user.id)
         Newflow::CreateSalesforceLead.perform_later(user_id: @user.id)
 
       end

--- a/app/routines/newflow/create_salesforce_lead.rb
+++ b/app/routines/newflow/create_salesforce_lead.rb
@@ -100,6 +100,7 @@ module Newflow
 
       user.salesforce_lead_id = lead.id
       if user.save!
+        Newflow::AddAccountToSalesforce.perform_later(user_id: @user.id)
         SecurityLog.create!(
           user:       user,
           event_type: :user_lead_id_updated_from_salesforce,

--- a/config/initializers/04-debugger.rb
+++ b/config/initializers/04-debugger.rb
@@ -1,11 +1,3 @@
 unless Rails.env.production?
-  # Let environment variables dictate which debugger to use; they are not compatible
-  if ENV['DEBUGGER'] == 'byebug'
-    # Call 'debugger' anywhere in the code to stop execution and get a debugger console
     require 'byebug'
-  else
-    # Debug in VS Code
-    require 'ruby-debug-ide'
-    require 'debase'
-  end
 end


### PR DESCRIPTION
Move the account object creation to the lead creation because there is a Salesforce trigger to link the two that requires the lead to be built first (if converted to a contact, it should link that instead).
Link to trigger: https://openstax--staging.lightning.force.com/builder_platform_interaction/flowBuilder.app?flowId=3016f000000HoOwAAK