### PR TITLE
reintroduce rails-settings-ui

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,8 @@ gem 'whenever', require: false
 
 # Admin toggles
 gem 'rails-settings-cached'
+# Using a fork of rails-settings-ui that has a fix for Ruby 3+
+gem 'rails-settings-ui', github: 'mwvolo/rails-settings-ui'
 
 # Respond to ELB healthchecks in /ping and /ping/
 gem 'openstax_healthcheck'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/mwvolo/rails-settings-ui.git
+  revision: 9b97fa39e803816e1655633ed08962149b2958a4
+  specs:
+    rails-settings-ui (2.0.0)
+      i18n
+      rails (>= 3.3)
+      rails-settings-cached (>= 2.0.0)
+
+GIT
   remote: https://github.com/openstax/intl-tel-input-rails.git
   revision: 3a63a495822d90bc9ca93e9541ef252fd7a0b50b
   branch: master
@@ -884,6 +893,7 @@ DEPENDENCIES
   rails-erd
   rails-i18n
   rails-settings-cached
+  rails-settings-ui!
   redis-rails
   representable
   rexml

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -61,6 +61,9 @@
             </li>
 
             <li><%= link_to 'Terms', main_app.routes.url_helpers.fine_print_path %></li>
+            <li><a href="/admin/settings">Settings</a></li>
+            <li><%= link_to "OAuth Admin", main_app.routes.url_helpers.oauth_applications_path, target: '_blank' %></li>
+            <li><a href="/admin/blazer" target="_blank">Blazer</a></li>
 
 <% if false %>
             <li class="dropdown">

--- a/config/initializers/rails_settings_ui.rb
+++ b/config/initializers/rails_settings_ui.rb
@@ -1,0 +1,18 @@
+require 'rails-settings-ui'
+
+RailsSettingsUi.setup do |config|
+  # Specify a controller for RailsSettingsUi::ApplicationController to inherit from:
+  config.parent_controller = 'Admin::BaseController' # default: '::ApplicationController'
+
+  config.settings_class = 'Settings::Db::Store'
+end
+
+Rails.application.config.to_prepare do
+  # If you use a *custom layout*, make route helpers available to RailsSettingsUi:
+  # RailsSettingsUi.inline_engine_routes!
+  RailsSettingsUi::ApplicationController.module_eval do
+    # Render RailsSettingsUi inside a custom layout
+    # (set to 'application' to use app layout, default is RailsSettingsUi's own layout)
+    layout 'admin'
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -396,6 +396,45 @@ en:
       apology_message_long_html: >-
         If you need help, please contact %{contact_info} and reference error %{error_id}.
 
+  settings:
+    attributes:
+      subjects:
+        name: Subjects
+        help_block: List of subjects that teachers choose from whe signing up
+      push_salesforce_lead_enabled:
+        name: 'Push leads to Salesforce?'
+        help_block: 'If checked (and SF configured), new accounts will be pushed to SF as Leads'
+      show_support_chat:
+        name: 'Show support chat widget'
+        help_block: 'If checked users will see CS chat widget'
+      user_info_error_emails_enabled:
+        name: 'Enable user info update error emails?'
+        help_block: 'If checked (and SF configured), once-a-day user update error emails will go out'
+      send_google_analytics:
+        name: 'Send Google Analytics data?'
+        help_block: 'If checked Google Analytics data will be sent.'
+      google_analytics_code:
+        name: 'Google Analytics Code'
+        help_block: 'Example: UA-XXXXXXXX-X'
+      google_tag_manager_code:
+        name: 'Google Tag Manager Code'
+        help_block: 'Example: GTM-XXXX'
+      student_feature_flag:
+        name: New student flow feature flag
+        help_block: New student flow activated?
+      educator_feature_flag:
+        name: New educator flow feature flag
+        help_block: New educator flow activated?
+      sheer_id_base_url:
+        name: SheerID base URL
+        help_block: >-
+          ie. https://offers.sheerid.com/openstax/staging/teacher/?env=dev
+          With the parameters that pre-populate the SheerID form, the full URL will look like
+          ie. https://offers.sheerid.com/openstax/staging/teacher/?env=dev&first_name=Elon&last_name=Musk&email=ceo@spacex.com
+      number_of_days_contacts_modified:
+        name: Contacts modified in last x days
+        help_block: Retrieve contacts modified in the last X days in update_user_salesforce_info
+
   layouts:
     application_footer:
       terms_of_use: Terms of Use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,7 @@ Rails.application.routes.draw do
     resources :external_ids, only: [:destroy]
 
     mount Blazer::Engine, at: "blazer", as: 'blazer_admin'
+    mount RailsSettingsUi::Engine, at: 'settings'
   end
 
   namespace 'dev' do

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -18,7 +18,7 @@ module Settings
     class Store < RailsSettings::Base
       field :push_salesforce_lead_enabled, type: :boolean, default: false
       field :user_info_error_emails_enabled, type: :boolean, default: false
-      field :show_support_chat, type: :boolean, default: true
+      field :show_support_chat, type: :boolean, default: false
       field :send_google_analytics, type: :boolean, default: false
       field :google_analytics_code, type: :string, default: 'UA-73668038-2'
       field :google_tag_manager_code, type: :string, default: 'GTM-W6N7PB'


### PR DESCRIPTION
I made a fork of rails-settings-ui and got it working for Ruby 3.
Not necessary, but would help with the setting being used to show the chat widget (so we can easily disable if support load is too high).