### PR TITLE
use ubuntu-latest for GH workflow runs

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   assets:
     timeout-minutes: 30
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   migrations:
     timeout-minutes: 30
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   tests:
     timeout-minutes: 30
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:11


### PR DESCRIPTION
the test are randomly failing (and will completely stop tomorrow)
see here for details: https://github.com/actions/runner-images/issues/11101