### PR TITLE
Disable gssencmode in the test env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -225,9 +225,11 @@ group :development, :test do
   # Codecov integration
   gem 'codecov', require: false
 
-  # Speedup and run specs when files change
+  # Speedup Rails boot time
   gem 'spring'
   gem 'spring-commands-rspec'
+
+  # Run specs when files change
   gem 'guard-rspec'
   gem 'guard-livereload', require: false
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,7 @@ test:
   <<: *default
   database: '<%= ENV['OXA_TEST_DB'] || 'ox_accounts_test' %><%=
                  "_#{ENV['TEST_ENV_NUMBER']}" if !ENV['TEST_ENV_NUMBER'].blank? %>'
+  <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %> # Prevent OS X OBJC crash
   reaping_frequency: 0 # 0 == disabled - incompatible with our DatabaseCleaner config
 
 production:


### PR DESCRIPTION
I already had this for dev but I also needed it in test to avoid a crash in OS X when running DB migrate etc commands in the test environment.