### PR TITLE
change subject to subject interest on lead creation, fix lead spec

### DIFF
--- a/app/routines/newflow/create_salesforce_lead.rb
+++ b/app/routines/newflow/create_salesforce_lead.rb
@@ -50,7 +50,7 @@ module Newflow
         position: sf_position,
         title: user.other_role_name,
         who_chooses_books: user.who_chooses_books,
-        subject: user.which_books,
+        subject_interest: user.which_books,
         num_students: user.how_many_students,
         adoption_status: ADOPTION_STATUS_FROM_USER[user.using_openstax_how],
         adoption_json: adoption_json,

--- a/spec/cassettes/Newflow_CreateSalesforceLead/sf_setup.yml
+++ b/spec/cassettes/Newflow_CreateSalesforceLead/sf_setup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://test.salesforce.com/services/oauth2/token
+    uri: https://<salesforce_login_domain>/services/oauth2/token
     body:
       encoding: US-ASCII
       string: grant_type=password&client_id=<salesforce_consumer_key>&client_secret=<salesforce_consumer_secret>&username=<salesforce_username_url>&password=<salesforce_password_url><salesforce_security_token>
@@ -21,18 +21,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Apr 2021 17:26:15 GMT
+      - Mon, 30 Oct 2023 19:37:51 GMT
+      Set-Cookie:
+      - BrowserId=0BGi1XdbEe6DIEORwVWHfA; domain=.salesforce.com; path=/; expires=Tue,
+        29-Oct-2024 19:37:51 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:0; path=/; expires=Tue, 29-Oct-2024 19:37:51 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:0; path=/; expires=Tue, 29-Oct-2024 19:37:51
+        GMT; Max-Age=31536000
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
-      Set-Cookie:
-      - BrowserId=Ww13ipfGEeudnT_rkdQ0OQ; domain=.salesforce.com; path=/; expires=Thu,
-        07-Apr-2022 17:26:15 GMT; Max-Age=31536000
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Readonlymode:
@@ -45,7 +48,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"<salesforce_access_token>","instance_url":"<salesforce_instance_url>","id":"<salesforce_id>","token_type":"Bearer","issued_at":"1617816375438","signature":"<salesforce_signature>"}'
+      string: '{"access_token":"<salesforce_access_token>","instance_url":"<salesforce_instance_url>","id":"https://<salesforce_login_domain>/id/00D040000003rgWEAQ/005U0000005MXdmIAG","token_type":"Bearer","issued_at":"1698694671993","signature":"<salesforce_signature>"}'
     http_version:
-  recorded_at: Wed, 07 Apr 2021 17:34:35 GMT
+  recorded_at: Mon, 30 Oct 2023 19:37:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Newflow_CreateSalesforceLead/works_on_the_happy_path.yml
+++ b/spec/cassettes/Newflow_CreateSalesforceLead/works_on_the_happy_path.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Lead"
+    body:
+      encoding: UTF-8
+      string: '{"FirstName":"Max","LastName":"Liebermann","Company":"Test University","Country":"United
+        States","Phone":"+17133484799","LeadSource":"Account Creation","Newsletter__c":false,"Newsletter_Opt_In__c":false,"Adoption_Status__c":"Confirmed
+        Adoption Won","Number_of_Students__c":"35","Accounts_ID__c":1,"Accounts_UUID__c":"f9b81c7c-b57b-4c8f-b8c7-dc760b14ed21","Application_Source__c":"Accounts","Role__c":"Instructor","Position__c":"instructor","who_chooses_books__c":"instructor","FV_Status__c":"pending_faculty","BRI_Marketing__c":false,"Title_1_school__c":false}'
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <salesforce_access_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 30 Oct 2023 19:38:13 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - BrowserId=0OvWbndbEe68IzGd4tbGQQ; domain=.salesforce.com; path=/; expires=Tue,
+        29-Oct-2024 19:37:52 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:1; path=/; expires=Tue, 29-Oct-2024 19:37:52 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:1; path=/; expires=Tue, 29-Oct-2024 19:37:52
+        GMT; Max-Age=31536000
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Sforce-Limit-Info:
+      - api-usage=22/5000000
+      Location:
+      - "/services/data/v51.0/sobjects/Lead/00Q04000006GrgJEAS"
+      Vary:
+      - Accept-Encoding
+      Server:
+      - sfdcedge
+      X-Sfdc-Request-Id:
+      - 07e99c888d917346e15aabd66b7aed91
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"00Q04000006GrgJEAS","success":true,"errors":[]}'
+    http_version:
+  recorded_at: Mon, 30 Oct 2023 19:38:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/routines/newflow/create_salesforce_lead_spec.rb
+++ b/spec/routines/newflow/create_salesforce_lead_spec.rb
@@ -34,16 +34,12 @@ module Newflow
       end
     end
 
-    xit 'works on the happy path' do
+    it 'works on the happy path' do
       expect(Rails.logger).not_to receive(:warn)
 
       lead = described_class[user: user]
-      expect(lead.errors).to be_empty
 
-
-      lead_from_sf = user.lead
-      expect(lead_from_sf).not_to be_nil
-      expect(lead_from_sf.application_source).to eq "Account Creation"
+      expect(user.salesforce_lead_id).not_to be_nil
     end
   end
 end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -54,6 +54,7 @@ VCR.configure do |c|
 
   %w(
     instance_url
+    login_domain
     username
     password
     security_token


### PR DESCRIPTION
This change is to reflect the work to unify the way we collect subjects of interest in Salesforce. 
Currently, we have `subject` and `subject_interest`, with `subject_interest` being the more acceptable version of this field because of the way it's configured in Salesforce.
The web is making a similar change, which can be viewed on [this card.](https://github.com/orgs/openstax/projects/14/views/9?filterQuery=&pane=issue&itemId=41667551)

This also readds the lead creation spec and cassette, which had been xit'd out.