### PR TITLE
upgrade omniauth-identity and bcrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 /public/500.html
 /public/503.html
 
+# Ignore
+/vendor/bundle
+
 # Ignore yaml_db database files
 /db/data.yml*
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,9 +125,7 @@ GEM
       rack (~> 2)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    bcrypt (3.1.16)
-    bcrypt-ruby (3.1.5)
-      bcrypt (>= 3.1.3)
+    bcrypt (3.1.18)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -386,9 +384,9 @@ GEM
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-identity (1.1.1)
-      bcrypt-ruby (~> 3.0)
-      omniauth (~> 1.0)
+    omniauth-identity (3.0.9)
+      bcrypt
+      omniauth
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
@@ -455,7 +453,7 @@ GEM
       get_process_mem (~> 0.2)
       puma (>= 2.7)
     racc (1.6.0)
-    rack (2.2.3.1)
+    rack (2.2.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-protection (2.2.0)


### PR DESCRIPTION
To solve 
```
"The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of", "installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your", "dependencies accordingly."
```
during the build