### PR TITLE
Fix fuzzy_search partial records and log SheerID error steps

### DIFF
--- a/app/handlers/newflow/educator_signup/sheerid_webhook.rb
+++ b/app/handlers/newflow/educator_signup/sheerid_webhook.rb
@@ -29,7 +29,7 @@ module Newflow
           return
         end
 
-        # there are no details included with this step that are helpful a future
+        # there are no details included with this step that are helpful in the future
         # TODO: might be to use this to update the user faculty state to PENDING_SHEERID or AWAITING_DOC_UPLOAD?
         return if verification_details_from_sheerid.current_step == 'collectTeacherPersonalInfo'
 

--- a/app/handlers/newflow/educator_signup/sheerid_webhook.rb
+++ b/app/handlers/newflow/educator_signup/sheerid_webhook.rb
@@ -15,9 +15,22 @@ module Newflow
         end
         verification_details_from_sheerid = SheeridAPI.get_verification_details(verification_id)
 
+        # Report error steps (e.g. verificationLimitExceeded) so we can see how
+        # often users get stuck on the SheerID form and why, then return as before.
+        if verification_details_from_sheerid.current_step == 'error'
+          Sentry.capture_message(
+            '[SheerID Webhook] error step received',
+            extra: {
+              verification_id: verification_id,
+              error_ids: verification_details_from_sheerid.error_ids,
+              email: verification_details_from_sheerid.email
+            }
+          )
+          return
+        end
+
         # there are no details included with this step that are helpful a future
         # TODO: might be to use this to update the user faculty state to PENDING_SHEERID or AWAITING_DOC_UPLOAD?
-        return if verification_details_from_sheerid.current_step == 'error'
         return if verification_details_from_sheerid.current_step == 'collectTeacherPersonalInfo'
 
         if !verification_details_from_sheerid.success?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -21,7 +21,7 @@ class School < ApplicationRecord
 
   def self.fuzzy_search(name, city = nil, state = nil)
     name_expression = sanitize_sql(["? <-> name", name])
-    match_rel = select(:id).where(
+    match_rel = where(
       Arel.sql "#{name_expression} <= #{MAX_NAME_MATCH_DISTANCE}"
     ).order(Arel.sql name_expression)
 

--- a/lib/sheerid_api/response.rb
+++ b/lib/sheerid_api/response.rb
@@ -4,7 +4,7 @@
 module SheeridAPI
   class Base
 
-    attr_reader :current_step, :first_name, :last_name, :email, :organization_name
+    attr_reader :current_step, :first_name, :last_name, :email, :organization_name, :error_ids
 
     def success?
       raise('Must implement')
@@ -21,7 +21,9 @@ module SheeridAPI
   class Response < SheeridAPI::Base
 
     def initialize(body_as_hash)
-      @current_step = body_as_hash.fetch('lastResponse', {}).fetch('currentStep', {})
+      last_response = body_as_hash.fetch('lastResponse', {})
+      @current_step = last_response.fetch('currentStep', {})
+      @error_ids = last_response.fetch('errorIds', [])
       person_info = body_as_hash.fetch('personInfo', {})
       @first_name = person_info&.fetch('firstName', '')
       @last_name = person_info&.fetch('lastName', '')

--- a/spec/handlers/newflow/educator_signup/sheerid_webhook_spec.rb
+++ b/spec/handlers/newflow/educator_signup/sheerid_webhook_spec.rb
@@ -37,18 +37,18 @@ describe Newflow::EducatorSignup::SheeridWebhook, type: :routine do
   #   end
   # end
 
-  before do
-    num_calls = verification.verified? ? :twice : :once
-    expect(SheeridAPI).to receive(:get_verification_details).with(
-      verification.verification_id
-    ).exactly(num_calls).and_return(verification_details)
-
-    expect(School).to receive(:find_by).with(
-      sheerid_school_name: school.sheerid_school_name
-    ).and_call_original
-  end
-
   context "user with verified verfication" do
+    before do
+      num_calls = verification.verified? ? :twice : :once
+      expect(SheeridAPI).to receive(:get_verification_details).with(
+        verification.verification_id
+      ).exactly(num_calls).and_return(verification_details)
+
+      expect(School).to receive(:find_by).with(
+        sheerid_school_name: school.sheerid_school_name
+      ).and_call_original
+    end
+
     xit 'finds schools based on the sheerid_reported_school field' do
       expect(School).not_to receive(:fuzzy_search)
 
@@ -70,6 +70,46 @@ describe Newflow::EducatorSignup::SheeridWebhook, type: :routine do
       #described_class.call verification_id: verification.verification_id
 
       expect(user.reload.school).to eq school
+    end
+  end
+
+  context 'when SheerID reports an error step' do
+    let(:verification_id) { 'error-verification-id' }
+    let(:verification_details) do
+      SheeridAPI::Response.new(
+        'lastResponse' => {
+          'currentStep' => 'error',
+          'errorIds' => ['verificationLimitExceeded']
+        },
+        'personInfo' => { 'email' => email_address.value }
+      )
+    end
+
+    before do
+      allow(SheeridAPI).to receive(:get_verification_details).with(
+        verification_id
+      ).and_return(verification_details)
+    end
+
+    it 'reports the error details to Sentry' do
+      expect(Sentry).to receive(:capture_message).with(
+        '[SheerID Webhook] error step received',
+        extra: {
+          verification_id: verification_id,
+          error_ids: ['verificationLimitExceeded'],
+          email: email_address.value
+        }
+      )
+
+      described_class.call(params: { 'verificationId' => verification_id })
+    end
+
+    it 'still returns early without creating a verification record' do
+      allow(Sentry).to receive(:capture_message)
+
+      expect {
+        described_class.call(params: { 'verificationId' => verification_id })
+      }.not_to change(SheeridVerification, :count)
     end
   end
 end

--- a/spec/handlers/newflow/educator_signup/sheerid_webhook_spec.rb
+++ b/spec/handlers/newflow/educator_signup/sheerid_webhook_spec.rb
@@ -37,7 +37,7 @@ describe Newflow::EducatorSignup::SheeridWebhook, type: :routine do
   #   end
   # end
 
-  context "user with verified verfication" do
+  context "user with verified verification" do
     before do
       num_calls = verification.verified? ? :twice : :once
       expect(SheeridAPI).to receive(:get_verification_details).with(

--- a/spec/lib/sheerid_api_spec.rb
+++ b/spec/lib/sheerid_api_spec.rb
@@ -73,6 +73,25 @@ describe SheeridAPI, type: :lib, vcr: VCR_OPTS do
     example 'success? is true' do
       expect(instance.success?).to be_truthy
     end
+
+    example 'exposes error_ids from the last response' do
+      expect(instance.error_ids).to eq []
+    end
+
+    context 'when the verification errored' do
+      let(:http_response_as_hash) do
+        {
+          'lastResponse' => {
+            'currentStep' => 'error',
+            'errorIds' => ['verificationLimitExceeded']
+          }
+        }
+      end
+
+      example 'exposes error_ids from the last response' do
+        expect(instance.error_ids).to eq ['verificationLimitExceeded']
+      end
+    end
   end
 
   describe SheeridAPI::NullResponse do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -17,6 +17,14 @@ describe School, type: :model do
     expect(described_class.fuzzy_search('OpenStax')).to be_nil
   end
 
+  it 'fuzzy search returns a fully-loaded record whose attributes are readable' do
+    match = described_class.fuzzy_search(school.name)
+
+    expect(match.name).to eq school.name
+    expect(match.city).to eq school.city
+    expect(match.state).to eq school.state
+  end
+
   it 'translates the school type to values used in the user record' do
     school.type = 'College/University (4)'
     expect(school.user_school_type).to eq :college


### PR DESCRIPTION
Replaces #1715 with the simpler one-query fix, plus visibility into SheerID error steps.

## Fix 1: `School.fuzzy_search` returned a partial record

`fuzzy_search` selected only `:id`, so reading any other attribute on the match (e.g. `school.name` in `OXPosthog.identify_school`) raised `ActiveModel::MissingAttributeError` — ~3K Sentry events from the SheerID webhook. The error was rescued, so the webhook and Salesforce lead processing were unaffected, but PostHog school group-identify silently failed for every fuzzy-matched school.

Selecting all columns costs nothing here (the expensive trigram-distance WHERE/ORDER BY is unchanged and the query returns at most one row), so just drop `select(:id)` — no reload needed.

## Fix 2: log SheerID webhook `error` steps to Sentry

The webhook handler returned early and silently whenever SheerID reported `currentStep: 'error'`, so we have no visibility into users hitting "Verification Limit Exceeded" (SheerID's `verificationLimitExceeded` error) and getting stuck on step 3 of educator signup. Now we parse `errorIds` from the SheerID response and report the error step to Sentry (verification id, error ids, email) before returning early as before — no behavior change for users.

Once we see real payloads (specifically whether the email is present), we can follow up with auto-routing limit-exceeded users to the profile step via `is_sheerid_unviable`, the same path as the existing "Stuck? Click here" link.

## Tests

- Regression test reads `name`/`city`/`state` on a fuzzy_search match (reproduced the production error before the fix)
- `SheeridAPI::Response#error_ids` parsing, empty and populated
- Webhook handler reports the Sentry message on error steps and still creates no verification record
- Moved the webhook spec's `before` block into the context it belongs to (its message expectations would fail any new unrelated example; existing examples there are `xit`-skipped, so no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)