### PR TITLE
Added external_ids to Find(OrCreate)UserRepresenter, allow users to be found by UUID

### DIFF
--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -25,6 +25,15 @@ module Api::V1
                description: "External ID to search by or assign to newly created user"
              }
 
+    collection :external_ids,
+               type: String,
+               readable: true,
+               writeable: false,
+               schema_info: {
+                 description: "The user's external_ids"
+               },
+               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
+
     property :username,
              type: String,
              readable: false,

--- a/app/representers/api/v1/find_user_representer.rb
+++ b/app/representers/api/v1/find_user_representer.rb
@@ -10,7 +10,7 @@ module Api::V1
     property :uuid,
              type: String,
              readable: true,
-             writeable: false
+             writeable: true
 
     property :support_identifier,
              type: String,
@@ -24,6 +24,15 @@ module Api::V1
              schema_info: {
                description: "External ID to search by"
              }
+
+    collection :external_ids,
+               type: String,
+               readable: true,
+               writeable: false,
+               schema_info: {
+                 description: "The user's external_ids"
+               },
+               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
 
     property :is_test,
              type: :boolean,

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -200,6 +200,13 @@ module Api::V1
                if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
                getter: ->(*) { FinePrint::Contract.published.latest.signed_by(self).pluck(:name) }
 
+    collection :external_ids,
+               type: String,
+               readable: true,
+               writeable: false,
+               if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
+               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
+
     def to_hash(options = {})
       # Avoid N+1 load on application_users.application
       ActiveRecord::Associations::Preloader.new.preload represented.application_users.to_a, :application

--- a/app/routines/search_users.rb
+++ b/app/routines/search_users.rb
@@ -36,7 +36,7 @@ class SearchUsers
 
   def exec(query, options={})
 
-    users = User.all
+    users = User.preload(:external_ids, application_users: :application)
     table = User.arel_table
     contact_info_table = ContactInfo.arel_table
     space = Arel::Nodes.build_quoted(' ')

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       expect(response.code).to eq('201')
       new_user = User.order(:id).last
       expect(response.body_as_hash).to eq(
-        id: new_user.id, uuid: new_user.uuid, support_identifier: new_user.support_identifier
+        id: new_user.id, uuid: new_user.uuid, external_ids: [], support_identifier: new_user.support_identifier
       )
     end
 
@@ -377,15 +377,17 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                  }
       end.to change { User.count }.by(1)
       expect(response.code).to eq('201')
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['external_ids']).to eq [ external_id ]
 
-      new_user = User.find(JSON.parse(response.body)['id'])
+      new_user = User.find(parsed_response['id'])
       expect(new_user.external_ids.first.external_id).to eq external_id
       expect(new_user.state).to eq 'external'
       expect(new_user.role).to eq 'student'
       expect(new_user.applications).to eq [ foc_trusted_application ]
-      expect(new_user.uuid).not_to be_blank
+      expect(new_user.uuid).to eq parsed_response['uuid']
 
-      sso_cookie = JSON.parse(response.body)['sso']
+      sso_cookie = parsed_response['sso']
       sso_hash = SsoCookie.read sso_cookie
       expect(sso_hash['sub']).to eq Api::V1::UserRepresenter.new(new_user).to_hash
       expect(sso_hash['exp']).to be <= (
@@ -422,6 +424,7 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
         expect(response.body_as_hash).to eq(
           id: unclaimed_user.id,
           uuid: unclaimed_user.uuid,
+          external_ids: [],
           support_identifier: unclaimed_user.support_identifier
         )
       end
@@ -432,7 +435,7 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                  body: { email: user_2.contact_infos.first.value }
         expect(response.code).to eq('201')
         expect(response.body_as_hash).to eq(
-          id: user_2.id, uuid: user_2.uuid, support_identifier: user_2.support_identifier
+          id: user_2.id, uuid: user_2.uuid, external_ids: [], support_identifier: user_2.support_identifier
         )
       end
     end

--- a/spec/representers/api/v1/find_user_representer_spec.rb
+++ b/spec/representers/api/v1/find_user_representer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::FindUserRepresenter, type: :representer do
-  let(:payload)         { Hashie::Mash.new }
+  let(:payload)         { Hashie::Mash.new external_ids: [] }
   subject(:representer) { described_class.new payload }
 
   context 'id' do
@@ -24,11 +24,9 @@ RSpec.describe Api::V1::FindUserRepresenter, type: :representer do
       expect(representer.to_hash['uuid']).to eq payload.uuid
     end
 
-    it 'cannot be written (attempts are silently ignored)' do
-      hash = { 'uuid' => SecureRandom.uuid }
-
-      expect(payload).not_to receive(:uuid=)
-      expect { representer.from_hash(hash) }.not_to change { payload.uuid }
+    it 'can be written' do
+      expect(payload).to receive(:uuid=).and_call_original
+      expect { representer.from_hash 'uuid' => SecureRandom.uuid }.to change { payload.uuid }
     end
   end
 
@@ -57,6 +55,20 @@ RSpec.describe Api::V1::FindUserRepresenter, type: :representer do
       expect { representer.from_hash 'external_id' => SecureRandom.uuid }.to(
         change { payload.external_id }
       )
+    end
+  end
+
+  context 'external_ids' do
+    it 'can be read' do
+      payload.external_ids = [ Hashie::Mash.new(external_id: SecureRandom.uuid) ]
+      expect(representer.to_hash['external_ids']).to eq payload.external_ids.map(&:external_id)
+    end
+
+    it 'cannot be written (attempts are silently ignored)' do
+      hash = { 'external_ids' => [ SecureRandom.uuid ] }
+
+      expect(payload).not_to receive(:external_ids=)
+      expect { representer.from_hash(hash) }.not_to change { payload.external_ids }
     end
   end
 

--- a/spec/support/user_hash.rb
+++ b/spec/support/user_hash.rb
@@ -44,6 +44,7 @@ def user_matcher(user, include_private_data: false)
           end
         )
     base_hash[:signed_contract_names] = FinePrint::Contract.published.latest.signed_by(user).pluck(:name)
+    base_hash[:external_ids] = a_collection_containing_exactly(*user.external_ids.map(&:external_id))
   end
 
   base_hash.delete_if { |k,v| v.nil? }


### PR DESCRIPTION
Assignable doesn't currently store the external ids. We want to be able to go from Account UUID to external id so we can find the correct LMS user when syncing scores manually.