### PR TITLE
newflow layout for error templates

### DIFF
--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -1091,3 +1091,45 @@ $very-narrow: 37rem * $scale-factor;
   pointer-events: none;
   cursor: not-allowed;
 }
+
+.error-page {
+    .page-header {
+        border-left: 0.1rem solid #d5d5d5;
+        border-right: 0.1rem solid #d5d5d5;
+        border-top: 0.1rem solid #d5d5d5;
+        border-top-left-radius: 0.3rem;
+        border-top-right-radius: 0.3rem;
+        text-align: center;
+        padding: 4rem 2rem 2rem;
+
+        @include width-up-to($phone-max) {
+            @include set-font(h4);
+            line-height: 3rem;
+            padding: 2rem 1rem 1rem;
+        }
+
+        @include wider-than($phone-max) {
+            @include set-font(h2);
+            margin: 0;
+        }
+    }
+
+    .error-page-body {
+        background-color: white;
+        border: 0.1rem solid #d5d5d5;
+        border-top: 0;
+        border-bottom-left-radius: 0.3rem;
+        border-bottom-right-radius: 0.3rem;
+        padding: 3rem;
+        text-align: center;
+
+        @include width-up-to($phone-max) {
+            padding: 2rem 1rem;
+        }
+
+        p {
+            max-width: 55.5rem;
+            margin: 0 auto;
+        }
+    }
+}

--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -86,7 +86,7 @@ module Newflow
           @first_name = unverified_user.first_name
           @email = unverified_user.email_addresses.first.value
           security_log(:student_verify_email_failed, email: @email)
-          render(:email_verification_form)
+          render(:student_email_verification_form)
         }
       )
     end

--- a/app/views/errors/any.html.erb
+++ b/app/views/errors/any.html.erb
@@ -1,14 +1,20 @@
-<% content_for :application_body do %>
-  <h3 class='rescue-from'><%= @message %> (<%= @code %>)</h3>
+<div id="login-signup-form" class="without-tabs">
+  <div class="content">
+    <div class="error-page">
+      <h1 class="page-header"><%= @message %> (<%= @code %>)</h1>
 
-  <p class='rescue-from'>
-    <% if @error_id and @did_notify %>
-      <%= t :".apology_message_long_html", code: @code,
-                                           contact_info: openstax_rescue_from_contact_info,
-                                           error_id: @error_id %>
-    <% else %>
-      <%= t :".apology_message_html", code: @code,
-                                      contact_info: openstax_rescue_from_contact_info %>
-    <% end %>
-  </p>
-<% end %>
+      <div class="error-page-body">
+        <p>
+          <% if @error_id and @did_notify %>
+            <%= t :".apology_message_long_html", code: @code,
+                                                 contact_info: openstax_rescue_from_contact_info,
+                                                 error_id: @error_id %>
+          <% else %>
+            <%= t :".apology_message_html", code: @code,
+                                            contact_info: openstax_rescue_from_contact_info %>
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/errors/static.html.erb
+++ b/app/views/errors/static.html.erb
@@ -1,18 +1,26 @@
 <% content_for :stylesheet_tag do %>
-  <%= view.stylesheet_link_tag 'application' %>
+  <%= view.stylesheet_link_tag 'newflow' %>
 <% end %>
 
-<% content_for :application_body do %>
-  <div class="ox-card">
-    <h3 class='rescue-from'><%= message %> (<%= code %>)</h3>
-
-    <p class='rescue-form'>
-      <%= t :"errors.any.apology_message_html", code: code,
-                                                contact_info: openstax_rescue_from_contact_info %>
-    </p>
-  </div>
+<% content_for :logo_image do %>
+  <%= view.image_tag 'openstax-logo.svg', class: 'logo-color', alt: 'OpenStax logo' %>
 <% end %>
 
 <% content_for :rice_logo do %>
-  <%= view.image_tag 'rice_logo_reversed.png', id: "footer-rice-logo-image" %>
+  <%= view.image_tag 'rice_logo.svg', id: "footer-rice-logo-image", alt: "Rice University logo" %>
 <% end %>
+
+<div id="login-signup-form" class="without-tabs">
+  <div class="content">
+    <div class="error-page">
+      <h1 class="page-header"><%= message %> (<%= code %>)</h1>
+
+      <div class="error-page-body">
+        <p>
+          <%= t :"errors.any.apology_message_html", code: code,
+                                                    contact_info: openstax_rescue_from_contact_info %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/newflow_error.html.erb
+++ b/app/views/layouts/newflow_error.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+        <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+        <title><%= @page_title + ' - ' unless @page_title.nil? %><%= PAGE_TITLE_SUFFIX %></title>
+
+        <%= stylesheet_link_tag 'newflow', media: 'all' %>
+        <%= csrf_meta_tags %>
+    </head>
+    <body>
+        <div class="main-menu">
+            <span class="logo-wrapper">
+                <span class="logo">
+                    <%= link_to logo_url, 'aria-label': 'OpenStax Home Page' do %>
+                        <%= image_tag 'openstax-logo.svg', class: 'logo-color', alt: 'OpenStax logo' %>
+                    <% end %>
+                </span>
+            </span>
+        </div>
+
+        <div class="content">
+            <%= yield %>
+        </div>
+
+        <%= render partial: 'layouts/newflow_footer' %>
+    </body>
+</html>

--- a/app/views/layouts/newflow_error.html.erb
+++ b/app/views/layouts/newflow_error.html.erb
@@ -14,15 +14,7 @@
         <%= csrf_meta_tags %>
     </head>
     <body>
-        <div class="main-menu">
-            <span class="logo-wrapper">
-                <span class="logo">
-                    <%= link_to logo_url, 'aria-label': 'OpenStax Home Page' do %>
-                        <%= image_tag 'openstax-logo.svg', class: 'logo-color', alt: 'OpenStax logo' %>
-                    <% end %>
-                </span>
-            </span>
-        </div>
+        <%= render partial: 'layouts/main_menu' %>
 
         <div class="content">
             <%= yield %>

--- a/app/views/layouts/static_error.html.erb
+++ b/app/views/layouts/static_error.html.erb
@@ -1,37 +1,46 @@
-<%# This file is the same as the application layout except that for whatever reason methods that use
+<%# This file is the same as the newflow layout except that for whatever reason methods that use
     the asset pipeline cannot be called here so tags are passed in from the static error template %>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <%= yield :stylesheet_tag %>
 
     <title><%= @page_title + ' - ' unless @page_title.nil? %><%= PAGE_TITLE_SUFFIX %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
 
-  <body class="error">
-    <%= render partial: "layouts/application_header" %>
+  <body>
+    <div class="main-menu">
+      <span class="logo-wrapper">
+        <span class="logo">
+          <a href="/" aria-label="OpenStax Home Page">
+            <%= yield :logo_image %>
+          </a>
+        </span>
+      </span>
+    </div>
 
-    <div id="application-container" class="container">
-      <%= render partial: "layouts/application_body" %>
+    <div class="content">
+      <%= yield %>
+    </div>
 
-      <div id="application-footer" class="row">
-        <div class="col-sm-12">
-          <div id="footer-rice-logo">
-            <%= link_to "http://www.rice.edu" do %>
-              <%= yield :rice_logo %>
-            <% end %>
-          </div>
+    <div class="content" id="newflow-footer">
+      <div>
+        <a href="http://www.rice.edu">
+          <%= yield :rice_logo %>
+        </a>
+      </div>
 
-          <div id="footer-copyright">
-            <%= link_to OpenStax::Utilities::Text.copyright('2013', COPYRIGHT_HOLDER), main_app.copyright_path %> |
-            <%= link_to 'Terms of Use', main_app.terms_path %>
-          </div>
-        </div>
+      <div id="newflow-footer--copyright">
+        <%= link_to OpenStax::Utilities::Text.copyright('2013', COPYRIGHT_HOLDER), main_app.copyright_path %> |
+        <%= link_to 'Terms of Use', main_app.terms_path %>
       </div>
     </div>
   </body>

--- a/app/views/layouts/static_error.html.erb
+++ b/app/views/layouts/static_error.html.erb
@@ -40,7 +40,7 @@
 
       <div id="newflow-footer--copyright">
         <%= link_to OpenStax::Utilities::Text.copyright('2013', COPYRIGHT_HOLDER), main_app.copyright_path %> |
-        <%= link_to 'Terms of Use', main_app.terms_path %>
+        <%= link_to t('layouts.application_footer.terms_of_use'), main_app.terms_path %>
       </div>
     </div>
   </body>

--- a/config/initializers/rescue_from.rb
+++ b/config/initializers/rescue_from.rb
@@ -21,7 +21,7 @@ OpenStax::RescueFrom.configure do |config|
   end
 
   config.html_error_template_path = 'errors/any'
-  config.html_error_template_layout_name = 'error'
+  config.html_error_template_layout_name = 'newflow_error'
 end
 
 OpenStax::RescueFrom.register_exception('Lev::SecurityTransgression', notify: false, status: :forbidden)


### PR DESCRIPTION
This pull request updates the error page layouts and templates to use the new "newflow" design system, improving consistency and appearance across error pages. The changes include updating the HTML structure, switching to the `newflow` stylesheet, and introducing a new layout for error pages.

**Error Page Redesign and Layout Updates:**

* Updated `errors/any.html.erb` and `errors/static.html.erb` to use new HTML structure and classes for a more modern error page appearance, including updating headings, container divs, and error message placement. 

**Layout and Asset Pipeline Adjustments:**

* Added a new layout file `layouts/newflow_error.html.erb` for error pages, featuring updated meta tags, favicon, logo, and footer rendering. 
* Updated the static error layout (`layouts/static_error.html.erb`) to match the new design, including improved HTML structure, logo placement, and footer updates. 

**Configuration Update:**

* Changed the default error page layout in the initializer to use `newflow_error` instead of the old `error` layout. 