### PR TITLE
upgrade FB graph API to v19.0

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,8 +8,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
   provider :facebook, secrets[:facebook_app_id], secrets[:facebook_app_secret],
            client_options: {
-             site: 'https://graph.facebook.com/v7.0',
-             authorize_url: "https://www.facebook.com/v7.0/dialog/oauth"
+             site: 'https://graph.facebook.com/v19.0',
+             authorize_url: "https://www.facebook.com/v19.0/dialog/oauth"
            }
 
   provider(
@@ -17,8 +17,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     secrets[:facebook_app_id],
     secrets[:facebook_app_secret],
     client_options: {
-      site: 'https://graph.facebook.com/v7.0',
-      authorize_url: "https://www.facebook.com/v7.0/dialog/oauth"
+      site: 'https://graph.facebook.com/v19.0',
+      authorize_url: "https://www.facebook.com/v19.0/dialog/oauth"
     }
   )
 


### PR DESCRIPTION
This really needs to be tested. We got an email saying v12.0, which our app is using (seems like we're using v7.0), is being deprecated.  
The current version is v19.0, and I have checked it with the Facebook Upgrade Tool, which shows no issues with upgrading.