### PR TITLE
Add role specific copy capability

### DIFF
--- a/app/helpers/newflow/educator_signup_helper.rb
+++ b/app/helpers/newflow/educator_signup_helper.rb
@@ -24,5 +24,17 @@ module Newflow
       current_user
     end
 
+    def educator_copy_audience
+      case user&.school_type
+      when 'k12_school', 'high_school', 'home_school' then :k12
+      else :default
+      end
+    end
+
+    def educator_copy(key)
+      scoped = "educator_profile_form.#{educator_copy_audience}.#{key}"
+      I18n.t(scoped, default: I18n.t("educator_profile_form.#{key}"))
+    end
+
   end
 end

--- a/app/helpers/newflow/educator_signup_helper.rb
+++ b/app/helpers/newflow/educator_signup_helper.rb
@@ -33,7 +33,7 @@ module Newflow
 
     def educator_copy(key)
       scoped = "educator_profile_form.#{educator_copy_audience}.#{key}"
-      I18n.t(scoped, default: I18n.t("educator_profile_form.#{key}"))
+      I18n.t(scoped, default: :"educator_profile_form.#{key}")
     end
 
   end

--- a/app/views/newflow/educator_signup/educator_profile_form.html.erb
+++ b/app/views/newflow/educator_signup/educator_profile_form.html.erb
@@ -4,10 +4,10 @@
   <div class="content">
     <%
       educator_complete_roles = [
-        [ I18n.t(:'educator_profile_form.instructor'), 'instructor', false ],
-        [ I18n.t(:'educator_profile_form.researcher'), 'researcher', false ],
-        [ I18n.t(:'educator_profile_form.administrator'), 'administrator', false ],
-        [ I18n.t(:'educator_profile_form.other'), 'other', false ]
+        [ educator_copy(:instructor), 'instructor', false ],
+        [ educator_copy(:researcher), 'researcher', false ],
+        [ educator_copy(:administrator), 'administrator', false ],
+        [ educator_copy(:other), 'other', false ]
       ]
     %>
 
@@ -16,7 +16,7 @@
 
     <%= newflow_login_signup_card(
           id: 'signup-page',
-          header: (I18n.t(:"educator_profile_form.complete_page_header")),
+          header: educator_copy(:complete_page_header),
           current_step: I18n.t(:"login_signup_form.step_counter", current_step: 4, total_steps: 4),
           classes: 'signup-page completed-step') do %>
     <% lev_form_for :signup, url: educator_complete_profile_path do |f| %>
@@ -38,17 +38,17 @@
                 <%=
                   label_tag(
                     :school_name,
-                    I18n.t(:"educator_profile_form.school_name"),
+                    educator_copy(:school_name),
                     class: 'field-label'
                   )
                 %>
                 <div class="school-name newflow-mustdo-alert">
-                  <%= I18n.t(:"educator_profile_form.school_name_must_be_entered") %>
+                  <%= educator_copy(:school_name_must_be_entered) %>
                 </div>
                 <%=
                   fh.text_field(
                     name: :school_name,
-                    placeholder: I18n.t(:"educator_profile_form.school_name"),
+                    placeholder: educator_copy(:school_name),
                     autofocus: true
                   )
                 %>
@@ -60,14 +60,14 @@
                 <%=
                   label_tag(
                     :school_issued_email,
-                    I18n.t(:"educator_profile_form.school_issued_email"),
+                    educator_copy(:school_issued_email),
                     class: 'field-label'
                   )
                 %>
                 <%=
                   fh.text_field(
                     name: :school_issued_email,
-                    placeholder: I18n.t(:"educator_profile_form.school_issued_email"),
+                    placeholder: educator_copy(:school_issued_email),
                     value: user.email_addresses.last&.value
                   )
                 %>
@@ -75,10 +75,10 @@
             </div>
 
             <fieldset class="question completed-role">
-              <legend class='field-label'><%= I18n.t(:"educator_profile_form.describe_role") %></legend>
+              <legend class='field-label'><%= educator_copy(:describe_role) %></legend>
               <div class="radio-control-group">
                 <div class="role newflow-mustdo-alert">
-                  <%= I18n.t(:"educator_profile_form.select_option") %>
+                  <%= educator_copy(:select_option) %>
                 </div>
 
                 <% educator_complete_roles.each do |(role, id, selected)| %>
@@ -99,16 +99,16 @@
               </div>
 
               <div class="other-specify">
-                <%= label_tag :other_role_name, I18n.t(:"educator_profile_form.other_please_specify"),
+                <%= label_tag :other_role_name, educator_copy(:other_please_specify),
                               class: 'field-label'
                 %>
                 <div class="other newflow-mustdo-alert">
-                  <%= I18n.t(:"educator_profile_form.fill_out") %>
+                  <%= educator_copy(:fill_out) %>
                 </div>
                 <%=
                   fh.text_field(
                     name: :other_role_name,
-                    placeholder: I18n.t(:"educator_profile_form.other_please_specify"),
+                    placeholder: educator_copy(:other_please_specify),
                     autofocus: true
                   )
                 %>
@@ -116,10 +116,10 @@
             </fieldset>
 
             <fieldset class="form-group question how-chosen">
-              <legend class='field-label'><%= I18n.t(:"educator_profile_form.how_textbooks_chosen") %></legend>
+              <legend class='field-label'><%= educator_copy(:how_textbooks_chosen) %></legend>
               <div class="radio-control-group">
                 <div class="chosen newflow-mustdo-alert">
-                  <%= I18n.t(:"educator_profile_form.select_option") %>
+                  <%= educator_copy(:select_option) %>
                 </div>
                 <label>
                   <%=
@@ -130,7 +130,7 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_primary_textbook, I18n.t(:"educator_profile_form.chosen_by_instructor"), class: 'custom-control-label' %>
+                  <%= label :using_primary_textbook, educator_copy(:chosen_by_instructor), class: 'custom-control-label' %>
                 </label>
                 <label>
                   <%=
@@ -141,7 +141,7 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_recommending_openstax, I18n.t(:"educator_profile_form.chosen_by_committee"), class: 'custom-control-label' %>
+                  <%= label :using_recommending_openstax, educator_copy(:chosen_by_committee), class: 'custom-control-label' %>
                 </label>
                 <label>
                   <%=
@@ -152,16 +152,16 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_future, I18n.t(:"educator_profile_form.chosen_by_coordinator"), class: 'custom-control-label' %>
+                  <%= label :using_future, educator_copy(:chosen_by_coordinator), class: 'custom-control-label' %>
                 </label>
               </div>
             </fieldset>
 
             <fieldset class="question how-using">
-              <legend class='field-label'><%= I18n.t(:"educator_profile_form.how_using") %></legend>
+              <legend class='field-label'><%= educator_copy(:how_using) %></legend>
               <div class="radio-control-group">
                 <div class="using newflow-mustdo-alert">
-                  <%= I18n.t(:"educator_profile_form.select_option") %>
+                  <%= educator_copy(:select_option) %>
                 </div>
                 <label>
                   <%=
@@ -172,7 +172,7 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_primary_textbook, I18n.t(:"educator_profile_form.using_primary_textbook"), class: 'custom-control-label' %>
+                  <%= label :using_primary_textbook, educator_copy(:using_primary_textbook), class: 'custom-control-label' %>
                 </label>
                 <label>
                   <%=
@@ -183,7 +183,7 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_recommending_openstax, I18n.t(:"educator_profile_form.using_recommending_openstax"), class: 'custom-control-label' %>
+                  <%= label :using_recommending_openstax, educator_copy(:using_recommending_openstax), class: 'custom-control-label' %>
                 </label>
                 <label>
                   <%=
@@ -194,7 +194,7 @@
                       class: 'completed-role custom-control-input'
                     )
                   %>
-                  <%= label :using_future, I18n.t(:"educator_profile_form.using_future"), class: 'custom-control-label' %>
+                  <%= label :using_future, educator_copy(:using_future), class: 'custom-control-label' %>
                 </label>
               </div>
             </fieldset>
@@ -203,15 +203,15 @@
               <%=
                 label_tag(
                   :books_used,
-                  I18n.t(:"educator_profile_form.books_used"),
+                  educator_copy(:books_used),
                   class: 'field-label'
                 )
               %>
               <div class="used newflow-mustdo-alert">
-                <%= I18n.t(:"educator_profile_form.select_option") %>
+                <%= educator_copy(:select_option) %>
               </div>
               <div class="used-limit newflow-mustdo-alert">
-                <%= I18n.t(:"educator_profile_form.select_option_limit_5") %>
+                <%= educator_copy(:select_option_limit_5) %>
               </div>
 
               <%= fh.select name: :books_used,
@@ -225,21 +225,21 @@
             <div data-template-id="used-book-info">
               <div class="form-group question students-using-book">
                 <%= label_tag nil, class: 'field-label' do %>
-                  <%= I18n.t(:"educator_profile_form.num_students_using_book_base") %>
+                  <%= educator_copy(:num_students_using_book_base) %>
                   <span data-placeholder-id="used-book-name"></span>
-                  <%= I18n.t(:"educator_profile_form.num_students_using_book_time_period") %>
+                  <%= educator_copy(:num_students_using_book_time_period) %>
 
                   <div class="form-helper-text">
-                    <%= I18n.t(:"educator_profile_form.num_students_using_book_supplemental") %>
+                    <%= educator_copy(:num_students_using_book_supplemental) %>
                   </div>
 
                   <div class="num-using-book newflow-mustdo-alert" style="display: none">
-                    <%= I18n.t(:"educator_profile_form.fill_out") %>
+                    <%= educator_copy(:fill_out) %>
                   </div>
                   <%=
                     fh.text_field(
                     name: 'books_used_details[%placeholder-book-name%]num_students_using_book',
-                    placeholder: "#{I18n.t(:'educator_profile_form.num_students_using_book_placeholder')}",
+                    placeholder: educator_copy(:num_students_using_book_placeholder),
                     autofocus: true,
                     numberonly: true,
                     disabled: true
@@ -250,12 +250,12 @@
 
               <div class="form-group question how-using-book">
                 <%= label_tag nil, class: 'field-label' do %>
-                  <%= I18n.t(:"educator_profile_form.how_using_book_base") %>
+                  <%= educator_copy(:how_using_book_base) %>
                   <span data-placeholder-id="used-book-name">
-                  </span><%= I18n.t(:"educator_profile_form.how_using_book_tail") %>
+                  </span><%= educator_copy(:how_using_book_tail) %>
 
                   <div class="using-book newflow-mustdo-alert"  style="display: none">
-                    <%= I18n.t(:"educator_profile_form.fill_out") %>
+                    <%= educator_copy(:fill_out) %>
                   </div>
 
                   <%= fh.select name: 'books_used_details[%placeholder-book-name%]how_using_book',
@@ -271,15 +271,15 @@
               <%=
                 label_tag(
                   :books_of_interest,
-                  I18n.t(:"educator_profile_form.books_of_interest"),
+                  educator_copy(:books_of_interest),
                   class: 'field-label'
                 )
               %>
               <div class="books-of-interest newflow-mustdo-alert">
-                <%= I18n.t(:"educator_profile_form.select_option") %>
+                <%= educator_copy(:select_option) %>
               </div>
               <div class="books-of-interest-limit newflow-mustdo-alert">
-                <%= I18n.t(:"educator_profile_form.select_option_limit_5") %>
+                <%= educator_copy(:select_option_limit_5) %>
               </div>
 
               <%= fh.select name: :books_of_interest,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,21 @@ en:
     school_issued_email_is_taken: Email already in use
     k12:
       instructor: K-12 Teacher
+      administrator: School or district administrator
+      other: Other school staff
+      complete_page_header: Complete your teacher profile
+      school_name: School or district name
+      describe_role: Which best describes your role at your school?
+      how_textbooks_chosen: How are textbooks chosen at your school or district?
+      chosen_by_instructor: Teachers choose textbooks for their classes
+      chosen_by_coordinator: School or district coordinator chooses the textbook
+      using_primary_textbook: Using an OpenStax book as my primary textbook
+      using_recommending_openstax: Recommending the book — my students use a different one
+      books_used: Which OpenStax book(s) are you using?
+      books_of_interest: Which OpenStax book(s) are you interested in?
+      include_ta_sections: Include all students across your classes
+      students_per_semester: Students per school year
+      num_students_using_book_placeholder: Number of students using this book per school year
 
   login_signup_form:
     cant_be_blank: can't be blank

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,8 @@ en:
     school_issued_email_must_be_entered: Please enter your school-issued email address
     school_issued_email_is_invalid: Please enter a valid email address
     school_issued_email_is_taken: Email already in use
+    k12:
+      instructor: K-12 Teacher
 
   login_signup_form:
     cant_be_blank: can't be blank

--- a/spec/controllers/newflow/educator_signup_controller_spec.rb
+++ b/spec/controllers/newflow/educator_signup_controller_spec.rb
@@ -11,6 +11,36 @@ module Newflow
       end
     end
 
+    describe 'GET #educator_profile_form' do
+      render_views
+      let(:user) { FactoryBot.create(:user, role: User::INSTRUCTOR_ROLE, school_type: school_type, is_profile_complete: false) }
+
+      before do
+        allow_any_instance_of(FetchBookData).to receive(:titles).and_return([])
+        controller.sign_in!(user)
+      end
+
+      context 'when the user is affiliated with a K-12 school' do
+        let(:school_type) { :k12_school }
+
+        it 'labels the instructor role radio as "K-12 Teacher"' do
+          get(:educator_profile_form)
+          expect(response.body).to include('K-12 Teacher')
+          expect(response.body).to_not match(/>\s*Instructor\s*</)
+        end
+      end
+
+      context 'when the user has a default (non-K-12) school type' do
+        let(:school_type) { :college }
+
+        it 'labels the instructor role radio as "Instructor"' do
+          get(:educator_profile_form)
+          expect(response.body).to match(/>\s*Instructor\s*</)
+          expect(response.body).to_not include('K-12 Teacher')
+        end
+      end
+    end
+
     describe 'POST #educator_signup' do
       before do
         load('db/seeds.rb') # create the FinePrint contracts

--- a/spec/helpers/newflow/educator_signup_helper_spec.rb
+++ b/spec/helpers/newflow/educator_signup_helper_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+module Newflow
+  describe EducatorSignupHelper, type: :helper do
+    describe '#educator_copy_audience' do
+      before { allow(helper).to receive(:current_user).and_return(current_user) }
+
+      %w[k12_school high_school home_school].each do |school_type|
+        context "when user has school_type '#{school_type}'" do
+          let(:current_user) { instance_double(User, school_type: school_type) }
+
+          it 'returns :k12' do
+            expect(helper.educator_copy_audience).to eq :k12
+          end
+        end
+      end
+
+      %w[college other_school_type unknown_school_type].each do |school_type|
+        context "when user has school_type '#{school_type}'" do
+          let(:current_user) { instance_double(User, school_type: school_type) }
+
+          it 'returns :default' do
+            expect(helper.educator_copy_audience).to eq :default
+          end
+        end
+      end
+
+      context 'when school_type is nil' do
+        let(:current_user) { instance_double(User, school_type: nil) }
+
+        it 'returns :default' do
+          expect(helper.educator_copy_audience).to eq :default
+        end
+      end
+
+      context 'when there is no current user' do
+        let(:current_user) { nil }
+
+        it 'returns :default' do
+          expect(helper.educator_copy_audience).to eq :default
+        end
+      end
+    end
+
+    describe '#educator_copy' do
+      before { allow(helper).to receive(:educator_copy_audience).and_return(audience) }
+
+      around do |example|
+        I18n.backend.store_translations(:en, educator_profile_form: {
+          instructor: 'Instructor',
+          researcher: 'Researcher',
+          k12: { instructor: 'K-12 Teacher' }
+        })
+        example.run
+        I18n.reload!
+      end
+
+      context 'when audience is :k12 and a scoped override exists' do
+        let(:audience) { :k12 }
+
+        it 'returns the scoped value' do
+          expect(helper.educator_copy(:instructor)).to eq 'K-12 Teacher'
+        end
+      end
+
+      context 'when audience is :k12 but no scoped override exists for the key' do
+        let(:audience) { :k12 }
+
+        it 'falls back to the default value' do
+          expect(helper.educator_copy(:researcher)).to eq 'Researcher'
+        end
+      end
+
+      context 'when audience is :default' do
+        let(:audience) { :default }
+
+        it 'returns the default value' do
+          expect(helper.educator_copy(:instructor)).to eq 'Instructor'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request updates the educator signup flow to support audience-specific copy, particularly for K-12 educators, and introduces helper methods and tests to manage and verify this behavior. The main changes include adding logic to select copy based on the user's school type, updating the view to use this logic throughout, and ensuring correctness with comprehensive tests.

**Audience-specific copy support:**

* Added `educator_copy_audience` and `educator_copy` helper methods in `EducatorSignupHelper` to select copy based on the user's `school_type`, allowing for K-12-specific text overrides in the educator profile form.
* Updated the educator profile form view (`educator_profile_form.html.erb`) to use the new `educator_copy` helper for all user-facing strings, enabling dynamic audience-based copy throughout the form.
* Added a K-12-specific translation for the instructor role ("K-12 Teacher") in the English locale file.

**Testing and validation:**

* Added comprehensive helper specs for `educator_copy_audience` and `educator_copy` to ensure correct copy selection and fallback behavior.
* Added controller specs for the educator profile form to verify that the correct role label ("K-12 Teacher" or "Instructor") is shown based on the user's school type.