### PR TITLE
Restore the original PostHog event names renamed in #1736, and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+OpenStax Accounts is the centralized user-account/authentication service for OpenStax products: login, signup, OAuth (via Doorkeeper), profile/personal data, email notifications, and Salesforce sync for leads/students/schools. It's a Rails 6.1 monolith (Ruby 3.1.6, PostgreSQL, `repeatable read` isolation level required).
+
+## Commands
+
+### Setup
+```sh
+bundle install --without production
+rake db:create db:setup      # or db:migrate if the DB already exists
+cp .env.example .env
+rails server                 # runs on http://localhost:2999
+```
+Docker alternative: `docker-compose up -d` (or `docker-compose run --rm app /bin/bash` for a shell).
+
+### Tests
+```sh
+rspec                                   # full suite
+rspec ./spec/features                   # one directory
+rspec ./spec/some/specific_spec.rb:42   # one spec at a line
+rake spec:fast                          # excludes specs tagged speed:slow
+rake spec:slow                          # only specs tagged speed:slow
+RAISE=true rspec                        # don't rescue exceptions in feature specs (easier debugging)
+```
+Feature specs use Selenium Manager (built into selenium-webdriver ≥ 4.11) to auto-manage chromedriver — no webdrivers gem or manual driver install; Chrome must be present. Use `bundle exec rspec` (bare `rspec` can hit a date-gem activation clash). Note: no specs currently carry the `speed:slow` tag, so `spec:slow` is a no-op and `spec:fast` runs everything.
+
+### Background jobs
+Jobs run inline in development by default. To run them out-of-process, set `USE_REAL_BACKGROUND_JOBS=true` in `.env` and start the worker: `bin/rake jobs:work`.
+
+### Debugging
+Set `DEBUGGER=byebug` in `.env` to use byebug instead of the VS Code debugger.
+
+### Linting
+Rubocop config is in `.rubocop.yml` (excludes `config/**/*.rb`). Any new disabled cop must be accompanied by a comment explaining why.
+
+## Architecture
+
+### Legacy vs. Newflow
+There are two parallel implementations of login/signup, both live in production and routed in `config/routes.rb`:
+- `app/controllers/legacy/*` — original controllers (`SessionsController`, `SignupController`, `IdentitiesController`, etc.).
+- `app/controllers/newflow/*` — the current, actively-developed login/signup/password-management flow (routes prefixed `/i/...`), with matching helpers in `app/helpers/newflow/*` and handlers in `app/handlers/`. New auth/signup work should target `newflow`, not `legacy`.
+
+Both flows converge on the same core models: `User`, `Authentication`, `Identity`, `ContactInfo`, `ApplicationUser`.
+
+### Lev handlers and routines
+Business logic is not written directly in controllers — it uses [Lev](https://github.com/lml/lev) ("ride the rails but don't touch them"):
+- **Handlers** (`app/handlers/`) process a user-submitted form/request. They implement `handle` (do the work, populate `outputs`/`errors`) and `authorized?`. Controllers invoke them via `handle_with(success:, failure:)`, and the lambdas see a `@handler_result`.
+- **Routines** (`app/routines/`) encapsulate one use case (e.g. `PushSalesforceLead`) and are callable outside a request/controller context (e.g. from rake tasks or other routines). Handlers are a superset of routines.
+- Both wrap their work in a DB transaction; use `fatal_error`/`transfer_errors_from` to add to the `errors` object.
+
+### Account creation paths
+A `User` is created via one of: direct signup (`newflow_signup_path`), signed params (`sp`/`authenticate_user!`, used for LMS-driven logins from Tutor), OAuth authorization (`/oauth/authorize`, Doorkeeper), the API (`POST /user/find-or-create`), or an admin rake import (`lib/tasks/accounts/import_users.rake`). Signup produces a `User`, an `Authentication` (login method), optionally an `Identity` (password), an optional `ApplicationUser` (association to the OAuth app that created the user), and a `ContactInfo` (email).
+
+### OAuth / Doorkeeper
+`config/initializers/doorkeeper.rb` and `config/initializers/doorkeeper_models.rb` wire Doorkeeper into the User/ApplicationUser models. Trusted `oauth_applications` skip the authorization screen. `FindOrCreateApplicationUser` associates users with the app that created them; non-trusted apps may only manage their own users.
+
+### Salesforce integration
+`app/models/openstax/salesforce/remote/*` defines remote models (e.g. `Student__c`) synced to Salesforce; `lib/settings/salesforce.rb` holds feature-flag-style toggles (`push_leads_enabled`, `push_students_enabled`, etc.). New signups (especially educators) become Salesforce leads (see `PushSalesforceLead`) so marketing/verification can track adoption. Design/implementation specs for sync work live in `docs/superpowers/` (specs and plans, not committed — working-tree only).
+
+Auth is the OAuth **client credentials** flow (`openstax_salesforce` ≥ 9.0, which requires Ruby ≥ 3.0 / Rails ≥ 6.1 / Restforce ≥ 7.1 — Restforce only gained the client-credentials middleware in 7.1), configured in `config/initializers/openstax_salesforce.rb` from `SALESFORCE_CONSUMER_KEY`/`SALESFORCE_CONSUMER_SECRET` only. `SALESFORCE_LOGIN_DOMAIN` must be the org's My Domain — Salesforce rejects this flow at `login.salesforce.com`/`test.salesforce.com`, and the gem raises on those. Everything runs as the connected app's **Run As** user, so a permission gap there shows up as silently missing writes. The retired username-password flow (Salesforce enforcement Feb 20, 2027) still works if `username`/`password`/`security_token` are set; don't reintroduce them.
+
+### Cloudfront path prefix
+Accounts can run entirely under an `/accounts` path prefix (for Cloudfront routing). `SIMULATE_CLOUDFRONT=true` makes the server raise if a request ever escapes that prefix — useful for verifying new routes don't leak out of the prefix.
+
+### Special request parameters
+Behavior-changing query params handled across controllers (see README for full detail): `go` (skip to signup/student signup), `sp` (signed params — auto-login or prefill signup), `signup_at` + `client_id` (custom signup link on the login page), `r` (trusted redirect-back target, stored via a `before_action` in `config/initializers/controllers.rb`), `redirect_uri` (OAuth exit-back target).
+
+### GDPR
+Logged-in-user API responses (`/api/user`) include `is_not_gdpr_location`; override the detected IP in development with `IP_ADDRESS_FOR_GDPR`.
+
+### Account-flow redesign (dm-account-features branch)
+The 2026 redesign (Claude Design project "Accounts Redesign") reshaped signup + account pages:
+- **Four signup funnels** off role selection (`newflow/signup/welcome.html.erb`): student, instructor (4 steps: account → verify email → SheerID → "about your teaching"), staff ("I support instruction" → `StaffSignupController`, skips SheerID, staff roles map onto existing `User::VALID_ROLES` with the label preserved in `other_role_name`), and lifelong learner (quiet text link; minimal signup; `role: :self_learner`, excluded from Salesforce lead push and all impact counts).
+- Choosing "Other staff" on instructor step 4 redirects to the staff questionnaire (`data-staff-details-path` + `onRoleChange` in `educator_complete_dynamic.js.coffee`).
+- **SheerID school-email gate**: `EmailAddress.looks_like_school_email?` (guidance-only heuristic) drives a banner on step 3 for personal-email users; adds school email via `EducatorSignup::AddSchoolEmail` → `CreateEmailForUser`.
+- **Account pages** (`AccountController`, `/i/account/...`): tabbed shell; students get a single-column overview (saved books + instructor-connect) with instructor-only tabs hidden. `InstructorConnection` stores student→instructor claims, always `status: 'unverified'`, never pushed to Salesforce, never counted in impact.
+- **Annual check-in** (`Account::CheckInController`): confirm-first rows, 7-day snooze dismissable twice then required, streak banner from `User#check_in_streak_years`.
+- **Impact tab**: `ImpactMilestones` PORO derives earned/next milestones purely from Adoption data. **Overview**: LMS question card persists to `users.lms_used`/`lms_prompt_dismissed_at`.
+- `SecurityLog.event_type` and `users.role` are **positional integer enums** — only ever append new values at the end.
+
+### View gotcha: lev_form_for needs `<%=`
+`capture` falls back to a block's return value only when the output buffer is empty, so a bare `<% lev_form_for ... do %>` renders only while the form is the sole printed content in its capture scope — adding any sibling `<%= %>` silently drops the whole form (no error, empty <form>). Always use `<%= lev_form_for ... do %>`. Related: never write literal ERB delimiters inside an ERB comment — a `%​>` sequence in the comment text terminates the comment early and the rest renders/compiles as template code (this has caused a whole-page 500).
+
+### Parallel test runs
+`config/database.yml` honors `OXA_DEV_DB`/`OXA_TEST_DB`. Concurrent rspec runs (multiple worktrees/agents) MUST each use a unique `OXA_TEST_DB=ox_accounts_test_<name>` (`rake db:create db:schema:load` first) — sharing the default test DB causes deadlocks and can corrupt `db/schema.rb` via out-of-sync `db:migrate` dumps. Feature specs disable Chrome's password manager in `spec/rails_helper.rb` (`CHROME_TEST_PREFS`); without it, the second login in a shared browser session silently loses its password field.

--- a/app/controllers/newflow/educator_signup_controller.rb
+++ b/app/controllers/newflow/educator_signup_controller.rb
@@ -47,7 +47,7 @@ module Newflow
               log_data[:redirect] = stored_url
             end
             security_log(:educator_began_signup, log_data)
-            log_posthog(@user, 'started_signup', { role: @user.role })
+            log_posthog(@user, 'educator_started_signup', { role: @user.role })
             clear_cache_BRI_marketing
             redirect_to(educator_email_verification_form_path)
           },
@@ -106,7 +106,7 @@ module Newflow
           clear_unverified_user
           sign_in!(@handler_result.outputs.user)
           security_log(:educator_verified_email, email:@email)
-          log_posthog(@handler_result.outputs.user, 'verified_email', { role: @handler_result.outputs.user.role })
+          log_posthog(@handler_result.outputs.user, 'educator_verified_email', { role: @handler_result.outputs.user.role })
           redirect_to(educator_sheerid_form_path)
         },
         failure: lambda {
@@ -114,7 +114,7 @@ module Newflow
           @first_name = unverified_user.first_name
           @email = unverified_email_address.value
           security_log(:educator_verify_email_failed, email: @email)
-          log_posthog(unverified_user, 'verified_email_failed', { role: unverified_user.role })
+          log_posthog(unverified_user, 'educator_verified_email_failed', { role: unverified_user.role })
           render(:educator_email_verification_form)
         }
       )

--- a/app/controllers/newflow/signup_controller.rb
+++ b/app/controllers/newflow/signup_controller.rb
@@ -20,13 +20,13 @@ module Newflow
           user = @handler_result.outputs.user
           sign_in!(user)
 
-          log_posthog(user, 'verified_email', { role: user.role })
-
           if user.student?
             security_log(:student_verified_email, {user: user, message: "Student verified email."})
+            log_posthog(user, 'student_verified_email', { role: user.role })
             redirect_to signup_done_path
           else
             security_log(:educator_verified_email, {user: user, message: "Educator verified email."})
+            log_posthog(user, 'educator_verified_email', { role: user.role })
             redirect_to(educator_sheerid_form_path)
           end
         },
@@ -38,7 +38,7 @@ module Newflow
 
     def signup_done
       security_log(:user_viewed_signup_form, form_name: action_name)
-      log_posthog(current_user, 'signup_done', { role: current_user.role })
+      log_posthog(current_user, 'user_signup_done', { role: current_user.role })
       @first_name = current_user.first_name
       @email_address = current_user.email_addresses.first&.value
     end

--- a/app/controllers/newflow/social_auth_controller.rb
+++ b/app/controllers/newflow/social_auth_controller.rb
@@ -45,7 +45,7 @@ module Newflow
             @last_name = user.last_name
             @email = @handler_result.outputs.email
             security_log(:student_social_sign_up, user: user, authentication_id: authentication.id)
-            log_posthog(user, 'signup_social', { provider: authentication.provider, role: user.role })
+            log_posthog(user, 'student_signup_social', { provider: authentication.provider, role: user.role })
             # must confirm their social info on signup
             render :confirm_social_info_form and return # TODO: if possible, update the route/path to reflect that this page is being rendered
           end
@@ -120,7 +120,7 @@ module Newflow
           clear_signup_state
           sign_in!(@handler_result.outputs.user)
           security_log(:student_social_auth_confirmation_success)
-          log_posthog(@handler_result.outputs.user, 'signup_done', { role: @handler_result.outputs.user.role })
+          log_posthog(@handler_result.outputs.user, 'student_signup_done', { role: @handler_result.outputs.user.role })
           redirect_to return_to
         },
         failure: -> {

--- a/app/controllers/newflow/student_signup_controller.rb
+++ b/app/controllers/newflow/student_signup_controller.rb
@@ -23,7 +23,7 @@ module Newflow
               log_data[:redirect] = stored_url
             end
             security_log(:student_signed_up, log_data)
-            log_posthog(user, 'started_signup', { role: user.role })
+            log_posthog(user, 'student_started_signup', { role: user.role })
             redirect_to student_email_verification_form_path
           },
           failure: lambda {
@@ -80,7 +80,7 @@ module Newflow
           user = @handler_result.outputs.user
           sign_in!(user)
           security_log(:student_verified_email)
-          log_posthog(user, 'verified_email', { role: user.role })
+          log_posthog(user, 'student_verified_email', { role: user.role })
           redirect_to(signup_done_path)
         },
         failure: lambda {


### PR DESCRIPTION
Two independent commits.

## 1. Restore the original PostHog event names

#1736 renamed ten signup/verification PostHog events to shorter, role-agnostic names:

| Restored | Was renamed to (in #1736) |
|---|---|
| `student_started_signup` / `educator_started_signup` | `started_signup` |
| `student_verified_email` / `educator_verified_email` | `verified_email` |
| `educator_verified_email_failed` | `verified_email_failed` |
| `student_signup_social` | `signup_social` |
| `student_signup_done` / `user_signup_done` | `signup_done` |

This puts the original names back. Nothing from #1736 has been deployed yet, so this is cheap to do now and avoids splitting every existing funnel and dashboard across two event names.

**Everything #1736 added stays:**

- **`role` on each event.** This is the useful half of the rename — it carries the student/educator distinction as a property rather than baked into the event name, and it gives us a clean transition path if we do want to consolidate the names later.
- **`client_app`**, still attached centrally by `ApplicationController#log_posthog`.
- All of the GTM / `posthog.init` work, untouched.

`user_logged_in` and `user_logged_in_social` were not renamed, so they're untouched here — their explicit `client_app` just moved to the central helper.

**One structural change:** `SignupController#verify_email_by_code` had its two per-branch `log_posthog` calls collapsed into a single call in #1736. Since the student/educator distinction is back in the event name, this splits it into two calls again, one per branch.

**Testing:** 59 controller specs pass across the four affected controllers. No spec asserted on the renamed strings.

## 2. Add CLAUDE.md

Repo guidance for Claude Code — setup/test/lint commands, the legacy vs. newflow split, Lev handlers and routines, account-creation paths, the Doorkeeper and Salesforce integrations, and the gotchas that have cost real debugging time (the `lev_form_for` capture bug, ERB delimiters inside ERB comments, parallel-rspec DB isolation).

Happy to drop this commit if we'd rather land the revert on its own.
