### PR TITLE
CORE-484 Ensure access tokens returned to Assignable have a minimum duration of 12 hours

### DIFF
--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -406,7 +406,10 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       sso_hash = SsoCookie.read sso_cookie
       expect(sso_hash['sub']).to eq Api::V1::UserRepresenter.new(new_user).to_hash
       expect(sso_hash['exp']).to be <= (
-        Time.current + Api::V1::UsersController::SSO_TOKEN_DURATION
+        Time.current + Api::V1::UsersController::SSO_TOKEN_INITIAL_DURATION
+      ).to_i
+      expect(sso_hash['exp']).to be >= (
+        Time.current + Api::V1::UsersController::SSO_TOKEN_MIN_DURATION
       ).to_i
 
       # Ensure the Doorkeeper token exists


### PR DESCRIPTION
To prevent random expired session errors.