### PR TITLE
Fix Doorkeeper scopes for user APIs

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -261,10 +261,12 @@ class Api::V1::UsersController < Api::V1::ApiController
   private
 
   def get_sso_token(application, user)
+    default_scopes = Doorkeeper.config.default_scopes.to_s
+
     access_token = Doorkeeper::AccessToken.find_or_create_for(
       application: application,
       resource_owner: user.id,
-      scopes: 'all',
+      scopes: default_scopes,
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false,
     )
@@ -278,7 +280,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     access_token = Doorkeeper::AccessToken.create_for(
       application: application.id,
       resource_owner: user.id,
-      scopes: 'all',
+      scopes: default_scopes,
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false
     )

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -264,7 +264,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     access_token = Doorkeeper::AccessToken.find_or_create_for(
       application: application,
       resource_owner: user.id,
-      scopes: '',
+      scopes: 'all',
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false,
     )
@@ -278,7 +278,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     access_token = Doorkeeper::AccessToken.create_for(
       application: application.id,
       resource_owner: user.id,
-      scopes: '',
+      scopes: 'all',
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false
     )


### PR DESCRIPTION
These need to match the default scopes configured in the initializer. I forgot to change them.

I'll also need to make another PR to fix keyword_search, which seems to be broken in dev