### PR TITLE
Core-889: Set page title for login and signup pages

### DIFF
--- a/app/views/layouts/newflow_layout.html.erb
+++ b/app/views/layouts/newflow_layout.html.erb
@@ -13,7 +13,7 @@
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
         <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
-        <title>OpenStax Accounts</title>
+        <title><%= @page_title + ' - ' unless @page_title.nil? %><%= PAGE_TITLE_SUFFIX %></title>
 
         <% unless Rails.env.test? %>
           <%= render partial: 'layouts/posthog' %>

--- a/app/views/newflow/educator_signup/educator_profile_form.html.erb
+++ b/app/views/newflow/educator_signup/educator_profile_form.html.erb
@@ -11,6 +11,7 @@
       ]
     %>
 
+    <% @page_title = 'Sign up (complete profile)' %>
     <%= render partial: 'newflow/tab_group', locals: { active_class: 'signup--active'} %>
 
     <%= newflow_login_signup_card(

--- a/app/views/newflow/educator_signup/educator_sheerid_form.html.erb
+++ b/app/views/newflow/educator_signup/educator_sheerid_form.html.erb
@@ -1,4 +1,5 @@
 <%= render 'newflow/educator_signup/refresh_upon_going_back' %>
+<% @page_title = 'Sign up (verify instructor)' %>
 
 <div id="login-signup-form">
   <div class="content educator-sheerid-form-page">

--- a/app/views/newflow/educator_signup/educator_signup_form.html.erb
+++ b/app/views/newflow/educator_signup/educator_signup_form.html.erb
@@ -7,6 +7,7 @@
     # TODO: show them in a modal instead of new tab
     # link_to contract.title, term_path(contract), remote: true
   }
+  @page_title = 'Sign up (educator)'
 %>
 
 <%= render 'newflow/educator_signup/refresh_upon_going_back' %>

--- a/app/views/newflow/login/login_form.html.erb
+++ b/app/views/newflow/login/login_form.html.erb
@@ -13,7 +13,10 @@
                     banners: @banners,
                     show_exit_icon: true) do %>
             <% lev_form_for :login_form, url: newflow_login_path do |f| %>
-                <% fh = NewflowFormHelper::Newflow.new(f: f, context: self, errors: @handler_result&.errors) %>
+                <%
+                    fh = NewflowFormHelper::Newflow.new(f: f, context: self, errors: @handler_result&.errors)
+                    @page_title = 'Log in'
+                %>
                     <div class="content social-section">
                         <div><%= I18n.t(:"login_signup_form.login_with") %></div>
 

--- a/app/views/newflow/signup/_email_verification_form_template.html.erb
+++ b/app/views/newflow/signup/_email_verification_form_template.html.erb
@@ -15,6 +15,7 @@
                         context: self,
                         errors: @handler_result&.errors
                     )
+                    @page_title = 'Sign up (confirm email)'
                 %>
 
                 <div class="content info-message">

--- a/app/views/newflow/signup/signup_done.html.erb
+++ b/app/views/newflow/signup/signup_done.html.erb
@@ -5,6 +5,7 @@
     :"login_signup_form.youre_done_description",
     email_address: @email_address
   ).html_safe
+  @page_title = 'Sign up (done)'
 %>
 
 <%=

--- a/app/views/newflow/signup/welcome.html.erb
+++ b/app/views/newflow/signup/welcome.html.erb
@@ -17,6 +17,7 @@
                         context: self,
                         errors: @handler_result&.errors
                     )
+                    @page_title = 'Sign up'
                 %>
                 <div class="content">
                     <div class="join-as">

--- a/app/views/newflow/student_signup/student_signup_form.html.erb
+++ b/app/views/newflow/student_signup/student_signup_form.html.erb
@@ -7,6 +7,8 @@
         # TODO: show them in a modal instead of new tab
         # link_to contract.title, term_path(contract), remote: true
     }
+
+    @page_title = 'Sign up (student)'
 %>
 
 <div id="login-signup-form">


### PR DESCRIPTION
[CORE-889]
I added titles for the Sign in and Sign up welcome pages, as well as each step of the sign up for Instructors.
There might be other pages whose titles need set.

[CORE-889]: https://openstax.atlassian.net/browse/CORE-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ