### PR TITLE
Fix email address in Polish educator pending screen

### DIFF
--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -87,7 +87,7 @@ pl:
     educator_pending_cs_verification_description: >-
       Twój dostęp do instruktora jest w toku.
        Sprawdzimy Twój status instruktora w ciągu 3-4 dni roboczych.
-       Aktualizacje Twojego statusu weryfikacji zostaną wysłane na adres <b>% {email_addess} </b>.
+       Aktualizacje Twojego statusu weryfikacji zostaną wysłane na adres <b>%{email_addess}</b>.
        W międzyczasie możesz uzyskać dostęp do wszystkich książek i zasobów
        z wyjątkiem tych, które wymagają weryfikacji instruktora.
     join_as_student_description: >-


### PR DESCRIPTION
Tiny PR to fix the educator pending screen in Polish - there are spaces around the email variable so it doesn't render properly.