### PR TITLE
CORE-1736: use ExternalIdRepresenter decorator for external_ids in UserRepresenter

### DIFF
--- a/app/representers/api/v1/external_id_representer.rb
+++ b/app/representers/api/v1/external_id_representer.rb
@@ -4,7 +4,7 @@ module Api::V1
 
     property :user_id,
              type: Integer,
-             readable: true,
+             readable: false,
              writeable: true
 
     property :external_id,

--- a/app/representers/api/v1/find_or_create_user_representer.rb
+++ b/app/representers/api/v1/find_or_create_user_representer.rb
@@ -21,13 +21,12 @@ module Api::V1
              }
 
     collection :external_ids,
-               type: String,
                readable: true,
                writeable: false,
                schema_info: {
                  description: "The user's external_ids"
                },
-               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
+               decorator: ExternalIdRepresenter
 
     property :username,
              type: String,

--- a/app/representers/api/v1/find_user_representer.rb
+++ b/app/representers/api/v1/find_user_representer.rb
@@ -31,13 +31,12 @@ module Api::V1
              }
 
     collection :external_ids,
-               type: String,
                readable: true,
                writeable: false,
                schema_info: {
                  description: "The user's external_ids"
                },
-               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
+               decorator: ExternalIdRepresenter
 
     property :is_test,
              type: :boolean,

--- a/app/representers/api/v1/user_representer.rb
+++ b/app/representers/api/v1/user_representer.rb
@@ -184,11 +184,10 @@ module Api::V1
                getter: ->(*) { FinePrint::Contract.published.latest.signed_by(self).pluck(:name) }
 
     collection :external_ids,
-               type: String,
                readable: true,
                writeable: false,
                if: ->(user_options:, **) { user_options.try(:fetch, :include_private_data, false) },
-               getter: ->(represented:, **) { represented.external_ids.map(&:external_id) }
+               decorator: ExternalIdRepresenter
 
     property :assignable_school_integrated,
              type: :boolean,

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -301,12 +301,13 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                 trusted_application_token,
                 body: valid_external_id_body
       expect(response).to have_http_status :ok
-      expect(response.body_as_hash).to match(
-        external_ids: [ external_id.external_id ],
-        id: user.id,
-        sso: kind_of(String),
-        uuid: user.uuid
-      )
+      response_hash = response.body_as_hash
+      expect(response_hash[:id]).to eq user.id
+      expect(response_hash[:uuid]).to eq user.uuid
+      expect(response_hash[:sso]).to be_kind_of(String)
+      expect(response_hash[:external_ids]).to be_a(Array)
+      expect(response_hash[:external_ids].length).to eq 1
+      expect(response_hash[:external_ids].first[:external_id]).to eq external_id.external_id
     end
 
     it "should find a user by uuid for a trusted app" do
@@ -314,11 +315,12 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                 trusted_application_token,
                 body: valid_uuid_body
       expect(response).to have_http_status :ok
-      expect(response.body_as_hash).to match(
-        external_ids: [ external_id.external_id ],
-        id: user.id,
-        uuid: user.uuid
-      )
+      response_hash = response.body_as_hash
+      expect(response_hash[:id]).to eq user.id
+      expect(response_hash[:uuid]).to eq user.uuid
+      expect(response_hash[:external_ids]).to be_a(Array)
+      expect(response_hash[:external_ids].length).to eq 1
+      expect(response_hash[:external_ids].first[:external_id]).to eq external_id.external_id
     end
 
     it "should not find a user that does not exist" do
@@ -400,7 +402,9 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       end.to change { User.count }.by(1)
       expect(response.code).to eq('201')
       parsed_response = JSON.parse(response.body)
-      expect(parsed_response['external_ids']).to eq [ external_id ]
+      expect(parsed_response['external_ids']).to be_a(Array)
+      expect(parsed_response['external_ids'].length).to eq 1
+      expect(parsed_response['external_ids'].first['external_id']).to eq external_id
 
       new_user = User.find(parsed_response['id'])
       expect(new_user.external_ids.first.external_id).to eq external_id

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -307,7 +307,10 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       expect(parsed_response['sso']).to be_kind_of(String)
       expect(parsed_response['external_ids']).to be_a(Array)
       expect(parsed_response['external_ids'].length).to eq 1
-      expect(parsed_response['external_ids'].first['external_id']).to eq external_id.external_id
+      # external_ids is a collection of objects with user_id, external_id, and role
+      external_id_obj = parsed_response['external_ids'].first
+      expect(external_id_obj).to be_a(Hash)
+      expect(external_id_obj['external_id']).to eq external_id.external_id
     end
 
     it "should find a user by uuid for a trusted app" do
@@ -320,7 +323,10 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       expect(parsed_response['uuid']).to eq user.uuid
       expect(parsed_response['external_ids']).to be_a(Array)
       expect(parsed_response['external_ids'].length).to eq 1
-      expect(parsed_response['external_ids'].first['external_id']).to eq external_id.external_id
+      # external_ids is a collection of objects with user_id, external_id, and role
+      external_id_obj = parsed_response['external_ids'].first
+      expect(external_id_obj).to be_a(Hash)
+      expect(external_id_obj['external_id']).to eq external_id.external_id
     end
 
     it "should not find a user that does not exist" do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -301,13 +301,13 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                 trusted_application_token,
                 body: valid_external_id_body
       expect(response).to have_http_status :ok
-      response_hash = response.body_as_hash
-      expect(response_hash[:id]).to eq user.id
-      expect(response_hash[:uuid]).to eq user.uuid
-      expect(response_hash[:sso]).to be_kind_of(String)
-      expect(response_hash[:external_ids]).to be_a(Array)
-      expect(response_hash[:external_ids].length).to eq 1
-      expect(response_hash[:external_ids].first[:external_id]).to eq external_id.external_id
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['id']).to eq user.id
+      expect(parsed_response['uuid']).to eq user.uuid
+      expect(parsed_response['sso']).to be_kind_of(String)
+      expect(parsed_response['external_ids']).to be_a(Array)
+      expect(parsed_response['external_ids'].length).to eq 1
+      expect(parsed_response['external_ids'].first['external_id']).to eq external_id.external_id
     end
 
     it "should find a user by uuid for a trusted app" do
@@ -315,12 +315,12 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
                 trusted_application_token,
                 body: valid_uuid_body
       expect(response).to have_http_status :ok
-      response_hash = response.body_as_hash
-      expect(response_hash[:id]).to eq user.id
-      expect(response_hash[:uuid]).to eq user.uuid
-      expect(response_hash[:external_ids]).to be_a(Array)
-      expect(response_hash[:external_ids].length).to eq 1
-      expect(response_hash[:external_ids].first[:external_id]).to eq external_id.external_id
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['id']).to eq user.id
+      expect(parsed_response['uuid']).to eq user.uuid
+      expect(parsed_response['external_ids']).to be_a(Array)
+      expect(parsed_response['external_ids'].length).to eq 1
+      expect(parsed_response['external_ids'].first['external_id']).to eq external_id.external_id
     end
 
     it "should not find a user that does not exist" do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Api::V1::UsersController, type: :controller, api: true, version: 
       end.to change { ExternalId.count }.by(1)
       expect(response).to have_http_status :created
       expect(response.body_as_hash).to eq(
-        user_id: valid_body[:user_id], external_id: valid_body[:external_id], role: 'unknown_role'
+        external_id: valid_body[:external_id], role: 'unknown_role'
       )
     end
 

--- a/spec/representers/api/v1/external_id_representer_spec.rb
+++ b/spec/representers/api/v1/external_id_representer_spec.rb
@@ -5,8 +5,8 @@ describe Api::V1::ExternalIdRepresenter, type: :representer do
   subject(:representer) { described_class.new external_id }
 
   context 'user_id' do
-    it 'can be read' do
-      expect(representer.to_hash['user_id']).to eq external_id.user_id
+    it 'cannot be read' do
+      expect(representer.to_hash).not_to have_key('user_id')
     end
 
     it 'can be written' do

--- a/spec/representers/api/v1/find_user_representer_spec.rb
+++ b/spec/representers/api/v1/find_user_representer_spec.rb
@@ -46,12 +46,18 @@ describe Api::V1::FindUserRepresenter, type: :representer do
 
   context 'external_ids' do
     it 'can be read' do
-      payload.external_ids = [ Hashie::Mash.new(external_id: SecureRandom.uuid) ]
-      expect(representer.to_hash['external_ids']).to eq payload.external_ids.map(&:external_id)
+      external_id_obj = Hashie::Mash.new(user_id: 1, external_id: SecureRandom.uuid, role: 'student')
+      payload.external_ids = [ external_id_obj ]
+      result = representer.to_hash['external_ids']
+      expect(result).to be_a(Array)
+      expect(result.length).to eq 1
+      expect(result.first['external_id']).to eq external_id_obj.external_id
+      expect(result.first['user_id']).to eq external_id_obj.user_id
+      expect(result.first['role']).to eq external_id_obj.role
     end
 
     it 'cannot be written (attempts are silently ignored)' do
-      hash = { 'external_ids' => [ SecureRandom.uuid ] }
+      hash = { 'external_ids' => [ { 'external_id' => SecureRandom.uuid } ] }
 
       expect(payload).not_to receive(:external_ids=)
       expect { representer.from_hash(hash) }.not_to change { payload.external_ids }

--- a/spec/representers/api/v1/find_user_representer_spec.rb
+++ b/spec/representers/api/v1/find_user_representer_spec.rb
@@ -52,7 +52,7 @@ describe Api::V1::FindUserRepresenter, type: :representer do
       expect(result).to be_a(Array)
       expect(result.length).to eq 1
       expect(result.first['external_id']).to eq external_id_obj.external_id
-      expect(result.first['user_id']).to eq external_id_obj.user_id
+      expect(result.first).not_to have_key('user_id')
       expect(result.first['role']).to eq external_id_obj.role
     end
 

--- a/spec/support/user_hash.rb
+++ b/spec/support/user_hash.rb
@@ -43,7 +43,11 @@ def user_matcher(user, include_private_data: false)
           end
         )
     base_hash[:signed_contract_names] = FinePrint::Contract.published.latest.signed_by(user).pluck(:name)
-    base_hash[:external_ids] = a_collection_containing_exactly(*user.external_ids.map(&:external_id))
+    base_hash[:external_ids] = a_collection_containing_exactly(
+      *user.external_ids.map do |external_id|
+        Api::V1::ExternalIdRepresenter.new(external_id).to_hash.symbolize_keys
+      end
+    )
     base_hash[:assignable_school_integrated] = user.school.has_assignable_contacts
     base_hash[:assignable_user] = user.external_ids.any?
   end


### PR DESCRIPTION
Related with: [CORE-1736]

[CORE-1736]: https://openstax.atlassian.net/browse/CORE-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ