### PR TITLE
Remove spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -225,10 +225,6 @@ group :development, :test do
   # Codecov integration
   gem 'codecov', require: false
 
-  # Speedup Rails boot time
-  gem 'spring'
-  gem 'spring-commands-rspec'
-
   # Run specs when files change
   gem 'guard-rspec'
   gem 'guard-livereload', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -761,9 +761,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    spring (4.2.1)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -923,8 +920,6 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers
   smarter_csv
-  spring
-  spring-commands-rspec
   timecop
   uglifier
   vcr

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -65,7 +65,7 @@ module HandleFailedJobInstantly
     job.fail! if fail_proc.present? && fail_proc.call(exception) ||
                  exception.try(:instantly_fail_if_in_background_job?)
 
-                 super(job, exception)
+    super(job, exception)
   end
 end
 


### PR DESCRIPTION
Spring is used to speedup local dev. However, it seems spring prevents environment variables from being reloaded. For example, after you launch once, then `USE_REAL_BACKGROUND_JOBS=true bin/rails c` won't actually set that ENV variable unless you run `spring stop` first. To prevent headaches, just remove spring.