### PR TITLE
add lti-gateway to dev trusted hosts

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -51,6 +51,7 @@ development:
     - rdls.org
     - localhost
     - 127.0.0.1
+    - lti-gateway.local
 
   # Set to true to disable the corner dev/admin console
   disable_corner_console: false


### PR DESCRIPTION
This will make it a little more convenient when setting up accounts for local development with Assignable.