### PR TITLE
Align book labels for book interest/use fields

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,8 +63,8 @@ en:
     students_per_semester: "Students per semester"
     how_using_this_book: "How are you using this book?"
     subjects_of_interest: Subjects of interest
-    books_used: Which textbook(s) are you currently using?
-    books_of_interest: Books of interest
+    books_used: Which OpenStax book(s)?
+    books_of_interest: Which OpenStax book(s)?
     using_primary_textbook: Using an OpenStax book as our primary textbook
     using_recommending_openstax: Recommending the book -- my students buy a different one
     using_future: Interested in using OpenStax in the future

--- a/spec/features/newflow/educator_signup_flow_spec.rb
+++ b/spec/features/newflow/educator_signup_flow_spec.rb
@@ -158,7 +158,7 @@ module Newflow
               find('#signup_using_openstax_how_as_primary').click
             end
 
-            it 'shows "Books used"' do
+            it 'shows the book selection label' do
               expect(page).to have_text(I18n.t(:"educator_profile_form.books_used"))
             end
           end
@@ -168,7 +168,7 @@ module Newflow
               find('#signup_using_openstax_how_as_recommending').click
             end
 
-            it 'shows "Books of interest"' do
+            it 'shows the book selection label' do
               expect(page).to have_text(I18n.t(:"educator_profile_form.books_of_interest"))
             end
           end


### PR DESCRIPTION
https://openstax.atlassian.net/browse/DATA-299
Based off the work on https://github.com/openstax/accounts/pull/1707

This pull request updates the educator signup flow to clarify that the book selection fields refer specifically to OpenStax books. The changes include updates to the English locale and corresponding test descriptions to ensure consistency.

**Localization improvements:**
* Updated the `books_used` and `books_of_interest` labels in `en.yml` to specify "Which OpenStax book(s)?" for greater clarity in the educator profile form.

**Test updates:**
* Changed test descriptions in `educator_signup_flow_spec.rb` to refer generically to the "book selection label" rather than the previous, now outdated, label text. This keeps the tests aligned with the updated localization. [[1]](diffhunk://#diff-628c3654bfde60a058f9de77818d39122552396c4ca8a811fc61734e7069602bL161-R161) [[2]](diffhunk://#diff-628c3654bfde60a058f9de77818d39122552396c4ca8a811fc61734e7069602bL171-R171)