### PR TITLE
CORE-986: Fix color contrast of signup heading

### DIFF
--- a/app/assets/javascripts/newflow/newflow_ui.js.coffee
+++ b/app/assets/javascripts/newflow/newflow_ui.js.coffee
@@ -2,17 +2,11 @@ NewflowUi = do () ->
   disableButton: (selector) ->
     $(selector).attr('disabled', 'disabled')
     $(selector).addClass('ui-state-disabled ui-button-disabled')
-    $(selector).css({
-        'background': '#ccc',
-        'box-shadow': 'none',
-        'color': '#666'
-      })
 
   enableButton: (selector) ->
     $(selector).removeAttr('disabled')
     $(selector).removeClass('ui-state-disabled ui-button-disabled')
     $(selector).button()
-    $(selector).css({ 'background': '', 'box-shadow': '', 'color': '' })
 
   renderAndOpenDialog: (html_id, content, modal_options = {}) ->
     if $('#' + html_id).exists() then $('#' + html_id).remove()

--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -674,7 +674,7 @@ $very-narrow: 37rem * $scale-factor;
             padding-right: 0;
 
             background-color: #f1f1f1;
-            color: #c1c1c1;
+            color: #666666;
 
             @include title-font(2.4rem);
             text-align: center;
@@ -774,10 +774,12 @@ $very-narrow: 37rem * $scale-factor;
 
     input[type=submit] {
         &:disabled {
+            background-color: #ccc;
+            box-shadow: none;
+            color: #666;
             opacity: 0.85;
         }
 
-        -webkit-appearance: none;
         border-radius: 0;
     }
 }

--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -223,7 +223,7 @@ label.required::after {
         top: 3.7rem;
         right: 1.8rem;
 
-        color: #027EB5;
+        color: #0070af;
         font-weight: bold;
         cursor: pointer;
 

--- a/app/views/newflow/login/login_form.html.erb
+++ b/app/views/newflow/login/login_form.html.erb
@@ -93,7 +93,8 @@
                     <%= f.submit I18n.t(:"login_signup_form.continue_button"),
                                 disable_with: I18n.t(:"login_signup_form.continue_button"),
                                 class: 'primary',
-                                data: { ga_category: 'Login', ga_action: 'Click', ga_label: 'Email' }
+                                data: { ga_category: 'Login', ga_action: 'Click', ga_label: 'Email' },
+                                disabled: 'disabled'
                     %>
                 </div>
 
@@ -118,5 +119,18 @@
 
 <script type="text/javascript">
     NewflowUi.focusOnFirstErrorItem();
+    const $requiredInputs = $('form input[aria-required="true"]');
+    const handleDisable = () => {
+        const disableSubmit = $requiredInputs.toArray().some((i) => i.value.length == 0);
+
+        if (disableSubmit) {
+            NewflowUi.disableButton('form [type="submit"]');
+        } else {
+            NewflowUi.enableButton('form [type="submit"]');
+        }    
+    }
+
+    $requiredInputs.on('input', handleDisable);
+    handleDisable();
 </script>
 

--- a/spec/features/newflow/user_cant_sign_in_spec.rb
+++ b/spec/features/newflow/user_cant_sign_in_spec.rb
@@ -17,11 +17,7 @@ feature "User can't sign in", js: true do
       screenshot!
     end
 
-    scenario "email blank" do
-      newflow_log_in_user('', 'password')
-      expect(page).to have_content(error_msg Newflow::LogInUser, :email, :blank)
-      screenshot!
-    end
+    # Removed test for blank email; blank email is not allowed
 
     scenario "multiple accounts match email but no usernames" do
       # For a brief window in 2017 users could sign up with jimbo@gmail.com and Jimbo@gmail.com


### PR DESCRIPTION
[CORE-986]
[CORE-1047]
New color contrast ratio is 5.
Also moved the disabled-submit styling to CSS
Also added some JS to control the disabled state of the Continue button on login.

For 1047, new color contrast ratio is at least 4.5.

[CORE-986]: https://openstax.atlassian.net/browse/CORE-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-1047]: https://openstax.atlassian.net/browse/CORE-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
