### PR TITLE
Fix multi-book adoption reporting, preserve return path, and clarify student overview copy

### DIFF
--- a/app/assets/javascripts/application/report_adoption_modal.js
+++ b/app/assets/javascripts/application/report_adoption_modal.js
@@ -8,11 +8,12 @@
     }
   }
 
-  var nextRowIndex = 1;
-
   function getBookRowTemplateHtml() {
     var template = document.getElementById('report-adoption-book-template');
-    return template ? template.innerHTML.trim().replace(/__INDEX__/g, nextRowIndex++) : '';
+    // Rows keep the template's __INDEX__ placeholder until renumberRows()
+    // assigns an index from their position, so removing a row can never
+    // leave two rows sharing one index.
+    return template ? template.innerHTML.trim() : '';
   }
 
   function addBookRow() {
@@ -27,7 +28,7 @@
     $row.find('input[type="number"]').val('');
     $('[data-report-adoption-books]').append($row);
     applyDefaultSchoolYear($row);
-    setRowLabels();
+    renumberRows();
     updateRemoveButtons();
     updateSummaryMetrics();
   }
@@ -50,7 +51,7 @@
     }
 
     $row.remove();
-    setRowLabels();
+    renumberRows();
     updateRemoveButtons();
     updateSummaryMetrics();
   }
@@ -78,7 +79,7 @@
     $rows.find('select').val('');
     $rows.find('input[type="number"]').val('');
     applyDefaultSchoolYear($rows.first());
-    setRowLabels();
+    renumberRows();
     updateRemoveButtons();
     updateSummaryMetrics();
   }
@@ -150,13 +151,17 @@
     updateBookCount();
   }
 
-  function setRowLabels() {
+  function renumberRows() {
     var $rows = $('[data-report-adoption-row]');
     $rows.each(function(index, row) {
       var $label = $(row).find('[data-report-adoption-row-label]');
       if ($label.length) {
         $label.text('Adoption ' + (index + 1));
       }
+
+      $(row).find('[name]').each(function(_, field) {
+        field.name = field.name.replace(/^books\[[^\]]*\]/, 'books[' + index + ']');
+      });
     });
   }
 
@@ -177,13 +182,12 @@
       form.reset();
     }
 
-    nextRowIndex = 1;
     resetBookRows();
-    setRowLabels();
+    renumberRows();
     updateSummaryMetrics();
   });
 
   // initialize on load
-  setRowLabels();
+  renumberRows();
   updateSummaryMetrics();
 })();

--- a/app/assets/javascripts/application/report_adoption_modal.js
+++ b/app/assets/javascripts/application/report_adoption_modal.js
@@ -8,9 +8,11 @@
     }
   }
 
+  var nextRowIndex = 1;
+
   function getBookRowTemplateHtml() {
     var template = document.getElementById('report-adoption-book-template');
-    return template ? template.innerHTML.trim() : '';
+    return template ? template.innerHTML.trim().replace(/__INDEX__/g, nextRowIndex++) : '';
   }
 
   function addBookRow() {
@@ -130,7 +132,7 @@
   }
 
   function updateBookCount() {
-    var selects = $('[data-report-adoption-row] select[name="books[][name]"]');
+    var selects = $('[data-report-adoption-row] select[name$="[name]"]');
     var count = 0;
 
     selects.each(function(_, select) {
@@ -163,10 +165,10 @@
   $(document).on('click', '[data-report-adoption-remove]', handleRemoveBookClick);
 
   $(document).on('input', '[data-report-adoption-students]', updateSummaryMetrics);
-  $(document).on('change', '[data-report-adoption-row] select[name="books[][name]"]', updateSummaryMetrics);
+  $(document).on('change', '[data-report-adoption-row] select[name$="[name]"]', updateSummaryMetrics);
 
   // Submission is a plain form POST handled by Account::AdoptionReportsController;
-  // the browser follows the redirect back to the books page on its own.
+  // the browser follows the redirect back to the page that opened the modal.
 
   $(document).on('show.bs.modal', '#reportAdoptionModal', function() {
     var form = document.getElementById('report-adoption-form');
@@ -175,6 +177,7 @@
       form.reset();
     }
 
+    nextRowIndex = 1;
     resetBookRows();
     setRowLabels();
     updateSummaryMetrics();

--- a/app/controllers/account/adoption_reports_controller.rb
+++ b/app/controllers/account/adoption_reports_controller.rb
@@ -6,7 +6,7 @@ module Account
       rows = valid_rows(params[:books])
 
       if rows.blank?
-        redirect_to account_books_path,
+        redirect_to return_path,
                     alert: 'Please select at least one book and school year to report an adoption.'
         return
       end
@@ -18,12 +18,12 @@ module Account
       PushAdoptionReports.perform_later(user: current_user) if results.any?
 
       if results.all?
-        redirect_to account_books_path,
+        redirect_to return_path,
                     notice: "Thanks — your report helps us measure OpenStax's impact."
       else
         # Static text only — flash notices/alerts are rendered html_safe by
         # the layout, so no user-typed row data belongs in here.
-        redirect_to account_books_path,
+        redirect_to return_path,
                     alert: "Thanks for the report — some rows couldn't be saved. Please check your entries and try again."
       end
     end
@@ -33,7 +33,9 @@ module Account
     # Skip fully blank rows (the modal always submits at least one row, plus
     # any the user added); a row only counts once it has a book and year.
     def valid_rows(raw_rows)
-      Array(raw_rows).filter_map do |row|
+      rows = raw_rows.respond_to?(:values) ? raw_rows.values : Array(raw_rows)
+
+      rows.filter_map do |row|
         next unless row.respond_to?(:[])
 
         book_title = row[:name].to_s.strip
@@ -42,6 +44,14 @@ module Account
 
         { book_title: book_title, school_year: school_year, students: row[:students] }
       end
+    end
+
+    # The report modal is shared across account pages. Return users to the
+    # page where they opened it, while accepting only known local paths.
+    def return_path
+      allowed_paths = [account_overview_path, account_books_path, account_impact_path]
+      requested_path = params[:return_to].to_s.split('?').first
+      allowed_paths.include?(requested_path) ? params[:return_to] : account_books_path
     end
 
     def upsert_adoption_report(row)

--- a/app/views/account/student_overview.html.erb
+++ b/app/views/account/student_overview.html.erb
@@ -63,8 +63,8 @@
           <% end %>
         </section>
 
-        <section class="account-student-overview__connect-card" aria-label="Connect with your instructor">
-          <h2>Tell us who teaches your class <span class="account-student-overview__optional">(optional)</span></h2>
+        <section class="account-student-overview__connect-card" aria-labelledby="instructor-connect-heading">
+          <h2 id="instructor-connect-heading">Tell us who teaches your class <span class="account-student-overview__optional">(optional)</span></h2>
           <p>This helps OpenStax understand which courses use our books. It does not message your instructor, connect your accounts, or change your saved books.</p>
 
           <div class="account-student-overview__autocomplete" data-instructor-autocomplete data-not-listed-target="instructor-not-listed-panel">
@@ -276,7 +276,7 @@
         close();
 
         if (instructor) {
-          connectToInstructor(instructor);
+          submitInstructor(instructor);
         } else if (notListedPanel) {
           notListedPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });
           var firstField = notListedPanel.querySelector('input, select');
@@ -284,9 +284,9 @@
         }
       }
 
-      function connectToInstructor(instructor) {
+      function submitInstructor(instructor) {
         input.value = instructor.name;
-        setStatus('Connecting...');
+        setStatus('Submitting...');
 
         fetch(CONNECT_URL, {
           method: 'POST',
@@ -297,7 +297,7 @@
           },
           body: JSON.stringify({ instructor_connection_form: { instructor_id: instructor.id } })
         })
-          .then(function(response) { return response.ok ? setStatus('Connected to ' + instructor.name + '.') : setStatus('Something went wrong — please try again.'); })
+          .then(function(response) { return response.ok ? setStatus('Thanks — we recorded ' + instructor.name + ' as your instructor.') : setStatus('Something went wrong — please try again.'); })
           .catch(function() { setStatus('Something went wrong — please try again.'); });
       }
 

--- a/app/views/account/student_overview.html.erb
+++ b/app/views/account/student_overview.html.erb
@@ -64,14 +64,14 @@
         </section>
 
         <section class="account-student-overview__connect-card" aria-label="Connect with your instructor">
-          <h2>Who teaches your class?</h2>
-          <p>Connect to your instructor and we'll keep your saved books in sync with what they assign. Start typing — most instructors are already here.</p>
+          <h2>Tell us who teaches your class <span class="account-student-overview__optional">(optional)</span></h2>
+          <p>This helps OpenStax understand which courses use our books. It does not message your instructor, connect your accounts, or change your saved books.</p>
 
           <div class="account-student-overview__autocomplete" data-instructor-autocomplete data-not-listed-target="instructor-not-listed-panel">
-            <label for="instructor-search-input" class="sr-only">Instructor name</label>
+            <label for="instructor-search-input">Search for your instructor</label>
             <input type="text"
                    id="instructor-search-input"
-                   placeholder="Instructor name"
+                   placeholder="Start typing a name"
                    data-instructor-search-input
                    autocomplete="off"
                    role="combobox"
@@ -86,13 +86,13 @@
 
           <% if @instructor_connections.any? %>
             <div class="account-student-overview__connections">
-              <p class="account-student-overview__connections-label">You've added:</p>
+              <p class="account-student-overview__connections-label">Instructor information you submitted:</p>
               <ul>
                 <% @instructor_connections.each do |connection| %>
                   <li>
                     <%= connection.instructor_name %>
                     <% if connection.school_name.present? %>(<%= connection.school_name %>)<% end %>
-                    <span class="account-badge account-student-overview__unverified-chip">Unverified</span>
+                    <span class="account-badge account-student-overview__unverified-chip">Submitted</span>
                   </li>
                 <% end %>
               </ul>
@@ -101,19 +101,19 @@
         </section>
 
         <div class="account-student-overview__not-listed-panel" id="instructor-not-listed-panel">
-          <h3>Add your instructor</h3>
-          <p>If they're not in the list, tell us who they are — we'll take it from here.</p>
+          <h3>Can't find your instructor?</h3>
+          <p>Enter the information you know below. Required fields are marked.</p>
 
           <%= form_with url: account_instructor_connections_path, method: :post, local: true,
                         class: 'account-student-overview__not-listed-form' do %>
             <div class="account-student-overview__not-listed-grid">
               <div class="account-student-overview__field">
-                <label for="instructor-name">Instructor name</label>
+                <label for="instructor-name">Instructor name (required)</label>
                 <input type="text" id="instructor-name" name="instructor_connection_form[instructor_name]"
                        placeholder="First and last name" required>
               </div>
               <div class="account-student-overview__field">
-                <label for="instructor-school">School</label>
+                <label for="instructor-school">School (required)</label>
                 <input type="text" id="instructor-school" name="instructor_connection_form[school_name]"
                        value="<%= current_user.school&.name %>" required>
               </div>
@@ -134,7 +134,7 @@
                 <input type="email" id="instructor-email" name="instructor_connection_form[instructor_email]" placeholder="If you know it">
               </div>
             </div>
-            <button type="submit" class="account-student-overview__submit">Add instructor</button>
+            <button type="submit" class="account-student-overview__submit">Submit instructor information</button>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_report_adoption_modal.html.erb
+++ b/app/views/shared/_report_adoption_modal.html.erb
@@ -40,7 +40,8 @@
       <div class="report-adoption__field report-adoption__field--book">
         <label>
           Book
-          <select name="books[][name]"
+          <select name="books[__INDEX__][name]"
+                  required
                   class="form-control">
             <option value="">Select a book</option>
             <% book_options.each do |label, value| %>
@@ -53,7 +54,8 @@
       <div class="report-adoption__field report-adoption__field--year">
         <label>
           School year
-          <select name="books[][school_year]"
+          <select name="books[__INDEX__][school_year]"
+                  required
                   class="form-control"
                   data-report-adoption-school-year>
             <option value="">Select school year</option>
@@ -73,7 +75,7 @@
                 tabindex="0"
                 aria-label="Total number of students using OpenStax for the full academic year.">i</span>
           <input type="number"
-                 name="books[][students]"
+                 name="books[__INDEX__][students]"
                  class="form-control"
                  min="0"
                  placeholder="e.g., 120"
@@ -96,7 +98,7 @@
         <div class="report-adoption__header-text">
           <h5 class="modal-title" id="reportAdoptionModalLabel">Report an adoption</h5>
           <p class="report-adoption__header-helper">
-            A quick update helps OpenStax support your courses and keep resources students affordable.
+            Tell us which books you use, for which school year, and approximately how many students you teach.
           </p>
         </div>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -105,7 +107,7 @@
       </div>
       <div class="modal-body">
         <div class="report-adoption__callout">
-          Reporting helps OpenStax measure student impact and continuing supporting high-quality learning resources.
+          Your report helps OpenStax understand student impact and continue supporting high-quality, affordable learning resources.
         </div>
         <%= form_tag account_adoption_reports_path,
                       method: :post,
@@ -113,8 +115,10 @@
                       class: 'report-adoption__form',
                       data: { current_school_year: current_school_year_label } do %>
 
+          <%= hidden_field_tag :return_to, request.fullpath %>
+
           <div class="report-adoption__books" data-report-adoption-books>
-            <%= book_row_markup.html_safe %>
+            <%= book_row_markup.gsub('__INDEX__', '0').html_safe %>
           </div>
 
           <template id="report-adoption-book-template">
@@ -137,7 +141,7 @@
               <p class="report-adoption__helper-text">You can add multiple books before saving.</p>
             </div>
 
-            <%= submit_tag 'Save',
+            <%= submit_tag 'Submit report',
                            class: 'ox-button ox-button--solid' %>
           </div>
         <% end %>

--- a/spec/controllers/account/adoption_reports_controller_spec.rb
+++ b/spec/controllers/account/adoption_reports_controller_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe Account::AdoptionReportsController, type: :controller do
         expect(flash[:notice]).to be_present
       end
 
+      it 'accepts the indexed hash submitted by the browser form and returns to its source page' do
+        expect {
+          post :create, params: {
+            return_to: account_impact_path(view: 'current'),
+            books: {
+              '0' => { name: 'Intro to Sociology', school_year: '2025 - 26', students: '120' },
+              '1' => { name: 'College Physics', school_year: '2025 - 26', students: '45' }
+            }
+          }
+        }.to change { AdoptionReport.count }.by(2)
+
+        expect(response).to redirect_to(account_impact_path(view: 'current'))
+      end
+
+      it 'does not redirect to an untrusted return path' do
+        post :create, params: {
+          return_to: '//example.com',
+          books: [{ name: 'Intro to Sociology', school_year: '2025 - 26', students: '10' }]
+        }
+
+        expect(response).to redirect_to(account_books_path)
+      end
+
       it "flashes a partial-failure notice and still enqueues the push when some rows can't be saved" do
         expect(PushAdoptionReports).to receive(:perform_later).with(user: user)
 

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe AccountController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('Welcome back, Jordan')
-      expect(response.body).to include('Who teaches your class?')
+      expect(response.body).to include('Tell us who teaches your class')
       expect(response.body).to include('account-badge--student')
       expect(response.body).not_to include('Verified educator')
     end
@@ -170,7 +170,7 @@ RSpec.describe AccountController, type: :controller do
       get :overview
 
       expect(response.body).to include('Sarah Delgado')
-      expect(response.body).to include('Unverified')
+      expect(response.body).to include('account-student-overview__unverified-chip">Submitted')
     end
 
     it 'still renders every other account page for a student' do

--- a/spec/features/newflow/report_adoption_modal_spec.rb
+++ b/spec/features/newflow/report_adoption_modal_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+feature 'report an adoption modal', js: true do
+  let!(:biology) { Book.create!(book_uuid: SecureRandom.uuid, title: 'Biology 2e') }
+  let!(:physics) { Book.create!(book_uuid: SecureRandom.uuid, title: 'College Physics') }
+
+  let!(:instructor) do
+    create_newflow_user('instructor@openstax.org', 'password', true, nil, 'instructor')
+  end
+
+  def open_modal
+    find('[data-report-adoption-trigger]').click
+    expect(page).to have_css('#reportAdoptionModal.in', wait: 5)
+    wait_for_animations
+  end
+
+  # Rows are numbered by their position, so a removed row can't leave two
+  # rows sharing an index (which would silently drop one adoption on POST).
+  scenario 'keeps row indexes unique after a row is removed and the modal is reopened' do
+    newflow_log_in_user('instructor@openstax.org', 'password')
+
+    visit(account_overview_path)
+    wait_for_animations
+    wait_for_ajax
+
+    open_modal
+    click_button('+ Add another book')
+    expect(page).to have_css('[data-report-adoption-row]', count: 2)
+
+    # Drop the original row 0; the survivor must be renumbered back to 0.
+    first('[data-report-adoption-row] [data-report-adoption-remove]').click
+    expect(page).to have_css('select[name="books[0][name]"]', count: 1)
+
+    find('#reportAdoptionModal button.close').click
+    expect(page).to have_no_css('#reportAdoptionModal.in', wait: 5)
+
+    open_modal
+    click_button('+ Add another book')
+
+    expect(page).to have_css('select[name="books[0][name]"]', count: 1)
+    expect(page).to have_css('select[name="books[1][name]"]', count: 1)
+
+    find('select[name="books[0][name]"]').select('Biology 2e')
+    find('select[name="books[1][name]"]').select('College Physics')
+
+    expect {
+      click_button('Submit report')
+      expect(page).to have_content("Thanks — your report helps us measure OpenStax's impact.", wait: 5)
+    }.to change { AdoptionReport.count }.by(2)
+  end
+end

--- a/spec/features/newflow/student_account_overview_spec.rb
+++ b/spec/features/newflow/student_account_overview_spec.rb
@@ -33,7 +33,8 @@ feature 'student account overview', js: true do
     expect(page).to have_content('Student')
     expect(page).to have_content('School verified')
     expect(page).to have_content('Biology 2e')
-    expect(page).to have_content('Who teaches your class?')
+    expect(page).to have_content('Tell us who teaches your class')
+    expect(page).to have_content('It does not message your instructor, connect your accounts, or change your saved books.')
 
     fill_in('instructor-search-input', with: 'Delg')
     expect(page).to have_css('li', text: 'Sarah Delgado', wait: 5)
@@ -71,7 +72,7 @@ feature 'student account overview', js: true do
     fill_in('instructor-school', with: 'University of Houston')
     fill_in('instructor-course', with: 'BIOL 101')
 
-    click_button('Add instructor')
+    click_button('Submit instructor information')
     wait_for_animations
     wait_for_ajax
 

--- a/spec/features/newflow/student_account_overview_spec.rb
+++ b/spec/features/newflow/student_account_overview_spec.rb
@@ -53,7 +53,7 @@ feature 'student account overview', js: true do
 
     # The autocomplete selection POSTs via fetch (not jQuery), so wait on the
     # status text it renders rather than wait_for_ajax's jQuery.active check.
-    expect(page).to have_content('Connected to Sarah Delgado.', wait: 5)
+    expect(page).to have_content('Thanks — we recorded Sarah Delgado as your instructor.', wait: 5)
 
     connection = InstructorConnection.find_by(student: student)
     expect(connection).to be_present


### PR DESCRIPTION
### Motivation
- Multi-book adoption submissions were being parsed incorrectly by the controller because form inputs used ambiguous `books[]` names, breaking the report flow and confusing users. 
- The adoption modal UX and copy were unclear about what to report and where the user would be returned after saving. 
- The student overview instructor-connect card copy implied stronger actions than it actually performs, causing potential user confusion.

### Description
- Change the adoption modal inputs to use indexed names (`books[__INDEX__][...]`), mark book/year as `required`, add a hidden `return_to` field, and improve helper copy and the submit button label (`Submit report`).
- Update the client JS to inject per-row indexes (`nextRowIndex`), replace `__INDEX__` when cloning rows, and relax selectors to match the new indexed name format (`name$="[name]"`), plus reset the index on modal open.
- Update `Account::AdoptionReportsController` to accept the indexed hash shape, normalize `params[:books]` into an ordered array, skip blank rows, upsert reports, and return users to an allowlisted `return_to` path when present (falling back to the books page for unsafe values).
- Clarify student overview language and form labels to indicate the instructor claim is optional and does not message instructors or change saved books, and adjust the fallback form button text; add/adjust spec coverage to assert indexed submissions, safe return redirects, and updated UI text.

### Testing
- `node --check app/assets/javascripts/application/report_adoption_modal.js` succeeded for the updated JS.
- `ruby -c` syntax check on `app/controllers/account/adoption_reports_controller.rb` succeeded.
- `git diff --check` and basic repository checks reported no issues.
- `bundle install` and the full `rspec` run could not be completed because installing gem dependencies failed (GitHub/Gem fetch returned HTTP 403 / the `pattern-library` git dependency was not checked out), so the full test suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7a6795b65883248b8145a1339f8209)