### PR TITLE
CORE-981: Privacy policy styling

### DIFF
--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -310,6 +310,10 @@ input.has-error {
     margin: 0 auto;
 }
 
+.flush-left p {
+    padding-left: 0;
+}
+
 .policy {
     max-width: 800px;
     margin: 20px auto;

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,5 +1,4 @@
-<% @page_title = @contract.title %>
-<%= ox_card(classes: "center") do %>
+<%= ox_card(classes: "flush-left") do %>
 
   <div class="policy">
     <%= @contract.content.html_safe %>


### PR DESCRIPTION
[CORE-981]
Instead of just making the bullet list left-justified, I replaced the center class with a new flush-left class that removes the paragraph-indent that it would otherwise have. This styles the Privacy and Terms pages closer to what is on osweb.

[CORE-981]: https://openstax.atlassian.net/browse/CORE-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ