### PR TITLE
Fix TypeError when educators submit an invalid student count

### DIFF
--- a/app/handlers/newflow/educator_signup/complete_profile.rb
+++ b/app/handlers/newflow/educator_signup/complete_profile.rb
@@ -149,19 +149,19 @@ module Newflow
 
       def validate_student_count!(value, field, message)
         if value.blank?
-          errors.add(field, message)
+          nonfatal_error(code: field, message: message, offending_inputs: field)
           return nil
         end
 
         count = Integer(value, 10)
         if count <= 0
-          errors.add(field, message)
+          nonfatal_error(code: field, message: message, offending_inputs: field)
           return nil
         end
 
         count
       rescue ArgumentError, TypeError
-        errors.add(field, message)
+        nonfatal_error(code: field, message: message, offending_inputs: field)
         nil
       end
 

--- a/spec/handlers/newflow/educator_signup/complete_profile_spec.rb
+++ b/spec/handlers/newflow/educator_signup/complete_profile_spec.rb
@@ -148,6 +148,46 @@ module Newflow
           end
         end
 
+        context 'as_recommending with a zero total_num_students' do
+          let(:params) do
+            {
+              signup: {
+                school_name: 'School Name',
+                books_used: [],
+                books_of_interest: ['Test Book'],
+                using_openstax_how: 'as_recommending',
+                educator_specific_role: 'instructor',
+                total_num_students: '0'
+              }
+            }
+          end
+
+          it 'returns a validation error instead of raising' do
+            result = handle
+            expect(result.errors.any? { |e| e.code == :total_num_students }).to be true
+          end
+        end
+
+        context 'as_recommending with a non-numeric total_num_students' do
+          let(:params) do
+            {
+              signup: {
+                school_name: 'School Name',
+                books_used: [],
+                books_of_interest: ['Test Book'],
+                using_openstax_how: 'as_recommending',
+                educator_specific_role: 'instructor',
+                total_num_students: 'about thirty'
+              }
+            }
+          end
+
+          it 'returns a validation error instead of raising' do
+            result = handle
+            expect(result.errors.any? { |e| e.code == :total_num_students }).to be true
+          end
+        end
+
         context 'as_recommending without total_num_students' do
           let(:params) do
             {
@@ -225,6 +265,30 @@ module Newflow
       end
 
       context 'with invalid params' do
+        context 'a zero num_students_using_book on the as_primary path' do
+          let(:params) do
+            {
+              signup: {
+                school_name: 'School Name',
+                books_used: ['Algebra and Trigonometry'],
+                books_used_details: {
+                  'Algebra and Trigonometry' => {
+                    'num_students_using_book' => '0',
+                    'how_using_book' => 'As the core textbook for my course'
+                  }
+                },
+                using_openstax_how: Newflow::EducatorSignup::CompleteProfile::AS_PRIMARY,
+                educator_specific_role: Newflow::EducatorSignup::CompleteProfile::INSTRUCTOR,
+              }
+            }
+          end
+
+          it 'returns a validation error instead of raising' do
+            result = handle
+            expect(result.errors.any? { |e| e.code == :books_used_details_0_num_students_using_book }).to be true
+          end
+        end
+
         context 'other must be filled out' do
           let(:educator_specific_role) { Newflow::EducatorSignup::CompleteProfile::OTHER }
 


### PR DESCRIPTION
Fixes the new Sentry issue ACCOUNTS-6BT (`TypeError: no implicit conversion of Symbol into Integer` in `Newflow::EducatorSignupController#educator_complete_profile`).

`validate_student_count!` (added with the recent usage-questions work) called `errors.add(field, message)`, but `Lev::Errors#add` has the signature `add(fail, args = {})` — so the field symbol became the fatal flag and lev tried `message[:kind]` on the message string, raising the TypeError. The rescue inside the method then called `errors.add` again, raising the same error and bubbling up.

Net effect: any educator submitting a zero, negative, or non-numeric student count on step 4 got a 500 instead of a validation message. Blank counts were unaffected (caught earlier in `check_params`), which is why specs stayed green.

Fix: use `nonfatal_error(code:, message:, offending_inputs:)`, the same idiom as `param_error` in this handler.

## Tests

Three regression tests (zero / non-numeric `total_num_students` on the recommending path, zero per-book count on the as-primary path). All three reproduced the production TypeError before the fix; the full newflow handler + controller suites pass after (172 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)