### PR TITLE
CORE-982: Set page title for terms and privacy pages

### DIFF
--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,6 +1,7 @@
 <%# Copyright 2011-2016 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
+<% @page_title = 'Site Terms' %>
 <%= ox_card(heading: (t :".page_heading"), classes: "center") do %>
 
   <% contract_links = @contracts.collect do |contract|

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,3 +1,4 @@
+<% @page_title = @contract.title %>
 <%= ox_card(classes: "center") do %>
 
   <div class="policy">


### PR DESCRIPTION
[CORE-982]
Title is set for Terms of Use, Privacy Policy, and the parent page, which is titled Site Terms