### PR TITLE
Removed oauth_access_token token field string size limit

### DIFF
--- a/db/migrate/20221210002041_remove_oauth_access_token_size_limit.rb
+++ b/db/migrate/20221210002041_remove_oauth_access_token_size_limit.rb
@@ -1,0 +1,5 @@
+class RemoveOauthAccessTokenSizeLimit < ActiveRecord::Migration[5.2]
+  def change
+    change_column :oauth_access_tokens, :token, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_03_202514) do
+ActiveRecord::Schema.define(version: 2022_12_10_002041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -251,7 +251,7 @@ ActiveRecord::Schema.define(version: 2022_08_03_202514) do
   create_table "oauth_access_tokens", id: :serial, force: :cascade do |t|
     t.integer "resource_owner_id"
     t.integer "application_id"
-    t.string "token", null: false
+    t.text "token", null: false
     t.string "refresh_token"
     t.integer "expires_in"
     t.datetime "revoked_at"


### PR DESCRIPTION
Accounts dev was failing to create tokens in the DB because of the change to use the SSO cookie and the size limit. This change fixes that.