### PR TITLE
Check profile complete and SheerID response in setting lead FV status

### DIFF
--- a/app/handlers/newflow/educator_signup/sheerid_webhook.rb
+++ b/app/handlers/newflow/educator_signup/sheerid_webhook.rb
@@ -105,7 +105,7 @@ module Newflow
         end
 
         if verification.current_step == 'rejected'
-          user.update!(faculty_status: User::REJECTED_FACULTY, sheerid_verification_id: verification_id)
+          user.update!(faculty_status: User::REJECTED_BY_SHEERID, sheerid_verification_id: verification_id)
           SecurityLog.create!(
             event_type: :fv_reject_by_sheerid,
             user: user,

--- a/app/models/sheerid_verification.rb
+++ b/app/models/sheerid_verification.rb
@@ -19,7 +19,7 @@ class SheeridVerification < ApplicationRecord
     when VERIFIED
       User.faculty_statuses[:confirmed_faculty]
     when REJECTED
-      User.faculty_statuses[:rejected_faculty]
+      User.faculty_statuses[:rejected_by_sheerid]
     else
       User.faculty_statuses[:pending_faculty]
     end

--- a/app/models/sheerid_verification.rb
+++ b/app/models/sheerid_verification.rb
@@ -1,6 +1,8 @@
 class SheeridVerification < ApplicationRecord
   VERIFIED = 'success'
   REJECTED = 'rejected'
+  PENDING = 'docUpload'
+  ERROR = 'error'
 
   validates :verification_id, presence: true
   validates :current_step, presence: true
@@ -13,13 +15,23 @@ class SheeridVerification < ApplicationRecord
     self.current_step == REJECTED
   end
 
+  def pending?
+    self.current_step == PENDING
+  end
+
+  def error?
+    self.current_step == ERROR
+  end
+
   # Translate SheerID nomenclature to `User#faculty_status` nomenclature
   def current_step_to_faculty_status
     case self.current_step
     when VERIFIED
       User.faculty_statuses[:confirmed_faculty]
-    when REJECTED
+    when REJECTED || ERROR
       User.faculty_statuses[:rejected_by_sheerid]
+    when PENDING
+      User.faculty_statuses[:pending_sheerid]
     else
       User.faculty_statuses[:pending_faculty]
     end

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -46,7 +46,7 @@ module Newflow
       end
 
       # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
-      if !user.is_profile_complete? && !user.faculty_status.include(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
+      if !user.is_profile_complete? && !user.faculty_status.include?(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -46,7 +46,7 @@ module Newflow
       end
 
       # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
-      if !user.is_profile_complete? && !user.faculty_status.include?(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
+      if !user.is_profile_complete? && !user.faculty_status.includes(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -45,8 +45,14 @@ module Newflow
         adoption_json = build_book_adoption_json_for_salesforce(user)
       end
 
-      # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
-      if !user.is_profile_complete? && !user.faculty_status == :confirmed_faculty
+      # Check the state of the SheerID response and profile completion to determine faculty status for lead
+      sheerid_response = SheeridVerification.find_by(verification_id: user.sheerid_verification_id)
+      if user.is_profile_complete?
+        user.faculty_status = :pending_faculty
+        unless sheerid_response.nil?
+          user.faculty_status = sheerid_response.current_step_to_faculty_status
+        end
+      else
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -46,7 +46,7 @@ module Newflow
       end
 
       # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
-      if !user.is_profile_complete? && !user.faculty_status.include?(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
+      if !user.is_profile_complete? && !user.faculty_status == :confirmed_faculty
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -46,7 +46,7 @@ module Newflow
       end
 
       # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
-      if !user.is_profile_complete? && !user.faculty_status.includes(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
+      if !user.is_profile_complete? && !user.faculty_status.include?(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -53,6 +53,7 @@ module Newflow
           user.faculty_status = sheerid_response.current_step_to_faculty_status
         end
       else
+        # User has not completed their profile
         user.faculty_status = :incomplete_signup
       end
 

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -45,8 +45,10 @@ module Newflow
         adoption_json = build_book_adoption_json_for_salesforce(user)
       end
 
-      # The user has not finished signing up
-      user.faculty_status = User::INCOMPLETE_SIGNUP unless user.is_profile_complete?
+      # The user has not finished signing up, check for confirmed faculty if they were verified by sheerid
+      if !user.is_profile_complete? && !user.faculty_status.include(:confirmed_faculty, :pending_sheerid, :rejected_by_sheerid)
+        user.faculty_status = :incomplete_signup
+      end
 
 
       if user.salesforce_lead_id

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,6 +10,9 @@ Sentry.init do |config|
   # Send POST data and cookies to Sentry
   config.send_default_pii = true
 
+  # Don't send transaction data to Sentry
+  config.traces_sample_rate = 0.0
+
   # Reduce the amount of logging from Sentry
   config.logger = Sentry::Logger.new(STDOUT)
   config.logger.level = Logger::ERROR

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,8 +6,11 @@ Sentry.init do |config|
   config.release = secrets.release_version
 
   config.breadcrumbs_logger = %i[sentry_logger active_support_logger http_logger]
-  config.traces_sample_rate = 0.5
 
   # Send POST data and cookies to Sentry
   config.send_default_pii = true
+
+  # Reduce the amount of logging from Sentry
+  config.logger = Sentry::Logger.new(STDOUT)
+  config.logger.level = Logger::ERROR
 end if Rails.env.production?


### PR DESCRIPTION
The command to create the lead was overwriting the faculty status set by SheerID. Checking to make sure it's not one of the 3 expected values to come from SheerID before changing to incomplete_signup.