### PR TITLE
chore: pin css_parser ~> 1.22 (CVE-2026-44312 fix; 3.0 blocked by Ruby 3.1.6)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -323,3 +323,13 @@ group :production do
 end
 
 gem "terser", "~> 1.2"
+
+# Pin css_parser (transitive via premailer-rails -> premailer) explicitly so the
+# flagged 1.19.0 doesn't drift back down and the version ceiling is documented in
+# one place. 1.22.0 fixes CVE-2026-44312 (improper HTTPS certificate validation /
+# MITM; the 1.x line was patched in 1.22.0). The remaining SSRF + local-file-
+# disclosure advisory, CVE-2026-53727, is only fixed in css_parser 3.0.0 -- and
+# 2.x/3.x require Ruby >= 3.3 while this app runs 3.1.6, so we cannot reach it
+# without first bumping the app's Ruby. Ceiling here is our Ruby version, not
+# css_parser: bump to '~> 3.0' once this app is on Ruby >= 3.3.
+gem 'css_parser', '~> 1.22'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,8 +103,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     aes_key_wrap (1.1.0)
     apipie-rails (1.4.2)
       actionpack (>= 5.0)
@@ -227,7 +227,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.19.0)
+    css_parser (1.22.0)
       addressable
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -559,7 +559,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     psych (3.3.4)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     puma (6.4.3)
       nio4r (~> 2.0)
     puma_worker_killer (1.0.0)
@@ -834,6 +834,7 @@ DEPENDENCIES
   codecov
   coffee-rails
   compass-rails
+  css_parser (~> 1.22)
   database_cleaner
   db-query-matchers
   delayed_job_active_record


### PR DESCRIPTION
## Summary

Pins `css_parser` (transitive via `premailer-rails → premailer`) to `~> 1.22`, bumping the resolved version **1.19.0 → 1.22.0** to fix a Dependabot-flagged advisory.

> [!IMPORTANT]
> **This does NOT do the css_parser 3.x major bump originally scoped.** That bump is **not achievable on this app** — see below. This PR takes the maximal safe step on our current Ruby, fixes one of the two open CVEs, and documents the second as blocked on a Ruby upgrade.

## CVEs

`css_parser 1.19.0` was vulnerable to two advisories. Reconciliation:

| CVE | Type / severity | Affected | Fixed in | Status here |
|-----|-----------------|----------|----------|-------------|
| **CVE-2026-44312** (GHSA-ff6c-w6qf-7xqc) | Improper HTTPS cert validation → MITM CSS injection. Moderate, CVSS 5.8 | `< 1.22.0` (1.x line) | **1.22.0** | ✅ **Fixed by this PR** |
| **CVE-2026-53727** (GHSA-9pmc-p236-855h) | SSRF + local file disclosure in `read_remote_file`. **High, CVSS 8.9** | `< 3.0.0` (incl. 1.22.0) | **3.0.0 only** | ❌ **Not fixable now — see below** |

## Why the fix can't reach 3.x (the requested major bump)

The only release that fixes the high-severity SSRF/LFD CVE is `css_parser 3.0.0`. Verified against the RubyGems API:

| css_parser | `required_ruby_version` | Compatible with this app (Ruby 3.1.6)? |
|------------|--------------------------|-----------------------------------------|
| 1.22.0 | `>= 3.0` | ✅ |
| 2.0.0 | `>= 3.3` | ❌ |
| 3.0.0 | `>= 3.3` | ❌ |

css_parser dropped Ruby < 3.3 at the 2.0.0 boundary. This app runs **Ruby 3.1.6**, so `bundle` cannot resolve 2.x/3.x at all. Reaching CVE-2026-53727's fix therefore requires **bumping the app's Ruby to ≥ 3.3 first** — out of scope for a dependency PR and tracked as a follow-up.

`premailer 1.27.0` itself declares `css_parser (>= 1.19.0)` with no upper bound, so it happily accepts 1.22.0 (and would accept 3.0.0 once Ruby allows it) — the ceiling is our Ruby version, not premailer.

**Mitigating factor for the un-fixed CVE:** the SSRF/LFD is in `CssParser::Parser#read_remote_file`, reached only when premailer fetches *remote* stylesheets. In this app, premailer-rails inlines local `<style>` blocks from mail templates and does not fetch attacker-controllable remote URLs, so the vulnerable path is not exercised in normal operation. This lowers but does not eliminate risk — hence the follow-up.

## premailer compatibility research

- Dependency chain: `premailer-rails 1.12.0 → premailer 1.27.0 → css_parser (>= 1.19.0)`.
- `css_parser 1.22.0` requires Ruby `>= 3.0` — compatible with 3.1.6.
- The 1.20 → 1.22 changes on the 1.x line are the TLS/cert-validation fix on the **remote-fetch** path plus minor perf; the **CSS-parsing / inlining** code path premailer actually uses is unchanged. No premailer API surface is affected.
- `bundle` resolves cleanly; `Gemfile.lock` also picks up compatible point bumps `addressable 2.8.7 → 2.9.0` and `public_suffix 6.0.1 → 6.0.2`.

## Manual verification performed

No existing spec covers email CSS-inlining, so I verified manually:

1. **Mailer specs (blast radius), isolated DB:** `rspec spec/mailers` → **20 examples, 0 failures**.
2. **Live inlining check** via `Premailer::Rails::CustomizedPremailer` on a representative email with a `<style>` block:
   - `body { height: auto }` → inlined as `style="height:auto"` on `<body>` ✅
   - `table { background-color }` → mapped to `bgcolor` attribute (premailer's standard email-client behavior) ✅
   - `@media` query → correctly preserved in a `<style>` block (can't be inlined) ✅
   - css_parser 1.22.0 parses the app's actual email CSS with no regression ✅
3. **Full fast suite** (`rspec --tag ~speed:slow`) on a dedicated isolated test DB (`TEST_ENV_NUMBER=9`): **1233 examples, 0 failures, 2 pending** (finished in 6m59s, seed 27067). The 2 pending are pre-existing `xit` skips in `spec/handlers/newflow/educator_signup/sheerid_webhook_spec.rb` — unrelated to this change.

> Note: the shared `rake spec:fast` DB in this environment produces spurious Postgres `deadlock detected` / `TransactionIsolationConflict` errors when multiple suites run concurrently (parallel dependency PRs). Those are environmental and unrelated to this change; I ran on a dedicated `TEST_ENV_NUMBER` DB to get a clean signal.

## ⚠️ Needs manual QA before merging

- This changes email CSS-inlining behavior and has **no automated spec coverage** for rendered email appearance. Before merge, please eyeball a real rendered email (e.g. signup confirmation) to confirm styling is unchanged.
- **CVE-2026-53727 (High) is still open** after this PR. Track the Ruby ≥ 3.3 upgrade separately, then bump `css_parser` to `~> 3.0`.

