### PR TITLE
Fix race condition disabling terms "Agree" button on bfcache restore

### DIFF
--- a/app/assets/javascripts/newflow/newflow_ui.js.coffee
+++ b/app/assets/javascripts/newflow/newflow_ui.js.coffee
@@ -33,10 +33,16 @@ NewflowUi = do () ->
   enableOnChecked: (targetSelector, sourceSelector) ->
     $(document).ready =>
 
-      enable_disable_continue = () =>
+      check = () =>
         this.checkCheckedButton(targetSelector, sourceSelector)
 
-      setTimeout(enable_disable_continue, 500)
+      check()
+
+      # Re-check on bfcache restore (e.g. browser back button), where the
+      # browser may refill form fields after this ready handler already ran,
+      # racing with jQuery-UJS's own disabling of the submit button.
+      window.addEventListener 'pageshow', (event) ->
+        check() if event.persisted
 
       $(sourceSelector).on 'click', =>
         this.checkCheckedButton(targetSelector, sourceSelector)


### PR DESCRIPTION
## Problem

On the POSE terms page (and other `NewflowUi.enableOnChecked` forms), users could get stranded with the **"Agree"** submit button stuck **disabled even when the agreement checkbox was checked**.

Root cause: `enableOnChecked` in `newflow_ui.js.coffee` ran its initial checkbox check inside a `setTimeout(..., 500)`. On **bfcache (back-button) restores**, the browser refills form fields *after* the `$(document).ready` handler has already run, and jQuery-UJS separately toggles the submit button's disabled state. The 500ms timer raced with that restore, so the button's final state didn't reflect the (restored, checked) checkbox.

## Fix

- Run the checkbox check **synchronously** in the ready handler (no `setTimeout`).
- Add a `pageshow` listener that re-runs the check when `event.persisted` is true, so **bfcache restores** get a fresh evaluation after the browser refills fields.

## Testing

- `spec/features/pose_terms_spec.rb` run **15×** with distinct seeds → **15/15 pass** (timing/race regression check).
- `spec/features/newflow/student_signup_flow_spec.rb` + `educator_signup_flow_spec.rb` (the other `enableOnChecked` consumers) → **18/18 pass**.

## Note on the legacy duplicate

The legacy `Accounts.Ui.enableOnChecked` in `app/assets/javascripts/application/ui.js.coffee` (used by `app/views/legacy/signup/profile.html.erb`) does **not** have this bug — it disables the button synchronously inside `$(document).ready` with no `setTimeout`, so no change was needed there.