### PR TITLE
update past adopter to be using_openstax for renewal popup

### DIFF
--- a/app/routines/update_user_contact_info.rb
+++ b/app/routines/update_user_contact_info.rb
@@ -14,7 +14,7 @@ class UpdateUserContactInfo
   ADOPTION_STATUSES = {
     "Current Adopter" => true,
     "Future Adopter" => true,
-    "Past Adopter" => false,
+    "Past Adopter" => true,
     "Not Adopter" => false
   }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,7 +88,7 @@ else
     current_time = Time.current
 
     if update_time.nil? || current_time - update_time > 60
-      Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+      Webdrivers::Chromedriver.update
 
       file.rewind
       file.write current_time.iso8601

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,7 +88,7 @@ else
     current_time = Time.current
 
     if update_time.nil? || current_time - update_time > 60
-      Webdrivers::Chromedriver.update
+      Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
       file.rewind
       file.write current_time.iso8601


### PR DESCRIPTION
The renewal popup (the only thing I am aware of looking at this field) is showing folks the popup if their adoption status is `true`. We want the renewal popup to show for these folks, so updating this to reflect that.