### PR TITLE
fix(educator signup): repair broken .edu check and book validation alerts

### DIFF
--- a/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
+++ b/app/assets/javascripts/newflow/educator_complete_dynamic.js.coffee
@@ -128,6 +128,21 @@ class NewflowUi.EducatorComplete
         total_num_students_valid)
       ev.preventDefault()
 
+      invalid_fields = (name for [name, valid] in [
+        ['school_name', school_name_valid]
+        ['role', role_valid]
+        ['other', other_valid]
+        ['chosen', chosen_valid]
+        ['using_how', using_how_valid]
+        ['books_used', books_used_valid]
+        ['books_used_max', books_used_valid_max]
+        ['books_used_details', books_used_details_valid]
+        ['books_of_interest', books_of_interest_valid]
+        ['books_of_interest_max', books_of_interest_valid_max]
+        ['total_num_students', total_num_students_valid]
+      ] when not valid)
+      window.posthog?.capture('educator_signup_validation_failed', { form: 'educator_profile', invalid_fields: invalid_fields })
+
   checkSchoolNameValid: () ->
     return true if document.getElementsByClassName('school-name-visible')[0] == undefined
 
@@ -166,10 +181,10 @@ class NewflowUi.EducatorComplete
 
     values = selects.map ->
       if $(this).val()
-        $(this).siblings('.how-using-book.newflow-mustdo-alert').hide()
+        $(this).siblings('.using-book.newflow-mustdo-alert').hide()
         true
       else
-        $(this).siblings('.how-using-book.newflow-mustdo-alert').show()
+        $(this).siblings('.using-book.newflow-mustdo-alert').show()
         false
     return values.get().every (value) -> value
 
@@ -349,6 +364,9 @@ class NewflowUi.EducatorComplete
     @updateBooksUsedFields(@getSelectedBooks('books_used'))
     @enforceMaxBooks('books_used')
     @checkBooksUsedValidMax()
+    # Adding a book disables Continue until its details are filled; removing one
+    # must re-open it, otherwise deselecting the blocking book leaves it dead.
+    @checkBooksUsedDetailsValid()
     @please_select_books_used.hide()
 
   onBooksOfInterestChange: ->
@@ -399,11 +417,14 @@ class NewflowUi.EducatorComplete
             coverImg.setAttribute('src', coverUrl || '')
             coverImg.setAttribute('alt', bookTitle)
 
+          # `name` keeps the literal %placeholder-book-name%, but Rails derives id/for
+          # from the name and turns each % into _, so match both forms to keep every
+          # clone's id/for unique instead of colliding on one shared id.
           clonedNode.querySelectorAll('label, select, input').forEach (element) ->
             element.removeAttribute('disabled')
             Array.from(element.attributes)
-            .filter((attr) -> attr.value.includes('%placeholder-book-name%'))
-            .forEach((attr) -> attr.value = attr.value.replace('%placeholder-book-name%', book))
+            .filter((attr) -> attr.value.includes('placeholder-book-name'))
+            .forEach((attr) -> attr.value = attr.value.replace(/%?placeholder-book-name%?/g, book))
 
           templateNode.insertAdjacentElement('afterend', clonedNode)
           @attachBookUsedEvents(clonedNode)

--- a/app/assets/javascripts/newflow/educator_signup_email_validations.js.coffee
+++ b/app/assets/javascripts/newflow/educator_signup_email_validations.js.coffee
@@ -23,7 +23,7 @@ class NewflowUi.SignupEmailValidations
       if @userType is 'instructor'
         @showing_warning = true
         window.posthog?.capture('educator_signup_email_suggestion_shown', { form: 'educator_signup' })
-        @group.addClass('has-error')
+        @group.removeClass('has-error')
         @group.find(".errors").empty()
         @group.find(".edu.warning").show()
         @email.focus()

--- a/app/assets/javascripts/newflow/educator_signup_email_validations.js.coffee
+++ b/app/assets/javascripts/newflow/educator_signup_email_validations.js.coffee
@@ -1,4 +1,7 @@
-IS_EDU = new RegExp('\.edu\s*$', 'i')
+# Institutional email domains: US .edu plus common international academic patterns
+# (.edu.au, .ac.uk, .k12.tx.us, .sch.uk, ...). A regex literal keeps the escapes
+# that a single-quoted string silently dropped.
+IS_EDU = /\.(edu|edu\.[a-z]{2}|ac\.[a-z]{2}|k12\.[a-z]{2}\.us|sch\.[a-z]{2})\s*$/i
 
 class NewflowUi.SignupEmailValidations
 
@@ -19,6 +22,7 @@ class NewflowUi.SignupEmailValidations
     if not ((@email.val() == '') or @showing_warning or IS_EDU.test(@email.val()))
       if @userType is 'instructor'
         @showing_warning = true
+        window.posthog?.capture('educator_signup_email_suggestion_shown', { form: 'educator_signup' })
         @group.addClass('has-error')
         @group.find(".errors").empty()
         @group.find(".edu.warning").show()

--- a/app/assets/stylesheets/newflow.scss
+++ b/app/assets/stylesheets/newflow.scss
@@ -990,8 +990,16 @@ $very-narrow: 37rem * $scale-factor;
 #login-signup-form  {
     .warning {
         &.edu, &.mistype {
-            color: #c22032;
             display: none;
+        }
+
+        &.mistype {
+            color: #c22032;
+        }
+
+        // A non-institutional address is a nudge to use a school email, not a rejection.
+        &.edu {
+            color: #31708f;
         }
     }
 


### PR DESCRIPTION
## What

Fixes two client-side validation bugs in the educator signup flow that made educators hit phantom validation errors and repeatedly click **Continue**.

### Email form (`educator_signup_email_validations.js.coffee`)
- **Broken regex.** `IS_EDU` was built with `new RegExp('\.edu\s*$', 'i')`. Inside a single-quoted string the `\.` and `\s` escapes are dropped, so the browser actually compiled `/.edus*$/i`. Replaced it with a real regex literal and widened it to cover international institutional domains (`.edu.au`, `.ac.uk`, `.k12.*.us`, `.sch.*`), so educators outside the US stop getting warned on every submit.
- **Suggestion, not rejection.** The school-email block was styled with the red error color, so a soft "is this your school email?" confirm read as a hard rejection. Restyled it as a neutral suggestion; the confirm-on-Continue behavior is intentional and unchanged.

### Profile form (`educator_complete_dynamic.js.coffee`)
- **Invisible "how are you using this book" error.** `checkBookUsedHowValid` toggled `.how-using-book.newflow-mustdo-alert`, but the markup renders `.using-book.newflow-mustdo-alert`, so the error never showed while it silently blocked submit. Corrected the selector.
- **Dead Continue button.** Adding a book disables Continue until its details are filled, but `onBooksUsedChange` never re-evaluated on removal, so deselecting the blocking book left the button permanently disabled. It now re-runs `checkBooksUsedDetailsValid`.
- **Colliding clone ids.** Cloned book cards shared one DOM `id` because Rails turns `%` into `_` when deriving `id`/`for` from the field `name`, so the `%placeholder-book-name%` substitution missed them. The substitution now matches both the raw and Rails-sanitized forms, giving each clone a unique id.

### Measurability
Neither form emitted an event when validation failed, so the friction couldn't be measured. Both now emit a guarded `posthog.capture` on validation failure (`educator_signup_email_suggestion_shown`, `educator_signup_validation_failed` with the list of invalid fields).

## Testing
- Regex behavior and the id-uniqueness substitution verified with node assertions across US/international/personal domains.
- Both CoffeeScript files compile cleanly under the project's compiler version (1.12.7).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*