### PR TITLE
CORE-983: Error handling for login page fields

### DIFF
--- a/app/helpers/newflow_form_helper.rb
+++ b/app/helpers/newflow_form_helper.rb
@@ -62,7 +62,9 @@ module NewflowFormHelper
                       onkeyup: onkeyup,
                       onkeydown: onkeydown,
                       disabled: disabled,
-                      'aria-required': required
+                      'aria-required': required,
+                      'aria-errormessage': errors_div.present? ? "errors-for-#{name}" : nil,
+                      'aria-invalid': errors_div.present? ? true : nil
         )
       else
         input = (

--- a/app/helpers/newflow_form_helper.rb
+++ b/app/helpers/newflow_form_helper.rb
@@ -77,9 +77,10 @@ module NewflowFormHelper
                       onkeyup: onkeyup,
                       onkeydown: onkeydown,
                       disabled: disabled,
-                      list: list,
-                      'aria-describedby': described,
-                      'aria-required': required
+                      'aria-described-by': described,
+                      'aria-required': required,
+                      'aria-errormessage': errors_div.present? ? "errors-for-#{name}" : nil,
+                      'aria-invalid': errors_div.present? ? true : nil
         )
       end
       "#{input}\n#{errors_div}".html_safe
@@ -128,7 +129,7 @@ module NewflowFormHelper
 
       return '' if field_errors.empty?
 
-      c.content_tag(:div, class: "errors invalid-message") do
+      c.content_tag(:div, class: "errors invalid-message", id: "errors-for-#{name}") do
         # TODO: show multiple error messages per field when the pattern-library is fixed.
         error_divs = field_errors.map do |field_error|
           field_error.translate.html_safe


### PR DESCRIPTION
[CORE-983]
[CORE-985]
When they have errors, email and password fields will have `aria-invalid=true` and `aria-errormessage` attributes set
Rolled 985 in here because the changes are closely related and share code.

[CORE-983]: https://openstax.atlassian.net/browse/CORE-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-985]: https://openstax.atlassian.net/browse/CORE-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ