### PR TITLE
re-add support_identifier

### DIFF
--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -50,6 +50,11 @@ module Api::V1
              readable: true,
              writeable: false
 
+    property :support_identifier,
+             type: String,
+             readable: true,
+             writeable: false
+
     property :consent_preferences,
              type: JSON,
              readable: true,

--- a/spec/support/user_hash.rb
+++ b/spec/support/user_hash.rb
@@ -11,6 +11,7 @@ def user_matcher(user, include_private_data: false)
     title: user.title,
     suffix: user.suffix,
     uuid: user.uuid,
+    support_identifier: user.support_identifier,
     consent_preferences: user.consent_preferences,
     is_test: user.is_test?,
     is_administrator: user.is_administrator?,


### PR DESCRIPTION
and this is why we need qa....

seems this [broke](https://openstax.sentry.io/issues/5108908364/?environment=production&project=5772471&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=6) a few things, so adding it back in

[not sure if this is also related](https://openstax.sentry.io/issues/5593702379/?environment=production&project=5772471&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=2)