### PR TITLE
Fix code scanning alert no. 21: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/config/initializers/database_url.rb
+++ b/config/initializers/database_url.rb
@@ -22,7 +22,7 @@ module DatabaseUrl
   end
 
   def self.db_config
-    config = YAML::load(ERB.new(IO.read(config_file)).result)
+    config = YAML::load(ERB.new(File.read(config_file)).result)
     config[env]
   end
 


### PR DESCRIPTION
Fixes [https://github.com/openstax/accounts/security/code-scanning/21](https://github.com/openstax/accounts/security/code-scanning/21)

To fix the problem, we need to replace the usage of `IO.read` with `File.read`. This change ensures that the code adheres to best practices and avoids potential security vulnerabilities associated with `IO.read`. The change is straightforward and does not alter the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
