### PR TITLE
Handle taken error from social auth

### DIFF
--- a/app/controllers/newflow/social_auth_controller.rb
+++ b/app/controllers/newflow/social_auth_controller.rb
@@ -63,10 +63,10 @@ module Newflow
                 sign_up: view_context.link_to(I18n.t(:"login_signup_form.sign_up"), newflow_signup_path)
               )
             )
-          when :authentication_taken
+          when :authentication_taken || :taken
             security_log(:authentication_transfer_failed, authentication_id: authentication.id)
             redirect_to(error_path(is_external, code), alert: I18n.t(:"controllers.sessions.sign_in_option_already_used"))
-          when :email_already_in_use || :taken
+          when :email_already_in_use
             security_log(:email_already_in_use, email: @email, authentication_id: authentication.id)
             redirect_to(error_path(is_external, code), alert: I18n.t(:"controllers.sessions.way_to_login_cannot_be_added"))
           when :mismatched_authentication

--- a/app/controllers/newflow/social_auth_controller.rb
+++ b/app/controllers/newflow/social_auth_controller.rb
@@ -66,7 +66,7 @@ module Newflow
           when :authentication_taken
             security_log(:authentication_transfer_failed, authentication_id: authentication.id)
             redirect_to(error_path(is_external, code), alert: I18n.t(:"controllers.sessions.sign_in_option_already_used"))
-          when :email_already_in_use
+          when :email_already_in_use || :taken
             security_log(:email_already_in_use, email: @email, authentication_id: authentication.id)
             redirect_to(error_path(is_external, code), alert: I18n.t(:"controllers.sessions.way_to_login_cannot_be_added"))
           when :mismatched_authentication


### PR DESCRIPTION
This should handle this [Sentry error](https://openstax.sentry.io/issues/3041152439/?environment=production&project=5772471&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=4). It seems we are getting a slightly different error code back from Google auth that is not handled.