### PR TITLE
Drop grant_tutor_access and other removed Salesforce Contact fields

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -136,7 +136,6 @@ module Admin
       @user.school_type = params[:user][:school_type] if params[:user][:school_type]
       @user.school_location = params[:user][:school_location] if params[:user][:school_location]
       @user.is_kip = params[:user][:is_kip]
-      @user.grant_tutor_access = params[:user][:grant_tutor_access]
       if @user.external_uuids.any? && params[:user][:keep_external_uuids] == '0'
         @user.external_uuids.destroy_all
       end

--- a/app/routines/update_user_contact_info.rb
+++ b/app/routines/update_user_contact_info.rb
@@ -130,7 +130,6 @@ class UpdateUserContactInfo
 
       user.adopter_status = sf_contact.adoption_status
       user.is_kip = sf_school&.is_kip || sf_school&.is_child_of_kip
-      user.grant_tutor_access = sf_contact.grant_tutor_access
 
       if school.nil? && !sf_school.nil?
         users_without_cached_school += 1
@@ -153,11 +152,9 @@ class UpdateUserContactInfo
     contacts ||= OpenStax::Salesforce::Remote::Contact.select(
                      :id,
                      :email,
-                     :email_alt,
                      :faculty_verified,
                      :school_type,
                      :adoption_status,
-                     :grant_tutor_access,
                      :accounts_uuid
                    )
                    .where("Accounts_UUID__c != null")

--- a/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
@@ -186,7 +186,7 @@ http_interactions:
   recorded_at: Tue, 08 Oct 2024 15:05:08 GMT
 - request:
     method: get
-    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Adoption_Status__c,%20Grant_Tutor_Access__c,%20Title_1_school__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Renewal_Eligible__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%27003Pc00000NsWSHIA3%27)%20LIMIT%201"
+    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20All_Emails__c,%20Adoption_Status__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%27003Pc00000NsWSHIA3%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/can_be_set_if_the_Contact_exists_in_SF.yml
@@ -242,8 +242,8 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v51.0/sobjects/Contact/003Pc00000NsWSHIA3"},"Id":"003Pc00000NsWSHIA3","Name":"Ricardo
-        Reynolds","FirstName":"Ricardo","LastName":"Reynolds","Email":"coy_mante@rennerryan.co","Email_alt__c":null,"Faculty_Confirmed_Date__c":null,"FV_Status__c":null,"LastModifiedDate":"2024-10-08T15:05:08.000+0000","AccountId":null,"School_Type__c":null,"SendFacultyVerificationTo__c":null,"All_Emails__c":"coy_mante@rennerryan.co","Adoption_Status__c":"Not
-        Adopter","Grant_Tutor_Access__c":false,"Title_1_school__c":false,"Accounts_UUID__c":null,"LeadSource":null,"Signup_Date__c":null,"Renewal_Eligible__c":false,"Assignable_Interest__c":null,"Assignable_Adoption_Date__c":null}]}'
+        Reynolds","FirstName":"Ricardo","LastName":"Reynolds","Email":"coy_mante@rennerryan.co","FV_Status__c":null,"LastModifiedDate":"2024-10-08T15:05:08.000+0000","AccountId":null,"School_Type__c":null,"All_Emails__c":"coy_mante@rennerryan.co","Adoption_Status__c":"Not
+        Adopter","Accounts_UUID__c":null,"LeadSource":null,"Signup_Date__c":null,"Assignable_Interest__c":null,"Assignable_Adoption_Date__c":null}]}'
     http_version:
   recorded_at: Tue, 08 Oct 2024 15:05:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_Contact_does_not_exist_in_SF.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Adoption_Status__c,%20Grant_Tutor_Access__c,%20Title_1_school__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Renewal_Eligible__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%270010v000002Wo0qAAC%27)%20LIMIT%201"
+    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20All_Emails__c,%20Adoption_Status__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%270010v000002Wo0qAAC%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_malformed.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_malformed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20Email_alt__c,%20Faculty_Confirmed_Date__c,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20SendFacultyVerificationTo__c,%20All_Emails__c,%20Adoption_Status__c,%20Grant_Tutor_Access__c,%20Title_1_school__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Renewal_Eligible__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%27somethingwonky%27)%20LIMIT%201"
+    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20Name,%20FirstName,%20LastName,%20Email,%20FV_Status__c,%20LastModifiedDate,%20AccountId,%20School_Type__c,%20All_Emails__c,%20Adoption_Status__c,%20Accounts_UUID__c,%20LeadSource,%20Signup_Date__c,%20Assignable_Interest__c,%20Assignable_Adoption_Date__c%20FROM%20Contact%20WHERE%20(Id%20=%20%27somethingwonky%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_malformed.yml
+++ b/spec/cassettes/Change_Salesforce_contact_manually/cannot_be_set_if_the_ID_is_malformed.yml
@@ -55,7 +55,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"message":"\nAssignable_Adoption_Date__c FROM Contact WHERE (Id =
         ''somethingwonky'') LIMIT 1\n                                                ^\nERROR
-        at Row:1:Column:392\ninvalid ID field: somethingwonky","errorCode":"INVALID_QUERY_FILTER_OPERATOR"}]'
+        at Row:1:Column:258\ninvalid ID field: somethingwonky","errorCode":"INVALID_QUERY_FILTER_OPERATOR"}]'
     http_version:
   recorded_at: Tue, 08 Oct 2024 15:05:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/pose_terms_spec.rb
+++ b/spec/features/pose_terms_spec.rb
@@ -19,6 +19,7 @@ describe 'Terms', type: :feature, js: true do
       expect(page).to have_content("To continue, please review and agree to the following site terms")
       expect(page).to have_content(t :"terms.pose.contract_acceptance_required")
       check 'agreement_i_agree'
+      expect(page).to have_button((t :"terms.pose.agree"), disabled: false)
       click_button (t :"terms.pose.agree")
       wait_for_animations
       wait_for_ajax

--- a/spec/lib/posthog_spec.rb
+++ b/spec/lib/posthog_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe OXPosthog, type: :lib do
       which_books: 'Biology',
       how_many_students: '100-200',
       title_1_school: false,
-      grant_tutor_access: true,
       country_code: 'US',
       receive_newsletter: true,
       is_administrator: false,

--- a/spec/representers/api/v1/user_representer_spec.rb
+++ b/spec/representers/api/v1/user_representer_spec.rb
@@ -149,19 +149,6 @@ describe Api::V1::UserRepresenter, type: :representer do
     end
   end
 
-  context 'grant_tutor_access' do
-    it 'can be read' do
-      expect(representer.to_hash['grant_tutor_access']).to eq user.grant_tutor_access
-    end
-
-    it 'cannot be written (attempts are silently ignored)' do
-      hash = { 'grant_tutor_access' => true }
-
-      expect(user).not_to receive(:grant_tutor_access=)
-      expect { representer.from_hash(hash) }.not_to change { user.reload.grant_tutor_access }
-    end
-  end
-
   context 'applications' do
     it 'can be read' do
       expected_hash = user.application_users.map do |application_user|

--- a/spec/support/salesforce_spec_helpers.rb
+++ b/spec/support/salesforce_spec_helpers.rb
@@ -6,8 +6,7 @@ module SalesforceSpecHelpers
       accounts_uuid: uuid,
       faculty_verified: faculty_verified,
       school_type: 'College/University (4)',
-      adoption_status: 'Not Adopter',
-      grant_tutor_access: false
+      adoption_status: 'Not Adopter'
     )
 
     # Mock the school association


### PR DESCRIPTION
I guess I removed these fields from openstax_salesforce [A YEAR AGO](https://github.com/openstax/openstax_salesforce/pull/83) 🤯 and didn't update accounts.

## Summary
- Builds on top of `data-301-expected-start-semester` (which bumped the `openstax_salesforce` gem to 8.3.0).
- Drops references to Contact fields the new gem version no longer exposes: `grant_tutor_access`, `email_alt`, plus the cassette URL leftovers for `faculty_confirmed_date`, `send_faculty_verification_to`, `title_1_school`, and `renewal_eligible`.
- The `users.grant_tutor_access` DB column is left in place — nothing reads it anymore, but dropping it can be a follow-up migration.

## Why split from the parent PR
The gem bump (data-301) is a small, focused change. This cleanup touches more files (admin controller, sync routine, multiple specs, three VCR cassettes) and deserves its own review.

## Changes
- `app/routines/update_user_contact_info.rb` — stop assigning `grant_tutor_access`; drop `:grant_tutor_access` and `:email_alt` from the SF Contact select
- `app/controllers/admin/users_controller.rb` — stop writing `grant_tutor_access` from admin form params
- `spec/support/salesforce_spec_helpers.rb`, `spec/lib/posthog_spec.rb`, `spec/representers/api/v1/user_representer_spec.rb` — drop stale references in test fixtures/expectations
- `spec/cassettes/Change_Salesforce_contact_manually/*.yml` — rewrite the `SELECT … FROM Contact` URL in three cassettes to match the new gem's Contact field list

## Test plan
- [ ] `bundle exec rspec spec/routines/update_user_contact_info_spec.rb spec/representers/api/v1/user_representer_spec.rb spec/lib/posthog_spec.rb spec/features/admin/change_salesforce_contact_manually_spec.rb`
- [ ] Verify nothing else in accounts reads `User#grant_tutor_access` (the column is now dead data)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)