### PR TITLE
CORE-2227 FindOrCreateUser role changes

### DIFF
--- a/app/routines/find_or_create_user.rb
+++ b/app/routines/find_or_create_user.rb
@@ -22,10 +22,14 @@ class FindOrCreateUser
   end
 
   # Attempt to find a user by either the external_id or email address
+  #
+  # role: Set on new records, but not used to require a match on existing records -
+  # prefer a role match if one exists, otherwise reuse whatever linkage is already there.
   def find_user(options)
     if options[:external_id].present?
-      ExternalId.find_by_external_id_and_role(options[:external_id], options[:role])&.user ||
-        find_by_verified_email(options)
+      external_ids = ExternalId.where(external_id: options[:external_id]).to_a
+      matching_role = external_ids.find { |ext_id| ext_id.role == options[:role].to_s } if options[:role]
+      (matching_role || external_ids.first)&.user || find_by_verified_email(options)
     elsif options[:email].present?
       return find_by_verified_email(options) if options[:already_verified]
       fatal_error(code: :invalid_input, message: 'An unverified email requires an external_id')

--- a/app/routines/find_or_create_user.rb
+++ b/app/routines/find_or_create_user.rb
@@ -22,13 +22,12 @@ class FindOrCreateUser
   end
 
   # Attempt to find a user by either the external_id or email address
-  #
-  # role: Set on new records, but not used to require a match on existing records -
-  # prefer a role match if one exists, otherwise reuse whatever linkage is already there.
+  # The role is set on new records, but not used to require a match on existing records
+  # We prefer a role match if one exists, but otherwise reuse whatever newest linkage is already there
   def find_user(options)
     if options[:external_id].present?
-      external_ids = ExternalId.where(external_id: options[:external_id]).to_a
-      matching_role = external_ids.find { |ext_id| ext_id.role == options[:role].to_s } if options[:role]
+      external_ids = ExternalId.where(external_id: options[:external_id]).order(id: :desc).to_a
+      matching_role = options[:role] && external_ids.find { |ext_id| ext_id.role == options[:role].to_s }
       (matching_role || external_ids.first)&.user || find_by_verified_email(options)
     elsif options[:email].present?
       return find_by_verified_email(options) if options[:already_verified]

--- a/spec/routines/find_or_create_user_spec.rb
+++ b/spec/routines/find_or_create_user_spec.rb
@@ -90,6 +90,28 @@ describe FindOrCreateUser do
 
     end
 
+    context "already linked under a different role" do
+
+      it "reuses the existing user instead of creating a duplicate, and leaves the existing ExternalId untouched" do
+        existing_user = described_class.call(
+          external_id: 'google-classroom/999', email: 'instructor@example.com',
+          first_name: 'Bob', last_name: 'Smith', already_verified: true, role: 'instructor'
+        ).outputs.user
+
+        found = nil
+        expect {
+          found = described_class.call(
+            external_id: 'google-classroom/999',
+            first_name: 'Bob', last_name: 'Smith', already_verified: false, role: 'student'
+          ).outputs.user
+        }.not_to change(User, :count)
+
+        expect(found).to eq(existing_user)
+        expect(existing_user.reload.external_ids.map(&:role)).to eq(['instructor'])
+      end
+
+    end
+
     context "given an email already claimed (unverified) by a different user" do
       let!(:other_user) { FactoryBot.create :user }
       let(:conflicting_email) { 'shared@example.com' }

--- a/spec/routines/find_or_create_user_spec.rb
+++ b/spec/routines/find_or_create_user_spec.rb
@@ -110,6 +110,38 @@ describe FindOrCreateUser do
         expect(existing_user.reload.external_ids.map(&:role)).to eq(['instructor'])
       end
 
+      it "prefers the matching-role ExternalId when multiple match the external_id" do
+        instructor_user = described_class.call(
+          external_id: 'google-classroom/1000', email: 'instructor@example.com',
+          first_name: 'Ada', last_name: 'Lovelace', already_verified: true, role: 'instructor'
+        ).outputs.user
+
+        student_user = FactoryBot.create :user
+        ExternalId.create!(external_id: 'google-classroom/1000', role: 'student', user: student_user)
+
+        found = described_class.call(
+          external_id: 'google-classroom/1000',
+          first_name: 'Ada', last_name: 'Lovelace', already_verified: false, role: 'instructor'
+        ).outputs.user
+
+        expect(found).to eq(instructor_user)
+      end
+
+      it "falls back deterministically (by most recent linkage)" do
+        legacy_user = FactoryBot.create :user
+        ExternalId.create!(external_id: 'google-classroom/1001', role: 'unknown_role', user: legacy_user)
+
+        other_role_user = FactoryBot.create :user
+        other_role_external_id = ExternalId.create!(external_id: 'google-classroom/1001', role: 'librarian', user: other_role_user)
+
+        found = described_class.call(
+          external_id: 'google-classroom/1001',
+          first_name: 'Bob', last_name: 'Smith', already_verified: false, role: 'instructor'
+        ).outputs.user
+
+        expect(found).to eq(other_role_external_id.user)
+      end
+
     end
 
     context "given an email already claimed (unverified) by a different user" do


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-2227

Made FindOrCreateUser prefer the passed role but ultimately reuse any ExternalId rather than creating a new account.

FindOrCreateUser is called to auto-create student accounts. If they are already linked to an instructor account, we can just use that account instead of creating a new one (more relevant to Google Classroom where the role is more likely to change per course).

The role is set so they can later add a separate link for an instructor account that they already have if needed. That process uses FindUser instead though so it should still work despite this change.