### PR TITLE
reduce marketing lingo in pin email for better deliverability

### DIFF
--- a/app/mailers/newflow_mailer.rb
+++ b/app/mailers/newflow_mailer.rb
@@ -23,6 +23,13 @@ class NewflowMailer < ApplicationMailer
     @confirmation_code = email_address.confirmation_code
     @confirmation_url = verify_email_by_code_url(@confirmation_code)
 
+    attachments.inline['openstax-logo.png'] = File.read(
+      Rails.root.join('app', 'assets', 'images', 'accounts_horiz_v2.png')
+    )
+    attachments.inline['rice-logo.png'] = File.read(
+      Rails.root.join('app', 'assets', 'images', 'rice_logo_4.png')
+    )
+
     mail to: @email_value,
          subject: if @should_show_pin
                     "Your OpenStax account PIN has arrived: #{@confirmation_pin}"

--- a/app/mailers/newflow_mailer.rb
+++ b/app/mailers/newflow_mailer.rb
@@ -23,10 +23,10 @@ class NewflowMailer < ApplicationMailer
     @confirmation_code = email_address.confirmation_code
     @confirmation_url = verify_email_by_code_url(@confirmation_code)
 
-    attachments.inline['openstax-logo.png'] = File.read(
+    attachments.inline['openstax-logo.png'] = File.binread(
       Rails.root.join('app', 'assets', 'images', 'accounts_horiz_v2.png')
     )
-    attachments.inline['rice-logo.png'] = File.read(
+    attachments.inline['rice-logo.png'] = File.binread(
       Rails.root.join('app', 'assets', 'images', 'rice_logo_4.png')
     )
 

--- a/app/views/newflow_mailer/signup_email_confirmation.html.erb
+++ b/app/views/newflow_mailer/signup_email_confirmation.html.erb
@@ -34,7 +34,7 @@
 													<tbody>
 														<tr>
 															<td align="center" style="padding-top: 15px;">
-                              <a href="<%= @confirmation_url %>" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MC6BQDZRG2LJH63GGTYUS7JVML2E?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 30%; object-fit: contain;" width="180" /></a>
+                              <a href="<%= @confirmation_url %>" target="_blank"><img alt="OpenStax" src="<%= attachments['openstax-logo.png'].url %>" style="width: 100%; display: block; border: none; max-width: 30%; object-fit: contain;" width="180" /></a>
 															</td>
 														</tr>
 													</tbody>
@@ -148,33 +148,6 @@
 										<tbody>
 											<tr>
 												<td>
-												<table cellpadding="0" cellspacing="0"  id="contentregion" style="font-size:14px; width: 100%; border-collapse: collapse; word-break: break-word;">
-													<tbody>
-														<tr>
-															<td class="contentbuilder-html" style="padding: 0;">
-															<table style="width: 30%; margin: 2rem auto 0 auto;">
-																<tbody>
-																	<tr>
-																		<td style="text-align: center;">
-                                      <a href="https://www.facebook.com/openstax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1n/218812/1677769915zhNb62dS/Group_49.png" style="max-width: 100%; height: auto;" /></a>
-                                    </td>
-																		<td style="text-align: center;">
-                                      <a href="https://www.instagram.com/openstax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1v/218812/16777699377tuRGVJk/Vector.png" style="max-width: 100%; height: auto;" /></a>
-                                    </td>
-																		<td style="text-align: center;">
-                                      <a href="https://twitter.com/OpenStax/"><img src="https://www2.openstax.org/l/218812/2023-03-02/21ctk1r/218812/1677769928Hl4fgNGi/Vector_2.png" style="max-width: 100%; height: auto;" /></a>
-                                    </td>
-																	</tr>
-																</tbody>
-															</table>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												</td>
-											</tr>
-											<tr>
-												<td>
 												<table cellpadding="0" cellspacing="0"  id="contentRegion" style="width: 100%; border-collapse: collapse; word-break: break-word; font-size: 14px">
 													<tbody>
 														<tr>
@@ -193,7 +166,7 @@
 													<tbody>
 														<tr>
 															<td align="center" style="padding-top: 20px;padding-bottom: 40px;">
-                                <a href="https://rice.edu" target="_blank"><img alt="" src="https://openstax.cdn.salesforce-experience.com/cms/delivery/media/MCD7V5TURECVAULPMT2H47VAHD5I?oid=00DU0000000KwchMAC&channelId=0ap6f000000KyjfAAC" style="width: 100%; display: block; border: none; max-width: 20%; object-fit: contain;" width="120" /></a>
+                                <a href="https://rice.edu" target="_blank"><img alt="Rice University" src="<%= attachments['rice-logo.png'].url %>" style="width: 100%; display: block; border: none; max-width: 20%; object-fit: contain;" width="120" /></a>
                               </td>
 														</tr>
 													</tbody>
@@ -214,5 +187,5 @@
 		</tr>
 	</tbody>
 </table>
-<img src="https://openstax.my.salesforce.com/servlet/servlet.ImageServer?oid=00DU0000000Kwch&esid=018Pc00000KtcU9&from=ext"></body>
+</body>
 </html>

--- a/spec/mailers/newflow_mailer_spec.rb
+++ b/spec/mailers/newflow_mailer_spec.rb
@@ -21,6 +21,10 @@ module Newflow
         expect(mail.header['to'].to_s).to eq('to@example.org')
         expect(mail.from).to eq(["noreply@openstax.org"])
         expect(mail.body.encoded).to include("Welcome to OpenStax!")
+        expect(mail.attachments['openstax-logo.png']).to be_present
+        expect(mail.attachments['rice-logo.png']).to be_present
+        expect(mail.body.encoded).to include("src=\"cid:#{mail.attachments['openstax-logo.png'].cid}\"")
+        expect(mail.body.encoded).to include("src=\"cid:#{mail.attachments['rice-logo.png'].cid}\"")
       end
 
       context 'when show_pin is not sent' do


### PR DESCRIPTION
This pull request updates the email confirmation process to embed organization logos directly into the email, replacing external image links with inline attachments. It also removes a block of social media icons and an unused tracking image from the email template.

**Email logo embedding:**
* [`app/mailers/newflow_mailer.rb`](diffhunk://#diff-a44c4fdb8c4b02f9a82180a0e6123bcb080039415f43d1584edc5ec383a2ed6dR26-R32): Adds the OpenStax and Rice University logos as inline attachments to the confirmation email, reading them from the local assets directory.
* [`app/views/newflow_mailer/signup_email_confirmation.html.erb`](diffhunk://#diff-848277e9cc0b25faf798538bed2c44c399743db7952f741784d78dd0cc7c0256L37-R37): Updates image tags for OpenStax and Rice University logos to use the new inline attachments instead of external URLs. [[1]](diffhunk://#diff-848277e9cc0b25faf798538bed2c44c399743db7952f741784d78dd0cc7c0256L37-R37) [[2]](diffhunk://#diff-848277e9cc0b25faf798538bed2c44c399743db7952f741784d78dd0cc7c0256L196-R169)

**Template cleanup:**
* [`app/views/newflow_mailer/signup_email_confirmation.html.erb`](diffhunk://#diff-848277e9cc0b25faf798538bed2c44c399743db7952f741784d78dd0cc7c0256L149-L175): Removes the social media icons section from the email template.
* [`app/views/newflow_mailer/signup_email_confirmation.html.erb`](diffhunk://#diff-848277e9cc0b25faf798538bed2c44c399743db7952f741784d78dd0cc7c0256L217-R190): Removes a tracking image at the bottom of the email.