### PR TITLE
default instructor to incomplete_signup

### DIFF
--- a/app/handlers/newflow/educator_signup/signup_form.rb
+++ b/app/handlers/newflow/educator_signup/signup_form.rb
@@ -3,7 +3,7 @@ module Newflow
     class SignupForm
 
       USER_DEFAULT_STATE = :unverified
-      USER_FACULTY_STATUS = User::PENDING_FACULTY
+      USER_FACULTY_STATUS = User::INCOMPLETE_SIGNUP
       USER_ROLE = :instructor
       USER_IS_NEWFLOW = true
       private_constant(:USER_DEFAULT_STATE, :USER_FACULTY_STATUS, :USER_ROLE, :USER_IS_NEWFLOW)

--- a/spec/handlers/newflow/educator_signup/signup_form_spec.rb
+++ b/spec/handlers/newflow/educator_signup/signup_form_spec.rb
@@ -33,8 +33,8 @@ module Newflow
           expect { handler_call }.to change { User.where(state: 'unverified', role: :instructor).count }
         end
 
-        it 'sets the new user\'s faculty status to pending_faculty' do
-          expect { handler_call }.to change { User.where(faculty_status: :pending_faculty).count }
+        it 'sets the new user\'s faculty status to incomplete_signup' do
+          expect { handler_call }.to change { User.where(faculty_status: :incomplete_signup).count }
         end
 
         it 'creates an authentication with provider = identity' do


### PR DESCRIPTION
The default state for an instructor signing up should be `incomplete_signup`. They are moved to `pending_faculty` after Profile completion, unless verified automatically or under SheerID review.