### PR TITLE
send language with lead creation

### DIFF
--- a/app/routines/newflow/create_or_update_salesforce_lead.rb
+++ b/app/routines/newflow/create_or_update_salesforce_lead.rb
@@ -146,11 +146,23 @@ module Newflow
       return nil unless user.books_used_details
 
       user.books_used_details.each do |book|
-         books_json << {
-          name: book[0],
+        book_value = book[0]
+        if book_value.match(/\[.*\]/)
+          book_name = book_value.gsub(/\[.*\]/, '').strip # Calculus Volume 1
+          book_language = book_value[/\[(.*?)\]/, 1] # Spanish (no brackets)
+          books_json << {
+            name: book_name,
+            students: book[1]["num_students_using_book"],
+            howUsing: book[1]["how_using_book"],
+            language: book_language,
+          }
+        else
+          books_json << {
+          name: book_value,
           students: book[1]["num_students_using_book"],
           howUsing: book[1]["how_using_book"]
         }
+        end
       end
 
       adoption_json['Books'] = books_json


### PR DESCRIPTION
If the book is foreign, we track that by appending the language to the book name in brackets - `Calculus Volume 1 [Spanish]`

This breaks that out from the book name and sends it with the adoptionJSON