### PR TITLE
update email to use same template as other transactional emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,7 +4,7 @@
 class ApplicationMailer < ActionMailer::Base
   helper :application, :sessions
 
-  default from: 'noreply@openstax.org'
+  default from: 'OpenStax Accounts <noreply@openstax.org>'
 
   def mail(headers={}, &block)
     headers[:subject] = "[OpenStax] #{headers[:subject]}"

--- a/app/mailers/newflow_mailer.rb
+++ b/app/mailers/newflow_mailer.rb
@@ -24,7 +24,7 @@ class NewflowMailer < ApplicationMailer
 
     mail to: @email_value,
          subject: if @should_show_pin
-                    "Use PIN #{@confirmation_pin} to confirm your email address"
+                    "Your OpenStax account PIN has arrived: #{@confirmation_pin}"
                   else
                     'Confirm your email address'
                   end

--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -17,6 +17,8 @@ module Newflow
     protected #################
 
     def exec(user:)
+      return unless user
+
       status.set_job_name(self.class.name)
       status.set_job_args(user: user.to_global_id.to_s)
 

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -89,8 +89,6 @@
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 10px;padding-right: 30px;padding-bottom: 20px;padding-left: 30px;">
 															<p style="color: rgb(0, 0, 0); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: normal; margin: 0px; line-height: 2;">
 																<div style="text-align: center">
-																	<h3>Please confirm <%= @email_value %> is your email.</h3>
-																	<hr>
 																	Verify your email by clicking the button below or use your pin: <b><%= @confirmation_pin %></b>
 																</div>
 															</p>
@@ -126,8 +124,8 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 50px;padding-bottom: 50px;padding-left: 50px;">
 															<div style="text-align: center; line-height: 2">
-                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.<br>
-																<small>If you did not signup for an OpenStax Account with the email <%= @email_value %>, please disregard this message.</small>
+                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.<br /><br />
+																<small>If you did not signup for an OpenStax Account with the email <b><%= raw @email_value %></b>, please disregard this message.</small>
                               </div>
 															</td>
 														</tr>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -1,18 +1,217 @@
-<p>Welcome!</p>
+<!DOCTYPE html>
+<html style="overflow-y: hidden;">
+<head>
+	<title></title>
+	<meta content="text/html; charset=UTF-8"><meta content="width=device-width, initialscale=1.0" name="viewport"><meta content="IE=edge">
+	<style type="text/css">
+      @media screen and (max-width: 480px) {slot[style] {margin-right: 0 !important;}.columnDiv {margin-right: 0 !important;}}@media screen and (min-width: 480px) {slot[style] {margin-bottom: 0 !important;}.columnDiv {margin-bottom: 0 !important;}}
+	</style>
+	<style type="text/css">
+      @media screen and (max-width: 480px) {.contentbuilderBaseColumnRow .columnCell {display:inline-block;width:100%}}
+	</style>
+	<style type="text/css">
+      .contentpageDefaultEmailTemplatePageTemplate .contentRoot {width: 600px;}@media only screen and (max-width: 480px) {.contentpageDefaultEmailTemplatePageTemplate .contentRoot {width: 320px;}}
+	</style>
+</head>
+<body style="height: auto; min-height: auto;">
+<table cellpadding="0" cellspacing="0" class="contentpageDefaultEmailTemplatePageTemplate" id="contentpage_emailTemplateBodyContent" style="background-color: #f1f1f1;" width="100%">
+	<tbody>
+		<tr>
+			<td align="center" width="100%">
+			<table cellpadding="0" cellspacing="0" class="contentRoot" style="background-color: #FFFFFF;" width="600">
+				<tbody>
+					<tr>
+						<td style="padding-top: 0px; padding-bottom: 0px; padding-left: 0px; padding-right: 0px;">
+						<table cellpadding="0" cellspacing="0" class="contentbuilderBaseColumnRow" style="align-items: flex-start; width: 100%;">
+							<tbody>
+								<tr valign="top">
+									<td class="columnCell" style="vertical-align: top;display: inline-block; float:left" width="100%">
+									<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse; word-break:break-word;">
+										<tbody>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width:100%; border-collapse: collapse; word-break:break-word;">
+													<tbody>
+														<tr>
+															<td align="center" style="padding-top: 15px;">
+                              <a href="<%= link_to @confirmation_url, @confirmation_url %>" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MC6BQDZRG2LJH63GGTYUS7JVML2E?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 30%; object-fit: contain;" width="180" /></a></td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+										</tbody>
+									</table>
+									</td>
+								</tr>
+							</tbody>
+						</table>
 
-<% if @should_show_pin %>
-  <p>Enter your 6-digit PIN in your browser to confirm your email address:</p>
+						<table cellpadding="0" cellspacing="0" class="contentbuilderBaseColumnRow" style="align-items: flex-start; width: 100%;">
+							<tbody>
+								<tr valign="top">
+									<td class="columnCell" style="vertical-align: top;display: inline-block; float:left" width="100%">
+									<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse; word-break:break-word;">
+										<tbody>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width: 100%; border-collapse: collapse; word-break: break-word; font-size: 14px">
+													<tbody>
+														<tr>
+															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 30px;padding-bottom: 10px;padding-left: 30px;">
+															<h1 style="color: rgb(17, 17, 17); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: bold; margin: 0px; text-align: center;">
+                                Confirm your email address
+                              </h1>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentregion=" style="font-size:14px; width: 100%; border-collapse: collapse; word-break: break-word;">
+													<tbody>
+														<tr>
+															<td class="contentbuilder-html" style="padding: 0;">
+															<hr style="border-top:5px solid #d4450c; width: 70%; margin: 2rem auto;" /></td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion=" style="width: 100%; border-collapse: collapse; word-break: break-word; font-size: 14px">
+													<tbody>
+														<tr>
+															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 10px;padding-right: 30px;padding-bottom: 20px;padding-left: 30px;">
+															<p style="color: rgb(0, 0, 0); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: normal; margin: 0px; line-height: 2;">
+                                Hello!<br />
+															<br />
+															Please complete signing up for you OpenStax Account by confirming your email address. Your pin is <b><%= @confirmation_pin %></b><br />
+															<br />
+															</p>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table  style="border: 0; width: 100%; border-collapse: collapse; mso-table-lspace:0pt;mso-table-rspace:0pt;">
+													<tbody>
+														<tr>
+															<td style="padding-top: 20px;padding-bottom: 20px;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+															<div style="word-break:break-word; border: 0; mso-border-alt: 0; text-align:center;">
+															<div style="display: inline-block; border: 0; mso-border-alt: 0;">
+                                <a href="<%= link_to @confirmation_url, @confirmation_url %>" style="direction:ltr;display:block;text-align:center;margin:0; font-family:Helvetica, Arial, Helvetica, sans-serif; font-size:16px; padding-top: 10px;padding-right: 20px;padding-bottom: 10px;padding-left: 20px; color:#ffffff;font-weight:normal;font-style:normal;text-decoration:none;border:0;background-color:#d4450c;border-radius:50px;mso-padding-alt:0;" target="_blank">
+                                  <span>Confirm Your Email Address</span>
+                                </a>
+                              </div>
+															</div>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width: 100%; border-collapse: collapse; word-break: break-word; font-size: 14px">
+													<tbody>
+														<tr>
+															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 50px;padding-bottom: 50px;padding-left: 50px;">
+															<div style="text-align: center; line-height: 2">
+                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.
+                              </div>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+										</tbody>
+									</table>
+									</td>
+								</tr>
+							</tbody>
+						</table>
 
-  <p>Your PIN: <b><%= @confirmation_pin %></b></p>
-
-  <p>If you have any trouble using this PIN, you can also click the link below to confirm your email address:</p>
-<% else %>
-  <p>Click on the link below to confirm your email address:</p>
-<% end %>
-
-<p><%= link_to @confirmation_url, @confirmation_url %></p>
-
-<p>We sent this message because someone is trying to use '<%= @email_value %>' to create an OpenStax account.  If this wasn't you, please disregard this message.</p>
-
-
-<%= render :partial => 'shared/email_closing' %>
+						<table cellpadding="0" cellspacing="0" class="contentbuilderBaseColumnRow" style="align-items: center; width: 100%; background-color:#f1f1f1;" width="100%">
+							<tbody>
+								<tr valign="middle">
+									<td class="columnCell" style="vertical-align: middle;display: inline-block; float:left" width="100%">
+									<table cellpadding="0" cellspacing="0" style="width: 100%; border-collapse: collapse; word-break:break-word;">
+										<tbody>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentregion" style="font-size:14px; width: 100%; border-collapse: collapse; word-break: break-word;">
+													<tbody>
+														<tr>
+															<td class="contentbuilder-html" style="padding: 0;">
+															<table style="width: 30%; margin: 2rem auto 0 auto;">
+																<tbody>
+																	<tr>
+																		<td style="text-align: center;">
+                                      <a href="https://www.facebook.com/openstax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1n/218812/1677769915zhNb62dS/Group_49.png" style="max-width: 100%; height: auto;" /></a>
+                                    </td>
+																		<td style="text-align: center;">
+                                      <a href="https://www.instagram.com/openstax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1v/218812/16777699377tuRGVJk/Vector.png" style="max-width: 100%; height: auto;" /></a>
+                                    </td>
+																		<td style="text-align: center;">
+                                      <a href="https://twitter.com/OpenStax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1r/218812/1677769928Hl4fgNGi/Vector_2.png" style="max-width: 100%; height: auto;" /></a>
+                                    </td>
+																	</tr>
+																</tbody>
+															</table>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width: 100%; border-collapse: collapse; word-break: break-word; font-size: 14px">
+													<tbody>
+														<tr>
+															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 20px;padding-bottom: 20px;">
+															<div style="text-align: center; font-size:11px; color:#6f6f6f; line-height: 2.5"><a href="https://openstax.org" style="font-weight: bold; color:#6f6f6f;">openstax.org</a><br />
+                                6100 Main St. MS-375 Houston, Texas 77005<br /></div>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+											<tr>
+												<td>
+												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width:100%; border-collapse: collapse; word-break:break-word;">
+													<tbody>
+														<tr>
+															<td align="center" style="padding-top: 20px;padding-bottom: 40px;">
+                                <a href="https://rice.edu" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MCD7V5TURECVAULPMT2H47VAHD5I?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 20%; object-fit: contain;" width="120" /></a>
+                              </td>
+														</tr>
+													</tbody>
+												</table>
+												</td>
+											</tr>
+										</tbody>
+									</table>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			</td>
+		</tr>
+	</tbody>
+</table>
+<img src="https://openstax.my.salesforce.com/servlet/servlet.ImageServer?oid=00DU0000000Kwch&esid=018Pc00000KtcU9&from=ext"></body>
+</html>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -124,8 +124,8 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 50px;padding-bottom: 50px;padding-left: 50px;">
 															<div style="text-align: center; line-height: 2">
-                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.<br /><br />
-																<small>If you did not signup for an OpenStax Account with the email <b><%= raw @email_value %></b>, please disregard this message.</small>
+                                If you need any assistance, please reach out to us at <a href="mailto:support@openstax.org">support@openstax.org</a>.<br />
+																<div style="font-size: 10px;">If you did not signup for OpenStax with the email <b style="text-decoration: none;"><%= @email_value %></b>, please disregard this message.</div>
                               </div>
 															</td>
 														</tr>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -61,7 +61,7 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 30px;padding-bottom: 10px;padding-left: 30px;">
 															<h1 style="color: rgb(17, 17, 17); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: bold; margin: 0px; text-align: center;">
-                                Confirm your email address
+                                Welcome to OpenStax!
                               </h1>
 															</td>
 														</tr>
@@ -88,7 +88,11 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 10px;padding-right: 30px;padding-bottom: 20px;padding-left: 30px;">
 															<p style="color: rgb(0, 0, 0); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: normal; margin: 0px; line-height: 2;">
-																<div style="text-align: center">Verify your email by clicking the button below or use your pin: <b><%= @confirmation_pin %></b></div>
+																<div style="text-align: center">
+																	<h3>Please confirm <%= @email_value %> is your email.</h3>
+																	<hr>
+																	Verify your email by clicking the button below or use your pin: <b><%= @confirmation_pin %></b>
+																</div>
 															</p>
 															</td>
 														</tr>
@@ -122,7 +126,8 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 30px;padding-right: 50px;padding-bottom: 50px;padding-left: 50px;">
 															<div style="text-align: center; line-height: 2">
-                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.
+                                If you need any assistance, please reply to this email at&nbsp;<a href="mailto:support@openstax.org">support@openstax.org</a>.<br>
+																<small>If you did not signup for an OpenStax Account with the email <%= @email_value %>, please disregard this message.</small>
                               </div>
 															</td>
 														</tr>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -88,10 +88,7 @@
 														<tr>
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 10px;padding-right: 30px;padding-bottom: 20px;padding-left: 30px;">
 															<p style="color: rgb(0, 0, 0); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: normal; margin: 0px; line-height: 2;">
-                                Hello!<br />
-															<br />
-															Please complete signing up for you OpenStax Account by confirming your email address. Your pin is <b><%= @confirmation_pin %></b><br />
-															<br />
+																<div style="text-align: center">Verify your email by clicking the button below or use your pin: <b><%= @confirmation_pin %></b></div>
 															</p>
 															</td>
 														</tr>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -108,7 +108,7 @@
 															<td style="padding-top: 20px;padding-bottom: 20px;mso-table-lspace:0pt;mso-table-rspace:0pt;">
 															<div style="word-break:break-word; border: 0; mso-border-alt: 0; text-align:center;">
 															<div style="display: inline-block; border: 0; mso-border-alt: 0;">
-                                <a href="<%= @confirmation_url %>" style="direction:ltr;display:block;text-align:center;margin:0; font-family:Helvetica, Arial, Helvetica, sans-serif; font-size:16px; padding-top: 10px;padding-right: 20px;padding-bottom: 10px;padding-left: 20px; color:#ffffff;font-weight:normal;font-style:normal;text-decoration:none;border:0;background-color:#d4450c;border-radius:50px;mso-padding-alt:0;" target="_blank">
+                                <a href="<%= @confirmation_url %>" id="confirm-link" style="direction:ltr;display:block;text-align:center;margin:0; font-family:Helvetica, Arial, Helvetica, sans-serif; font-size:16px; padding-top: 10px;padding-right: 20px;padding-bottom: 10px;padding-left: 20px; color:#ffffff;font-weight:normal;font-style:normal;text-decoration:none;border:0;background-color:#d4450c;border-radius:50px;mso-padding-alt:0;" target="_blank">
                                   <span>Confirm Your Email Address</span>
                                 </a>
                               </div>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -89,7 +89,7 @@
 															<td style="font-family: Arial, Helvetica, sans-serif;padding-top: 10px;padding-right: 30px;padding-bottom: 20px;padding-left: 30px;">
 															<p style="color: rgb(0, 0, 0); font-family: Helvetica, Arial, Helvetica, sans-serif; font-weight: normal; margin: 0px; line-height: 2;">
 																<div style="text-align: center">
-																	Verify your email by clicking the button below or use your pin: <b><%= @confirmation_pin %></b>
+																	Verify your email by clicking the button below or use your pin: <b id='pin'><%= @confirmation_pin %></b>
 																</div>
 															</p>
 															</td>

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -34,7 +34,8 @@
 													<tbody>
 														<tr>
 															<td align="center" style="padding-top: 15px;">
-                              <a href="<%= link_to @confirmation_url, @confirmation_url %>" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MC6BQDZRG2LJH63GGTYUS7JVML2E?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 30%; object-fit: contain;" width="180" /></a></td>
+                              <a href="<%= @confirmation_url %>" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MC6BQDZRG2LJH63GGTYUS7JVML2E?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 30%; object-fit: contain;" width="180" /></a>
+															</td>
 														</tr>
 													</tbody>
 												</table>
@@ -106,7 +107,7 @@
 															<td style="padding-top: 20px;padding-bottom: 20px;mso-table-lspace:0pt;mso-table-rspace:0pt;">
 															<div style="word-break:break-word; border: 0; mso-border-alt: 0; text-align:center;">
 															<div style="display: inline-block; border: 0; mso-border-alt: 0;">
-                                <a href="<%= link_to @confirmation_url, @confirmation_url %>" style="direction:ltr;display:block;text-align:center;margin:0; font-family:Helvetica, Arial, Helvetica, sans-serif; font-size:16px; padding-top: 10px;padding-right: 20px;padding-bottom: 10px;padding-left: 20px; color:#ffffff;font-weight:normal;font-style:normal;text-decoration:none;border:0;background-color:#d4450c;border-radius:50px;mso-padding-alt:0;" target="_blank">
+                                <a href="<%= @confirmation_url %>" style="direction:ltr;display:block;text-align:center;margin:0; font-family:Helvetica, Arial, Helvetica, sans-serif; font-size:16px; padding-top: 10px;padding-right: 20px;padding-bottom: 10px;padding-left: 20px; color:#ffffff;font-weight:normal;font-style:normal;text-decoration:none;border:0;background-color:#d4450c;border-radius:50px;mso-padding-alt:0;" target="_blank">
                                   <span>Confirm Your Email Address</span>
                                 </a>
                               </div>

--- a/spec/features/newflow/educator_signup_flow_spec.rb
+++ b/spec/features/newflow/educator_signup_flow_spec.rb
@@ -92,7 +92,7 @@ module Newflow
           expect(current_email).to be_truthy
 
           # ... with a link
-          verify_email_url = get_path_from_absolute_link(current_email, 'a')
+          verify_email_url = get_path_from_absolute_link(current_email, '#confirm-link')
           visit(verify_email_url)
 
           # Step 3

--- a/spec/features/newflow/student_signup_flow_spec.rb
+++ b/spec/features/newflow/student_signup_flow_spec.rb
@@ -27,8 +27,8 @@ module Newflow
       before do
         visit newflow_signup_path(r: '/external_app_for_specs')
         find('.join-as__role.student').click
-        fill_in 'signup_first_name',	with: 'Bryan'
-        fill_in 'signup_last_name',	with: 'Dimas'
+        fill_in 'signup_first_name',	with: 'Sally'
+        fill_in 'signup_last_name',	with: 'Port'
         fill_in 'signup_email',	with: email
         fill_in 'signup_password',	with: password
         submit_signup_form
@@ -43,10 +43,10 @@ module Newflow
 
       example 'verify email by clicking link in the email' do
         # ... with a link
-        verify_email_url = get_path_from_absolute_link(current_email, 'a')
+        verify_email_url = get_path_from_absolute_link(current_email, '#confirm-link')
         visit verify_email_url
         # ... which sends you to "sign up done page"
-        expect(page).to have_text(t(:"login_signup_form.youre_done", first_name: 'Bryan'))
+        expect(page).to have_text(t(:"login_signup_form.youre_done", first_name: 'Sally'))
         screenshot!
 
         # can exit and go back to the app they came from
@@ -62,7 +62,7 @@ module Newflow
         screenshot!
         click_on('commit')
         # ... which sends you to "sign up done page"
-        expect(page).to have_text(t(:"login_signup_form.youre_done", first_name: 'Bryan'))
+        expect(page).to have_text(t(:"login_signup_form.youre_done", first_name: 'Sally'))
         expect(page).to have_text(
           strip_html(t(:"login_signup_form.youre_done_description", email_address: email))
         )
@@ -106,8 +106,8 @@ module Newflow
   example 'arriving from Tutor (a Doorkeeper app)' do
       app = create_tutor_application
       visit_authorize_uri(app: app, params: { go: 'student_signup' })
-      fill_in 'signup_first_name',	with: 'Bryan'
-      fill_in 'signup_last_name',	with: 'Dimas'
+      fill_in 'signup_first_name',	with: 'Sally'
+      fill_in 'signup_last_name',	with: 'Port'
       fill_in 'signup_email',	with: email
       fill_in 'signup_password',	with: password
       submit_signup_form
@@ -126,7 +126,7 @@ module Newflow
         click_on('commit')
 
         # ... redirects you back to Tutor
-        expect(page).not_to have_text(t(:"login_signup_form.youre_done", first_name: 'Bryan'))
+        expect(page).not_to have_text(t(:"login_signup_form.youre_done", first_name: 'Sally'))
         expect(page.current_path).to eq('/external_app_for_specs')
     end
 
@@ -145,8 +145,8 @@ module Newflow
       example 'user gets PIN wrong' do
         visit newflow_signup_path(r: '/external_app_for_specs')
         find('.join-as__role.student').click
-        fill_in 'signup_first_name',	with: 'Bryan'
-        fill_in 'signup_last_name',	with: 'Dimas'
+        fill_in 'signup_first_name',	with: 'Sally'
+        fill_in 'signup_last_name',	with: 'Port'
         fill_in 'signup_email',	with: email
         fill_in 'signup_password',	with: password
         submit_signup_form
@@ -164,8 +164,8 @@ module Newflow
       example 'user can change their initial email during the signup flow' do
         visit newflow_signup_path(r: '/external_app_for_specs')
         find('.join-as__role.student').click
-        fill_in 'signup_first_name',	with: 'Bryan'
-        fill_in 'signup_last_name',	with: 'Dimas'
+        fill_in 'signup_first_name',	with: 'Sally'
+        fill_in 'signup_last_name',	with: 'Port'
         fill_in 'signup_email',	with: email
         fill_in 'signup_password',	with: password
         submit_signup_form
@@ -176,7 +176,7 @@ module Newflow
         # capture_email!(address: email)
         expect(current_email).to be_truthy
         old_pin = current_email.find('b').text
-        old_confirmation_code_url = get_path_from_absolute_link(current_email, 'a')
+        old_confirmation_code_url = get_path_from_absolute_link(current_email, '#confirm-link')
 
         # edit email
         click_on('edit your email')
@@ -199,7 +199,7 @@ module Newflow
         pin = current_email.find('b').text
         expect(pin).not_to eq(old_pin)
         # ...as well as a different confirmation code url
-        confirmation_code_url = get_path_from_absolute_link(current_email, 'a')
+        confirmation_code_url = get_path_from_absolute_link(current_email, '#confirm-link')
         expect(confirmation_code_url).not_to eq(old_confirmation_code_url)
 
         screenshot!

--- a/spec/features/newflow/student_signup_flow_spec.rb
+++ b/spec/features/newflow/student_signup_flow_spec.rb
@@ -57,7 +57,7 @@ module Newflow
 
       example 'verify email by entering PIN sent in the email' do
         # ... with a link
-        pin = current_email.find('b').text
+        pin = current_email.find('#pin').text
         fill_in('confirm_pin', with: pin)
         screenshot!
         click_on('commit')
@@ -120,7 +120,7 @@ module Newflow
       expect(current_email).to be_truthy
 
         # ... with a link
-        pin = current_email.find('b').text
+        pin = current_email.find('#pin').text
         fill_in('confirm_pin', with: pin)
         screenshot!
         click_on('commit')
@@ -175,7 +175,7 @@ module Newflow
         open_email email
         # capture_email!(address: email)
         expect(current_email).to be_truthy
-        old_pin = current_email.find('b').text
+        old_pin = current_email.find('#pin').text
         old_confirmation_code_url = get_path_from_absolute_link(current_email, '#confirm-link')
 
         # edit email
@@ -196,7 +196,7 @@ module Newflow
         # a different pin is sent in the edited email
         open_email new_email
         capture_email!(address: new_email)
-        pin = current_email.find('b').text
+        pin = current_email.find('#pin').text
         expect(pin).not_to eq(old_pin)
         # ...as well as a different confirmation code url
         confirmation_code_url = get_path_from_absolute_link(current_email, '#confirm-link')


### PR DESCRIPTION
This modifies the pin confirmation email to reflect the email templates being used for other communications from Salesforce/Pardot.

[DATA-140](https://openstax.atlassian.net/jira/software/projects/DATA/boards/19?selectedIssue=DATA-140)

[DATA-140]: https://openstax.atlassian.net/browse/DATA-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ