### PR TITLE
Fix user API scopes again

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -261,12 +261,10 @@ class Api::V1::UsersController < Api::V1::ApiController
   private
 
   def get_sso_token(application, user)
-    default_scopes = Doorkeeper.config.default_scopes.to_s
-
     access_token = Doorkeeper::AccessToken.find_or_create_for(
       application: application,
       resource_owner: user.id,
-      scopes: default_scopes,
+      scopes: Doorkeeper.config.default_scopes,
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false,
     )
@@ -280,7 +278,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     access_token = Doorkeeper::AccessToken.create_for(
       application: application.id,
       resource_owner: user.id,
-      scopes: default_scopes,
+      scopes: Doorkeeper.config.default_scopes,
       expires_in: SSO_TOKEN_INITIAL_DURATION,
       use_refresh_token: false
     )


### PR DESCRIPTION
Turns out you cannot call `to_s` on the scopes beforehand, otherwise it crashes at some point trying to call `.sort` on a string.