### PR TITLE
Fix School.fuzzy_search returning partial record

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -39,7 +39,11 @@ class School < ApplicationRecord
       ).order(Arel.sql state_expression)
     end
 
-    match_rel.first
+    # `select(:id)` keeps the fuzzy-distance ordering query lean, but returns a
+    # partial record. Reload the winning row by primary key so callers can read
+    # any attribute (e.g. name/city/state) without a MissingAttributeError.
+    match = match_rel.first
+    match && find(match.id)
   end
 
   def user_school_type

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -42,8 +42,8 @@ class School < ApplicationRecord
     # `select(:id)` keeps the fuzzy-distance ordering query lean, but returns a
     # partial record. Reload the winning row by primary key so callers can read
     # any attribute (e.g. name/city/state) without a MissingAttributeError.
-    match = match_rel.first
-    match && find(match.id)
+match = match_rel.first
+match && find_by(id: match.id)
   end
 
   def user_school_type

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -17,6 +17,16 @@ describe School, type: :model do
     expect(described_class.fuzzy_search('OpenStax')).to be_nil
   end
 
+  it 'returns a fully-loaded record whose attributes are accessible' do
+    match = described_class.fuzzy_search(school.name)
+
+    # Regression: fuzzy_search used to `select(:id)` only, so reading any other
+    # attribute (e.g. in PostHog school identification) raised MissingAttributeError.
+    expect(match.name).to eq school.name
+    expect(match.city).to eq school.city
+    expect(match.state).to eq school.state
+  end
+
   it 'translates the school type to values used in the user record' do
     school.type = 'College/University (4)'
     expect(school.user_school_type).to eq :college


### PR DESCRIPTION
fuzzy_search used `select(:id)` to keep the trigram-distance ordering query lean, but that returned a partial record. When the fuzzy-matched school was later assigned to a user and PostHog read school.name/city/ state (OXPosthog.identify_school), it raised ActiveModel::Missing- AttributeError. This surfaced in the SheerID webhook (~2.9K Sentry events) but was harmless to Salesforce — the lead job enqueues before the PostHog call and the error is rescued.

Reload the winning row by primary key so callers can read any attribute, keeping the lean projection on the ordering query.