### PR TITLE
Changed the Assignable token expiration to 6 hours

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::UsersController < Api::V1::ApiController
+  SSO_TOKEN_DURATION = 6.hours
 
   resource_description do
     api_versions "v1"
@@ -251,7 +252,7 @@ class Api::V1::UsersController < Api::V1::ApiController
       application,
       user.id,
       '',
-      1.hour,
+      SSO_TOKEN_DURATION,
       false,
     ).token
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -373,7 +373,9 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       sso_cookie = JSON.parse(response.body)['sso']
       sso_hash = SsoCookie.read sso_cookie
       expect(sso_hash['sub']).to eq Api::V1::UserRepresenter.new(new_user).to_hash
-      expect(sso_hash['exp']).to be <= (Time.current + 1.hour).to_i
+      expect(sso_hash['exp']).to be <= (
+        Time.current + Api::V1::UsersController::SSO_TOKEN_DURATION
+      ).to_i
 
       # Ensure the Doorkeeper token exists
       Doorkeeper::AccessToken.find_by! token: sso_cookie


### PR DESCRIPTION
The team felt 1 hour was too short and would cause too many logins