### PR TITLE
require box to be checked before accepting

### DIFF
--- a/app/views/terms/pose.html.erb
+++ b/app/views/terms/pose.html.erb
@@ -28,13 +28,13 @@
 
 
     <%= f.hidden_field :contract_id, value: @contract.id %>
-    <%= f.submit (t :".agree"), id: "agreement_submit", class: 'primary new-style' %>
+    <%= f.submit (t :".agree"), id: "agreement_submit", class: 'primary new-style', data: { disable_with: (t :".agree") } %>
   <% end %>
 
 <% end %>
 
 <% content_for :javascript do %>
   <script type="text/javascript">
-    Accounts.Ui.enableOnChecked('#agreement_submit', '#agreement_i_agree');
+      NewflowUi.enableOnChecked('#agreement_submit', '#agreement_i_agree');
   </script>
 <% end %>


### PR DESCRIPTION
Users were able to submit the form without checking the box to agree. Disable the button until the box is checked.