### PR TITLE
Allow searching for users by external id

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -50,7 +50,8 @@ class Api::V1::UsersController < Api::V1::ApiController
     * `name` &ndash; Matches Users' first, last, or full names, case insensitive. (uses wildcard matching)
     * `id` &ndash; Matches Users' IDs exactly.
     * `email` &ndash; Matches Users' emails exactly.
-    * `uuid` &ndash; Mathces Users' UUIDs exactly.
+    * `uuid` &ndash; Matches Users' UUIDs exactly.
+    * `external_id` &ndash; Matches Users' external IDs exactly.
 
     You can also add search terms without prefixes, separated by spaces.
 

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -116,6 +116,11 @@ class SearchUsers
         users = users.where(contact_infos: {type: 'EmailAddress', verified: true, is_searchable: true}) unless options[:admin]
       end
 
+      with.keyword :external_id do |external_ids|
+        sanitized_external_ids = sanitize_strings external_ids
+        users = users.joins(:external_ids).where(external_ids: { external_id: sanitized_external_ids })
+      end
+
       # Rerun the queries above for 'any' terms (which are ones without a
       # prefix).
 

--- a/spec/routines/search_users_spec.rb
+++ b/spec/routines/search_users_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe SearchUsers, type: :routine do
                                           username: 'bigbear'
   end
 
+  let!(:external_id)     { FactoryBot.create :external_id, user: user_4 }
+
   let!(:billy_users) do
     (0..8).to_a.map do |ii|
       FactoryBot.create :user,
@@ -136,6 +138,11 @@ RSpec.describe SearchUsers, type: :routine do
   it 'should match by id' do
     outcome = described_class.call("id:#{user_3.id}").outputs.items.to_a
     expect(outcome).to eq [user_3]
+  end
+
+  it 'should match by external_id' do
+    outcome = described_class.call("external_id:#{user_4.external_ids.first.external_id}").outputs.items.to_a
+    expect(outcome).to eq [user_4]
   end
 
   it 'should not match by support_identifier' do


### PR DESCRIPTION
We determined that the LTI Gateway will need this in order to figure out if instructors need to be sent to a different flow to link their existing accounts.